### PR TITLE
fix(core): 持有开机自启动设置任务引用并记录异常

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -358,7 +358,19 @@ class AppConfig(GlobalConfig):
         self.bind("Start", "IfSelfStart", System.set_SelfStart)
         self.bind("Function", "IfAllowSleep", System.set_Sleep)
         self.bind("Function", "IfEnableTelemetry", set_telemetry_enabled)
-        asyncio.create_task(System.set_SelfStart(self.get("Start", "IfSelfStart")))
+        # 注册自启动会读写注册表, 不阻塞初始化; 持有引用避免被 GC 且异常不被静默吞掉
+        self_start_task = asyncio.create_task(
+            System.set_SelfStart(self.get("Start", "IfSelfStart"))
+        )
+        self.temp_task.append(self_start_task)
+
+        def _self_start_done(t: asyncio.Task) -> None:
+            if t in self.temp_task:
+                self.temp_task.remove(t)
+            if not t.cancelled() and t.exception() is not None:
+                logger.warning(f"设置开机自启动失败: {t.exception()}")
+
+        self_start_task.add_done_callback(_self_start_done)
         await System.set_Sleep(self.get("Function", "IfAllowSleep"))
         set_telemetry_enabled(self.get("Function", "IfEnableTelemetry"))
 

--- a/res/version.json
+++ b/res/version.json
@@ -16,7 +16,8 @@
             "修复BUG": [
                 "SRC专项 修复任务结束后进程残留、异常清理时配置丢失及 traceback 日志误判人工接管问题 by [@Craun718](https://github.com/Craun718)",
                 "MaaEnd专项 修复脚本正常退出后 AUTO-MAS 仍持续等待、导致后续调度无法执行的问题 by [@HarcoChen](https://github.com/HarcoChen)",
-                "HSR专项 修复 M7A 切换游戏界面失败（无法切换到指定游戏界面）时未触发任务失败重启、导致任务长时间挂起的问题 by [@1w1w11w1](https://github.com/1w1w11w1)"
+                "HSR专项 修复 M7A 切换游戏界面失败（无法切换到指定游戏界面）时未触发任务失败重启、导致任务长时间挂起的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "修复开机自启动设置的后台任务异常被静默忽略的问题：持有任务引用并在失败时记录警告日志 by [@1w1w11w1](https://github.com/1w1w11w1)"
             ]
         },
         "v5.4.0": {


### PR DESCRIPTION
## 问题

#407 把 `System.set_SelfStart` 改为 fire-and-forget 的 `asyncio.create_task(...)`，但未持有返回的 task 引用：

- task 可能在执行前被 GC；
- 若注册失败（如注册表写入被拒），异常被静默吞掉，无任何日志。

## 改动

沿用本类既有的 `temp_task` + `add_done_callback` 模式（与 `_stage_refresh_task` 一致）：

- `temp_task` 持有 task 引用，避免被 GC；
- done 回调中移除引用，失败时记录 `logger.warning`；
- 仍以 fire-and-forget 方式执行，不阻塞配置初始化。

## 验证

- 全量测试：`7 failed, 200 passed`，那 7 项在 dev 上已失败，与本 PR 无关。
- 本地端到端启动正常。
- `ruff format --check`：触碰文件均 already formatted。

## Sourcery 摘要

修复自启动设置后台任务可能被垃圾回收且异常被静默忽略的问题。