### PR TITLE
chore(frontend): 清理前端 typecheck 错误与 ESLint 告警

### DIFF
--- a/frontend/electron/services/dependencyService.ts
+++ b/frontend/electron/services/dependencyService.ts
@@ -8,7 +8,11 @@ import * as path from 'path'
 import * as crypto from 'crypto'
 import { spawn } from 'child_process'
 import { MirrorService, MirrorSource } from './mirrorService'
-import { MirrorRotationService, NetworkOperationCallback, NetworkOperationProgress } from './mirrorRotationService'
+import {
+  MirrorRotationService,
+  NetworkOperationCallback,
+  NetworkOperationProgress,
+} from './mirrorRotationService'
 
 import { getLogger } from './logger'
 const logger = getLogger('后端依赖安装服务')
@@ -16,22 +20,22 @@ const logger = getLogger('后端依赖安装服务')
 // ==================== 类型定义 ====================
 
 export interface DependencyCheckResult {
-    requirementsExists: boolean
-    needsInstall: boolean
-    currentHash?: string
-    lastHash?: string
+  requirementsExists: boolean
+  needsInstall: boolean
+  currentHash?: string
+  lastHash?: string
 }
 
 export interface DependencyProgress {
-    stage: 'check' | 'install'
-    progress: number
-    message: string
-    details?: {
-        checkInfo?: DependencyCheckResult
-        currentMirror?: string
-        mirrorProgress?: { current: number; total: number }
-        operationDesc?: string
-    }
+  stage: 'check' | 'install'
+  progress: number
+  message: string
+  details?: {
+    checkInfo?: DependencyCheckResult
+    currentMirror?: string
+    mirrorProgress?: { current: number; total: number }
+    operationDesc?: string
+  }
 }
 
 export type DependencyProgressCallback = (progress: DependencyProgress) => void
@@ -39,402 +43,426 @@ export type DependencyProgressCallback = (progress: DependencyProgress) => void
 // ==================== 依赖安装服务类 ====================
 
 export class DependencyService {
-    private appRoot: string
-    private pythonExe: string
-    private requirementsPath: string
-    private hashFilePath: string
-    private mirrorService: MirrorService
-    private rotationService: MirrorRotationService
+  private appRoot: string
+  private pythonExe: string
+  private requirementsPath: string
+  private hashFilePath: string
+  private mirrorService: MirrorService
+  private rotationService: MirrorRotationService
 
-    constructor(appRoot: string, mirrorService: MirrorService) {
-        this.appRoot = appRoot
-        this.pythonExe = path.join(appRoot, 'environment', 'python', 'python.exe')
-        this.requirementsPath = path.join(appRoot, 'requirements.txt')
-        this.hashFilePath = path.join(appRoot, 'environment', '.requirements_hash')
-        this.mirrorService = mirrorService
-        this.rotationService = new MirrorRotationService()
+  constructor(appRoot: string, mirrorService: MirrorService) {
+    this.appRoot = appRoot
+    this.pythonExe = path.join(appRoot, 'environment', 'python', 'python.exe')
+    this.requirementsPath = path.join(appRoot, 'requirements.txt')
+    this.hashFilePath = path.join(appRoot, 'environment', '.requirements_hash')
+    this.mirrorService = mirrorService
+    this.rotationService = new MirrorRotationService()
+  }
+
+  /**
+   * 依赖安装方法
+   */
+  async installDependencies(
+    onProgress?: DependencyProgressCallback,
+    selectedMirror?: string,
+    forceInstall: boolean = false
+  ): Promise<{ success: boolean; error?: string; skipped?: boolean }> {
+    try {
+      // 第一步：环境检查
+      onProgress?.({
+        stage: 'check',
+        progress: 0,
+        message: '正在检查依赖状态...',
+        details: {},
+      })
+      const checkResult = await this.checkDependencies()
+
+      // 上报检查结果
+      onProgress?.({
+        stage: 'check',
+        progress: 50,
+        message: '依赖检查完成',
+        details: {
+          checkInfo: checkResult,
+        },
+      })
+
+      if (!forceInstall && !checkResult.needsInstall) {
+        logger.info('依赖已是最新版本，跳过安装')
+        onProgress?.({
+          stage: 'check',
+          progress: 100,
+          message: '依赖已是最新',
+          details: {
+            checkInfo: checkResult,
+          },
+        })
+        return { success: true, skipped: true }
+      }
+
+      logger.info(`依赖检查结果: ${JSON.stringify(checkResult)}`)
+
+      // 第二步：安装依赖
+      // 不在这里发送 progress: 0，避免进度条跳回0
+      const installResult = await this.performInstall(
+        (opProgress, mirrorName, mirrorIndex, totalMirrors) => {
+          onProgress?.({
+            stage: 'install',
+            progress: opProgress.progress,
+            message: opProgress.description,
+            details: {
+              currentMirror: mirrorName,
+              mirrorProgress: { current: mirrorIndex + 1, total: totalMirrors },
+              operationDesc: opProgress.description,
+            },
+          })
+        },
+        selectedMirror
+      )
+
+      if (!installResult.success) {
+        return { success: false, error: installResult.error }
+      }
+
+      // 保存当前哈希值
+      if (checkResult.currentHash) {
+        this.saveHash(checkResult.currentHash)
+      }
+
+      onProgress?.({
+        stage: 'install',
+        progress: 100,
+        message: '依赖安装完成',
+        details: {},
+      })
+      return { success: true }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`依赖安装失败: ${errorMsg}`)
+      return { success: false, error: errorMsg }
+    }
+  }
+
+  /**
+   * 检查依赖状态
+   */
+  private async checkDependencies(): Promise<DependencyCheckResult> {
+    logger.info('=== 检查依赖状态 ===')
+
+    // 检查 requirements.txt 是否存在
+    if (!fs.existsSync(this.requirementsPath)) {
+      logger.info('requirements.txt 不存在')
+      return { requirementsExists: false, needsInstall: false }
     }
 
-    /**
-     * 依赖安装方法
-     */
-    async installDependencies(
-        onProgress?: DependencyProgressCallback,
-        selectedMirror?: string,
-        forceInstall: boolean = false
-    ): Promise<{ success: boolean; error?: string; skipped?: boolean }> {
-        try {
-            // 第一步：环境检查
-            onProgress?.({
-                stage: 'check',
-                progress: 0,
-                message: '正在检查依赖状态...',
-                details: {}
-            })
-            const checkResult = await this.checkDependencies()
+    // 计算当前哈希
+    const currentHash = this.calculateHash()
+    logger.info(`当前哈希: ${currentHash.substring(0, 8)}...`)
 
-            // 上报检查结果
-            onProgress?.({
-                stage: 'check',
-                progress: 50,
-                message: '依赖检查完成',
-                details: {
-                    checkInfo: checkResult
-                }
-            })
+    // 读取上次安装的哈希
+    const lastHash = this.loadHash()
+    logger.info(`上次哈希: ${lastHash ? lastHash.substring(0, 8) + '...' : 'null'}`)
 
-            if (!forceInstall && !checkResult.needsInstall) {
-                logger.info('依赖已是最新版本，跳过安装')
-                onProgress?.({
-                    stage: 'check',
-                    progress: 100,
-                    message: '依赖已是最新',
-                    details: {
-                        checkInfo: checkResult
-                    }
-                })
-                return { success: true, skipped: true }
-            }
+    // 判断是否需要安装
+    const needsInstall = lastHash === null || currentHash !== lastHash
 
-            logger.info(`依赖检查结果: ${JSON.stringify(checkResult)}`)
-
-            // 第二步：安装依赖
-            // 不在这里发送 progress: 0，避免进度条跳回0
-            const installResult = await this.performInstall((opProgress, mirrorName, mirrorIndex, totalMirrors) => {
-                onProgress?.({
-                    stage: 'install',
-                    progress: opProgress.progress,
-                    message: opProgress.description,
-                    details: {
-                        currentMirror: mirrorName,
-                        mirrorProgress: { current: mirrorIndex + 1, total: totalMirrors },
-                        operationDesc: opProgress.description
-                    }
-                })
-            }, selectedMirror)
-
-            if (!installResult.success) {
-                return { success: false, error: installResult.error }
-            }
-
-            // 保存当前哈希值
-            if (checkResult.currentHash) {
-                this.saveHash(checkResult.currentHash)
-            }
-
-            onProgress?.({
-                stage: 'install',
-                progress: 100,
-                message: '依赖安装完成',
-                details: {}
-            })
-            return { success: true }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`依赖安装失败: ${errorMsg}`)
-            return { success: false, error: errorMsg }
-        }
+    return {
+      requirementsExists: true,
+      needsInstall,
+      currentHash,
+      lastHash: lastHash || undefined,
     }
+  }
 
-    /**
-     * 检查依赖状态
-     */
-    private async checkDependencies(): Promise<DependencyCheckResult> {
-        logger.info('=== 检查依赖状态 ===')
+  /**
+   * 计算 requirements.txt 的哈希值
+   */
+  private calculateHash(): string {
+    const content = fs.readFileSync(this.requirementsPath, 'utf-8')
+    return crypto.createHash('sha256').update(content.trim()).digest('hex')
+  }
 
-        // 检查 requirements.txt 是否存在
-        if (!fs.existsSync(this.requirementsPath)) {
-            logger.info('requirements.txt 不存在')
-            return { requirementsExists: false, needsInstall: false }
-        }
-
-        // 计算当前哈希
-        const currentHash = this.calculateHash()
-        logger.info(`当前哈希: ${currentHash.substring(0, 8)}...`)
-
-        // 读取上次安装的哈希
-        const lastHash = this.loadHash()
-        logger.info(`上次哈希: ${lastHash ? lastHash.substring(0, 8) + '...' : 'null'}`)
-
-        // 判断是否需要安装
-        const needsInstall = lastHash === null || currentHash !== lastHash
-
-        return {
-            requirementsExists: true,
-            needsInstall,
-            currentHash,
-            lastHash: lastHash || undefined
-        }
+  /**
+   * 加载上次安装的哈希值
+   */
+  private loadHash(): string | null {
+    try {
+      if (!fs.existsSync(this.hashFilePath)) {
+        return null
+      }
+      return fs.readFileSync(this.hashFilePath, 'utf-8').trim()
+    } catch (error) {
+      logger.warn(`读取哈希文件失败: ${error}`)
+      return null
     }
+  }
 
-    /**
-     * 计算 requirements.txt 的哈希值
-     */
-    private calculateHash(): string {
-        const content = fs.readFileSync(this.requirementsPath, 'utf-8')
-        return crypto.createHash('sha256').update(content.trim()).digest('hex')
+  /**
+   * 保存哈希值
+   */
+  private saveHash(hash: string): void {
+    try {
+      const dir = path.dirname(this.hashFilePath)
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+      }
+      fs.writeFileSync(this.hashFilePath, hash, 'utf-8')
+      logger.info('哈希值已保存')
+    } catch (error) {
+      logger.warn(`保存哈希文件失败: ${error}`)
     }
+  }
 
-    /**
-     * 加载上次安装的哈希值
-     */
-    private loadHash(): string | null {
-        try {
-            if (!fs.existsSync(this.hashFilePath)) {
-                return null
-            }
-            return fs.readFileSync(this.hashFilePath, 'utf-8').trim()
-        } catch (error) {
-            logger.warn(`读取哈希文件失败: ${error}`)
-            return null
-        }
-    }
+  /**
+   * 执行依赖安装
+   */
+  private async performInstall(
+    onProgress?: (
+      progress: NetworkOperationProgress,
+      mirrorName: string,
+      mirrorIndex: number,
+      totalMirrors: number
+    ) => void,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
+    const mirrors = this.mirrorService.getMirrors('pip_mirror')
 
-    /**
-     * 保存哈希值
-     */
-    private saveHash(hash: string): void {
-        try {
-            const dir = path.dirname(this.hashFilePath)
-            if (!fs.existsSync(dir)) {
-                fs.mkdirSync(dir, { recursive: true })
-            }
-            fs.writeFileSync(this.hashFilePath, hash, 'utf-8')
-            logger.info('哈希值已保存')
-        } catch (error) {
-            logger.warn(`保存哈希文件失败: ${error}`)
-        }
-    }
+    // 定义依赖安装操作
+    const installOperation: NetworkOperationCallback = async (mirror, onOpProgress) => {
+      try {
+        // 1. 检查并安装基础工具
+        onOpProgress({ progress: 20, description: '检查基础工具...' })
+        await this.ensureBasicTools(mirror)
 
-    /**
-     * 执行依赖安装
-     */
-    private async performInstall(
-        onProgress?: (progress: NetworkOperationProgress, mirrorName: string, mirrorIndex: number, totalMirrors: number) => void,
-        selectedMirror?: string
-    ): Promise<{ success: boolean; error?: string }> {
-        const mirrors = this.mirrorService.getMirrors('pip_mirror')
+        // 2. 安装依赖
+        onOpProgress({ progress: 40, description: '安装依赖包...' })
+        await this.installRequirements(mirror, progress => {
+          onOpProgress({ progress, description: '安装依赖包...' })
+        })
 
-        // 定义依赖安装操作
-        const installOperation: NetworkOperationCallback = async (mirror, onOpProgress) => {
-            try {
-                // 1. 检查并安装基础工具
-                onOpProgress({ progress: 20, description: '检查基础工具...' })
-                await this.ensureBasicTools(mirror)
-
-                // 2. 安装依赖
-                onOpProgress({ progress: 40, description: '安装依赖包...' })
-                await this.installRequirements(mirror, (progress) => {
-                    onOpProgress({ progress, description: '安装依赖包...' })
-                })
-
-                onOpProgress({ progress: 100, description: '安装完成' })
-                return { success: true }
-            } catch (error) {
-                const errorMsg = error instanceof Error ? error.message : String(error)
-                return { success: false, error: errorMsg }
-            }
-        }
-
-        // 使用镜像源轮替
-        const result = await this.rotationService.execute(mirrors, installOperation, (rotationProgress) => {
-            onProgress?.(
-                rotationProgress.operationProgress,
-                rotationProgress.currentMirror.name,
-                rotationProgress.mirrorIndex,
-                rotationProgress.totalMirrors
-            )
-        }, selectedMirror)
-
-        if (!result.success) {
-            return { success: false, error: result.error }
-        }
-
-        logger.info(`依赖安装完成，使用镜像源: ${result.usedMirror?.name}`)
+        onOpProgress({ progress: 100, description: '安装完成' })
         return { success: true }
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error)
+        return { success: false, error: errorMsg }
+      }
     }
 
-    /**
-     * 确保基础工具已安装（setuptools, wheel）
-     */
-    private async ensureBasicTools(mirror: MirrorSource): Promise<void> {
-        logger.info('=== 检查基础工具 ===')
+    // 使用镜像源轮替
+    const result = await this.rotationService.execute(
+      mirrors,
+      installOperation,
+      rotationProgress => {
+        onProgress?.(
+          rotationProgress.operationProgress,
+          rotationProgress.currentMirror.name,
+          rotationProgress.mirrorIndex,
+          rotationProgress.totalMirrors
+        )
+      },
+      selectedMirror
+    )
 
-        // 检查 setuptools 和 wheel 是否已安装
-        const toolsInstalled = await this.checkBasicTools()
+    if (!result.success) {
+      return { success: false, error: result.error }
+    }
 
-        if (toolsInstalled) {
-            logger.info('基础工具已安装')
-            return
+    logger.info(`依赖安装完成，使用镜像源: ${result.usedMirror?.name}`)
+    return { success: true }
+  }
+
+  /**
+   * 确保基础工具已安装（setuptools, wheel）
+   */
+  private async ensureBasicTools(mirror: MirrorSource): Promise<void> {
+    logger.info('=== 检查基础工具 ===')
+
+    // 检查 setuptools 和 wheel 是否已安装
+    const toolsInstalled = await this.checkBasicTools()
+
+    if (toolsInstalled) {
+      logger.info('基础工具已安装')
+      return
+    }
+
+    logger.info('正在安装基础工具...')
+
+    await new Promise<void>((resolve, _reject) => {
+      const hostname = new URL(mirror.url).hostname
+
+      const proc = spawn(
+        this.pythonExe,
+        [
+          '-m',
+          'pip',
+          'install',
+          '--upgrade',
+          'setuptools',
+          'wheel',
+          '-i',
+          mirror.url,
+          '--trusted-host',
+          hostname,
+        ],
+        {
+          cwd: this.appRoot,
+          stdio: 'pipe',
+        }
+      )
+
+      proc.stdout?.on('data', data => {
+        logger.info(`setuptools/wheel: ${data.toString().trim()}`)
+      })
+
+      proc.stderr?.on('data', data => {
+        logger.info(`setuptools/wheel error: ${data.toString().trim()}`)
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          logger.info('基础工具安装完成')
+          resolve()
+        } else {
+          // 即使失败也继续，因为可能已经存在
+          logger.warn('⚠️ 基础工具安装失败，但继续')
+          resolve()
+        }
+      })
+
+      proc.on('error', error => {
+        logger.warn(`基础工具安装进程错误: ${error}`)
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * 检查基础工具是否已安装
+   */
+  private checkBasicTools(): Promise<boolean> {
+    return new Promise(resolve => {
+      const proc = spawn(this.pythonExe, ['-m', 'pip', 'list'], {
+        cwd: this.appRoot,
+        stdio: 'pipe',
+      })
+
+      let output = ''
+      proc.stdout?.on('data', data => {
+        output += data.toString()
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          const hasSetuptools = output.includes('setuptools')
+          const hasWheel = output.includes('wheel')
+          resolve(hasSetuptools && hasWheel)
+        } else {
+          resolve(false)
+        }
+      })
+
+      proc.on('error', () => {
+        resolve(false)
+      })
+    })
+  }
+
+  /**
+   * 安装 requirements.txt 中的依赖
+   */
+  private installRequirements(
+    mirror: MirrorSource,
+    onProgress?: (progress: number) => void
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const hostname = new URL(mirror.url).hostname
+
+      const proc = spawn(
+        this.pythonExe,
+        [
+          '-m',
+          'pip',
+          'install',
+          '-r',
+          this.requirementsPath,
+          '-i',
+          mirror.url,
+          '--trusted-host',
+          hostname,
+          '--no-warn-script-location',
+        ],
+        {
+          cwd: this.appRoot,
+          stdio: 'pipe',
+        }
+      )
+
+      let stdoutData = ''
+      let stderrData = ''
+      let totalPackages = 0
+      let installedPackages = 0
+
+      proc.stdout?.on('data', data => {
+        const output = data.toString().trim()
+        stdoutData += output
+        logger.info(`pip install: ${output}`)
+
+        // 解析pip输出，统计安装进度
+        // 匹配 "Collecting xxx" 来统计总包数
+        const collectingMatches = output.match(/Collecting\s+\S+/g)
+        if (collectingMatches) {
+          totalPackages += collectingMatches.length
         }
 
-        logger.info('正在安装基础工具...')
+        // 匹配 "Installing collected packages:" 或 "Successfully installed" 来统计已安装包数
+        const installingMatch = output.match(/Installing collected packages:/)
+        if (installingMatch) {
+          // 开始安装阶段
+          installedPackages = Math.floor(totalPackages * 0.8) // 假设收集完成后进度到80%
+          if (onProgress) {
+            const progress = 40 + (installedPackages / Math.max(totalPackages, 1)) * 50 // 40% - 90%
+            onProgress(Math.min(progress, 90))
+          }
+        }
 
-        await new Promise<void>((resolve, reject) => {
-            const hostname = new URL(mirror.url).hostname
+        const successMatch = output.match(/Successfully installed/)
+        if (successMatch) {
+          installedPackages = totalPackages
+          if (onProgress) {
+            onProgress(95) // 安装完成，进度到95%
+          }
+        }
+      })
 
-            const proc = spawn(this.pythonExe, [
-                '-m',
-                'pip',
-                'install',
-                '--upgrade',
-                'setuptools',
-                'wheel',
-                '-i',
-                mirror.url,
-                '--trusted-host',
-                hostname
-            ], {
-                cwd: this.appRoot,
-                stdio: 'pipe'
-            })
+      proc.stderr?.on('data', data => {
+        const output = data.toString().trim()
+        stderrData += output
+        logger.info(`pip install error: ${output}`)
+      })
 
-            proc.stdout?.on('data', (data) => {
-                logger.info(`setuptools/wheel: ${data.toString().trim()}`)
-            })
+      proc.on('close', code => {
+        logger.info(`pip install 退出码: ${code}`)
 
-            proc.stderr?.on('data', (data) => {
-                logger.info(`setuptools/wheel error: ${data.toString().trim()}`)
-            })
+        // 检查是否有实际错误
+        const hasActualError =
+          stderrData.toLowerCase().includes('error:') ||
+          stderrData.toLowerCase().includes('failed') ||
+          stderrData.toLowerCase().includes('could not find')
 
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    logger.info('基础工具安装完成')
-                    resolve()
-                } else {
-                    // 即使失败也继续，因为可能已经存在
-                    logger.warn('⚠️ 基础工具安装失败，但继续')
-                    resolve()
-                }
-            })
+        // 检查是否成功安装
+        const hasSuccess =
+          stdoutData.toLowerCase().includes('successfully installed') ||
+          stdoutData.toLowerCase().includes('requirement already satisfied')
 
-            proc.on('error', (error) => {
-                logger.warn(`基础工具安装进程错误: ${error}`)
-                resolve()
-            })
-        })
-    }
+        if (code === 0 || hasSuccess || !hasActualError) {
+          logger.info('依赖安装成功')
+          resolve()
+        } else {
+          reject(new Error(`依赖安装失败，退出码: ${code}`))
+        }
+      })
 
-    /**
-     * 检查基础工具是否已安装
-     */
-    private checkBasicTools(): Promise<boolean> {
-        return new Promise((resolve) => {
-            const proc = spawn(this.pythonExe, ['-m', 'pip', 'list'], {
-                cwd: this.appRoot,
-                stdio: 'pipe'
-            })
-
-            let output = ''
-            proc.stdout?.on('data', (data) => {
-                output += data.toString()
-            })
-
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    const hasSetuptools = output.includes('setuptools')
-                    const hasWheel = output.includes('wheel')
-                    resolve(hasSetuptools && hasWheel)
-                } else {
-                    resolve(false)
-                }
-            })
-
-            proc.on('error', () => {
-                resolve(false)
-            })
-        })
-    }
-
-    /**
-     * 安装 requirements.txt 中的依赖
-     */
-    private installRequirements(mirror: MirrorSource, onProgress?: (progress: number) => void): Promise<void> {
-        return new Promise((resolve, reject) => {
-            const hostname = new URL(mirror.url).hostname
-
-            const proc = spawn(this.pythonExe, [
-                '-m',
-                'pip',
-                'install',
-                '-r',
-                this.requirementsPath,
-                '-i',
-                mirror.url,
-                '--trusted-host',
-                hostname,
-                '--no-warn-script-location'
-            ], {
-                cwd: this.appRoot,
-                stdio: 'pipe'
-            })
-
-            let stdoutData = ''
-            let stderrData = ''
-            let totalPackages = 0
-            let installedPackages = 0
-
-            proc.stdout?.on('data', (data) => {
-                const output = data.toString().trim()
-                stdoutData += output
-                logger.info(`pip install: ${output}`)
-
-                // 解析pip输出，统计安装进度
-                // 匹配 "Collecting xxx" 来统计总包数
-                const collectingMatches = output.match(/Collecting\s+\S+/g)
-                if (collectingMatches) {
-                    totalPackages += collectingMatches.length
-                }
-
-                // 匹配 "Installing collected packages:" 或 "Successfully installed" 来统计已安装包数
-                const installingMatch = output.match(/Installing collected packages:/)
-                if (installingMatch) {
-                    // 开始安装阶段
-                    installedPackages = Math.floor(totalPackages * 0.8) // 假设收集完成后进度到80%
-                    if (onProgress) {
-                        const progress = 40 + (installedPackages / Math.max(totalPackages, 1)) * 50 // 40% - 90%
-                        onProgress(Math.min(progress, 90))
-                    }
-                }
-
-                const successMatch = output.match(/Successfully installed/)
-                if (successMatch) {
-                    installedPackages = totalPackages
-                    if (onProgress) {
-                        onProgress(95) // 安装完成，进度到95%
-                    }
-                }
-            })
-
-            proc.stderr?.on('data', (data) => {
-                const output = data.toString().trim()
-                stderrData += output
-                logger.info(`pip install error: ${output}`)
-            })
-
-            proc.on('close', (code) => {
-                logger.info(`pip install 退出码: ${code}`)
-
-                // 检查是否有实际错误
-                const hasActualError =
-                    stderrData.toLowerCase().includes('error:') ||
-                    stderrData.toLowerCase().includes('failed') ||
-                    stderrData.toLowerCase().includes('could not find')
-
-                // 检查是否成功安装
-                const hasSuccess =
-                    stdoutData.toLowerCase().includes('successfully installed') ||
-                    stdoutData.toLowerCase().includes('requirement already satisfied')
-
-                if (code === 0 || hasSuccess || !hasActualError) {
-                    logger.info('依赖安装成功')
-                    resolve()
-                } else {
-                    reject(new Error(`依赖安装失败，退出码: ${code}`))
-                }
-            })
-
-            proc.on('error', reject)
-        })
-    }
+      proc.on('error', reject)
+    })
+  }
 }

--- a/frontend/electron/services/environmentService.ts
+++ b/frontend/electron/services/environmentService.ts
@@ -108,14 +108,17 @@ abstract class BaseEnvironmentInstaller {
   /**
    * 环境安装三步走
    */
-  async install(onProgress?: InstallProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }> {
+  async install(
+    onProgress?: InstallProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
     try {
       // 第一步：环境检查
       onProgress?.({
         stage: 'check',
         progress: 0,
         message: '正在检查环境...',
-        details: {}
+        details: {},
       })
       const checkResult = await this.checkEnvironment()
 
@@ -125,8 +128,8 @@ abstract class BaseEnvironmentInstaller {
         progress: 50,
         message: '环境检查完成',
         details: {
-          checkInfo: checkResult
-        }
+          checkInfo: checkResult,
+        },
       })
 
       if (checkResult.exeExists && checkResult.canRun) {
@@ -136,8 +139,8 @@ abstract class BaseEnvironmentInstaller {
           progress: 100,
           message: '环境已就绪',
           details: {
-            checkInfo: checkResult
-          }
+            checkInfo: checkResult,
+          },
         })
         return { success: true }
       }
@@ -149,17 +152,17 @@ abstract class BaseEnvironmentInstaller {
         stage: 'download',
         progress: 0,
         message: '正在下载安装包...',
-        details: {}
+        details: {},
       })
-      const downloadResult = await this.downloadPackage((progress) => {
+      const downloadResult = await this.downloadPackage(progress => {
         onProgress?.({
           stage: 'download',
           progress: progress.progress,
           message: `下载中... ${progress.progress.toFixed(1)}%`,
           details: {
             downloadSpeed: progress.speed,
-            downloadSize: progress.downloadedSize
-          }
+            downloadSize: progress.downloadedSize,
+          },
         })
       }, selectedMirror)
 
@@ -172,14 +175,14 @@ abstract class BaseEnvironmentInstaller {
         stage: 'install',
         progress: 0,
         message: '正在安装环境...',
-        details: {}
+        details: {},
       })
       const installResult = await this.installEnvironment((progress, message, details) => {
         onProgress?.({
           stage: 'install',
           progress,
           message,
-          details: details || {}
+          details: details || {},
         })
       }, selectedMirror)
 
@@ -188,7 +191,7 @@ abstract class BaseEnvironmentInstaller {
           stage: 'install',
           progress: 100,
           message: '安装完成',
-          details: {}
+          details: {},
         })
       }
 
@@ -208,7 +211,10 @@ abstract class BaseEnvironmentInstaller {
   /**
    * 下载安装包（抽象方法）
    */
-  protected abstract downloadPackage(onProgress?: ProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }>
+  protected abstract downloadPackage(
+    onProgress?: ProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }>
 
   /**
    * 安装环境（抽象方法）
@@ -258,14 +264,14 @@ export class PythonInstaller extends BaseEnvironmentInstaller {
       const proc = spawn(this.pythonExe, ['-V'], { stdio: 'pipe' })
 
       let output = ''
-      proc.stdout?.on('data', (data) => {
+      proc.stdout?.on('data', data => {
         output += data.toString()
       })
-      proc.stderr?.on('data', (data) => {
+      proc.stderr?.on('data', data => {
         output += data.toString()
       })
 
-      proc.on('close', (code) => {
+      proc.on('close', code => {
         if (code === 0) {
           resolve(output.trim())
         } else {
@@ -277,7 +283,10 @@ export class PythonInstaller extends BaseEnvironmentInstaller {
     })
   }
 
-  protected async downloadPackage(onProgress?: ProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }> {
+  protected async downloadPackage(
+    onProgress?: ProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
     logger.info('=== 下载 Python 安装包 ===')
 
     const mirrors = this.mirrorService.getMirrors('python')
@@ -296,7 +305,7 @@ export class PythonInstaller extends BaseEnvironmentInstaller {
 
       onOpProgress({ progress: 0, description: `正在从 ${mirror.name} 下载...` })
 
-      const result = await this.downloader.download(mirror.url, tempZipPath, (progress) => {
+      const result = await this.downloader.download(mirror.url, tempZipPath, progress => {
         // 检查是否是当前活跃的操作
         if (operationId !== this.currentOperationId) {
           // 这是一个过期的进度回调，忽略它
@@ -308,18 +317,23 @@ export class PythonInstaller extends BaseEnvironmentInstaller {
           progress: progress.progress,
           speed: progress.speed,
           downloadedSize: progress.downloadedSize,
-          totalSize: progress.totalSize
+          totalSize: progress.totalSize,
         })
         onOpProgress({
           progress: progress.progress,
-          description: `下载中... ${progress.progress.toFixed(1)}%`
+          description: `下载中... ${progress.progress.toFixed(1)}%`,
         })
       })
 
       return result
     }
 
-    const result = await this.rotationService.execute(mirrors, downloadOperation, undefined, selectedMirror)
+    const result = await this.rotationService.execute(
+      mirrors,
+      downloadOperation,
+      undefined,
+      selectedMirror
+    )
 
     if (!result.success) {
       return { success: false, error: result.error }
@@ -331,7 +345,7 @@ export class PythonInstaller extends BaseEnvironmentInstaller {
 
   protected async installEnvironment(
     onProgress?: (progress: number, message: string, details?: any) => void,
-    selectedMirror?: string
+    _selectedMirror?: string
   ): Promise<{ success: boolean; error?: string }> {
     logger.info('=== 安装 Python 环境 ===')
 
@@ -418,14 +432,14 @@ export class PipInstaller extends BaseEnvironmentInstaller {
       const proc = spawn(this.pythonExe, ['-m', 'pip', '--version'], { stdio: 'pipe' })
 
       let output = ''
-      proc.stdout?.on('data', (data) => {
+      proc.stdout?.on('data', data => {
         output += data.toString()
       })
-      proc.stderr?.on('data', (data) => {
+      proc.stderr?.on('data', data => {
         output += data.toString()
       })
 
-      proc.on('close', (code) => {
+      proc.on('close', code => {
         if (code === 0) {
           resolve(output.trim())
         } else {
@@ -437,7 +451,10 @@ export class PipInstaller extends BaseEnvironmentInstaller {
     })
   }
 
-  protected async downloadPackage(onProgress?: ProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }> {
+  protected async downloadPackage(
+    onProgress?: ProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
     logger.info('=== 下载 get-pip.py ===')
 
     const mirrors = this.mirrorService.getMirrors('get_pip')
@@ -450,7 +467,7 @@ export class PipInstaller extends BaseEnvironmentInstaller {
 
       onOpProgress({ progress: 0, description: `正在从 ${mirror.name} 下载...` })
 
-      const result = await this.downloader.download(mirror.url, getPipPath, (progress) => {
+      const result = await this.downloader.download(mirror.url, getPipPath, progress => {
         // 检查是否是当前活跃的操作
         if (operationId !== this.currentOperationId) {
           return
@@ -461,18 +478,23 @@ export class PipInstaller extends BaseEnvironmentInstaller {
           progress: progress.progress,
           speed: progress.speed,
           downloadedSize: progress.downloadedSize,
-          totalSize: progress.totalSize
+          totalSize: progress.totalSize,
         })
         onOpProgress({
           progress: progress.progress,
-          description: `下载中... ${progress.progress.toFixed(1)}%`
+          description: `下载中... ${progress.progress.toFixed(1)}%`,
         })
       })
 
       return result
     }
 
-    const result = await this.rotationService.execute(mirrors, downloadOperation, undefined, selectedMirror)
+    const result = await this.rotationService.execute(
+      mirrors,
+      downloadOperation,
+      undefined,
+      selectedMirror
+    )
 
     if (!result.success) {
       return { success: false, error: result.error }
@@ -500,18 +522,16 @@ export class PipInstaller extends BaseEnvironmentInstaller {
         await new Promise<void>((resolve, reject) => {
           const hostname = new URL(mirror.url).hostname
 
-          const proc = spawn(this.pythonExe, [
-            getPipPath,
-            '-i',
-            mirror.url,
-            '--trusted-host',
-            hostname
-          ], {
-            cwd: this.pythonPath,
-            stdio: 'pipe'
-          })
+          const proc = spawn(
+            this.pythonExe,
+            [getPipPath, '-i', mirror.url, '--trusted-host', hostname],
+            {
+              cwd: this.pythonPath,
+              stdio: 'pipe',
+            }
+          )
 
-          proc.stdout?.on('data', (data) => {
+          proc.stdout?.on('data', data => {
             const output = data.toString().trim()
             logger.info(`pip 安装输出: ${output}`)
 
@@ -523,11 +543,11 @@ export class PipInstaller extends BaseEnvironmentInstaller {
             }
           })
 
-          proc.stderr?.on('data', (data) => {
+          proc.stderr?.on('data', data => {
             logger.error(`pip 安装错误: ${data.toString().trim()}`)
           })
 
-          proc.on('close', (code) => {
+          proc.on('close', code => {
             if (code === 0) {
               logger.info('Pip 安装成功')
               onOpProgress({ progress: 100, description: 'Pip 安装完成' })
@@ -548,19 +568,24 @@ export class PipInstaller extends BaseEnvironmentInstaller {
     }
 
     // 使用镜像源轮替执行安装
-    const result = await this.rotationService.execute(mirrors, installOperation, (rotationProgress) => {
-      const totalProgress = rotationProgress.operationProgress.progress
-      const message = rotationProgress.operationProgress.description
-      const details = {
-        currentMirror: rotationProgress.currentMirror.name,
-        mirrorProgress: {
-          current: rotationProgress.mirrorIndex + 1,
-          total: rotationProgress.totalMirrors
-        },
-        operationDesc: rotationProgress.operationProgress.description
-      }
-      onProgress?.(totalProgress, message, details)
-    }, selectedMirror)
+    const result = await this.rotationService.execute(
+      mirrors,
+      installOperation,
+      rotationProgress => {
+        const totalProgress = rotationProgress.operationProgress.progress
+        const message = rotationProgress.operationProgress.description
+        const details = {
+          currentMirror: rotationProgress.currentMirror.name,
+          mirrorProgress: {
+            current: rotationProgress.mirrorIndex + 1,
+            total: rotationProgress.totalMirrors,
+          },
+          operationDesc: rotationProgress.operationProgress.description,
+        }
+        onProgress?.(totalProgress, message, details)
+      },
+      selectedMirror
+    )
 
     if (!result.success) {
       return { success: false, error: result.error }
@@ -616,14 +641,14 @@ export class GitInstaller extends BaseEnvironmentInstaller {
       const proc = spawn(this.gitExe, ['-v'], { stdio: 'pipe' })
 
       let output = ''
-      proc.stdout?.on('data', (data) => {
+      proc.stdout?.on('data', data => {
         output += data.toString()
       })
-      proc.stderr?.on('data', (data) => {
+      proc.stderr?.on('data', data => {
         output += data.toString()
       })
 
-      proc.on('close', (code) => {
+      proc.on('close', code => {
         if (code === 0) {
           resolve(output.trim())
         } else {
@@ -635,7 +660,10 @@ export class GitInstaller extends BaseEnvironmentInstaller {
     })
   }
 
-  protected async downloadPackage(onProgress?: ProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }> {
+  protected async downloadPackage(
+    onProgress?: ProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
     logger.info('=== 下载 Git 安装包 ===')
 
     const mirrors = this.mirrorService.getMirrors('git')
@@ -654,7 +682,7 @@ export class GitInstaller extends BaseEnvironmentInstaller {
 
       onOpProgress({ progress: 0, description: `正在从 ${mirror.name} 下载...` })
 
-      const result = await this.downloader.download(mirror.url, tempZipPath, (progress) => {
+      const result = await this.downloader.download(mirror.url, tempZipPath, progress => {
         // 检查是否是当前活跃的操作
         if (operationId !== this.currentOperationId) {
           return
@@ -665,18 +693,23 @@ export class GitInstaller extends BaseEnvironmentInstaller {
           progress: progress.progress,
           speed: progress.speed,
           downloadedSize: progress.downloadedSize,
-          totalSize: progress.totalSize
+          totalSize: progress.totalSize,
         })
         onOpProgress({
           progress: progress.progress,
-          description: `下载中... ${progress.progress.toFixed(1)}%`
+          description: `下载中... ${progress.progress.toFixed(1)}%`,
         })
       })
 
       return result
     }
 
-    const result = await this.rotationService.execute(mirrors, downloadOperation, undefined, selectedMirror)
+    const result = await this.rotationService.execute(
+      mirrors,
+      downloadOperation,
+      undefined,
+      selectedMirror
+    )
 
     if (!result.success) {
       return { success: false, error: result.error }
@@ -688,7 +721,7 @@ export class GitInstaller extends BaseEnvironmentInstaller {
 
   protected async installEnvironment(
     onProgress?: (progress: number, message: string, details?: any) => void,
-    selectedMirror?: string
+    _selectedMirror?: string
   ): Promise<{ success: boolean; error?: string }> {
     logger.info('=== 安装 Git 环境 ===')
 
@@ -746,7 +779,7 @@ export class GitInstaller extends BaseEnvironmentInstaller {
         fs.renameSync(sourcePath, targetPath)
 
         // 更新进度
-        const itemProgress = 60 + Math.floor((i + 1) / totalItems * 20)
+        const itemProgress = 60 + Math.floor(((i + 1) / totalItems) * 20)
         onProgress?.(itemProgress, `移动文件 ${i + 1}/${totalItems}...`)
       }
 

--- a/frontend/electron/services/index.ts
+++ b/frontend/electron/services/index.ts
@@ -1,17 +1,17 @@
 /**
  * 初始化服务 - 统一导出
- * 
+ *
  * 使用示例:
- * 
+ *
  * ```typescript
  * import { InitializationService } from './services'
- * 
+ *
  * const initService = new InitializationService(appRoot, 'dev')
- * 
+ *
  * const result = await initService.initialize((progress) => {
  *   console.log(`[${progress.stage}] ${progress.message} - ${progress.progress}%`)
  * })
- * 
+ *
  * if (result.success) {
  *   console.log('初始化成功')
  * } else {
@@ -28,51 +28,51 @@ export { SmartDownloader, DownloadProgress, ProgressCallback } from './downloadS
 
 // 镜像源轮替服务
 export {
-    MirrorRotationService,
-    NetworkOperationProgress,
-    NetworkOperationCallback,
-    MirrorRotationProgress,
-    MirrorRotationProgressCallback
+  MirrorRotationService,
+  NetworkOperationProgress,
+  NetworkOperationCallback,
+  MirrorRotationProgress,
+  MirrorRotationProgressCallback,
 } from './mirrorRotationService'
 
 // 环境安装服务
 export {
-    PythonInstaller,
-    PipInstaller,
-    GitInstaller,
-    EnvironmentCheckResult,
-    InstallProgress,
-    InstallProgressCallback
+  PythonInstaller,
+  PipInstaller,
+  GitInstaller,
+  EnvironmentCheckResult,
+  InstallProgress,
+  InstallProgressCallback,
 } from './environmentService'
 
 // 仓库服务
 export {
-    RepositoryService,
-    RepositoryCheckResult,
-    RepositoryProgress,
-    RepositoryProgressCallback
+  RepositoryService,
+  RepositoryCheckResult,
+  RepositoryProgress,
+  RepositoryProgressCallback,
 } from './repositoryService'
 
 // 依赖服务
 export {
-    DependencyService,
-    DependencyCheckResult,
-    DependencyProgress,
-    DependencyProgressCallback
+  DependencyService,
+  DependencyCheckResult,
+  DependencyProgress,
+  DependencyProgressCallback,
 } from './dependencyService'
 
 // 初始化总流程服务
 export {
-    InitializationService,
-    InitializationProgress,
-    InitializationProgressCallback,
-    InitializationResult
+  InitializationService,
+  InitializationProgress,
+  InitializationProgressCallback,
+  InitializationResult,
 } from './initializationService'
 
 // 后端服务
 export {
-    BackendService,
-    BackendStatus,
-    BackendStartOptions,
-    BackendStatusCallback
+  BackendService,
+  BackendStatus,
+  BackendStartOptions,
+  BackendStatusCallback,
 } from './backendService'

--- a/frontend/electron/services/initializationService.ts
+++ b/frontend/electron/services/initializationService.ts
@@ -16,402 +16,413 @@ const logger = getLogger('初始化服务')
 // ==================== 类型定义 ====================
 
 export interface InitializationProgress {
-    stage: 'mirror' | 'python' | 'pip' | 'git' | 'repository' | 'dependency' | 'backend' | 'complete'
-    stageIndex: number
-    totalStages: number
-    progress: number
-    message: string
-    details?: {
-        checkInfo?: any  // 可以是 EnvironmentCheckResult, RepositoryCheckResult, 或 DependencyCheckResult
-        currentMirror?: string
-        mirrorProgress?: { current: number; total: number }
-        downloadSpeed?: number
-        downloadSize?: number
-        operationDesc?: string
-    }
+  stage: 'mirror' | 'python' | 'pip' | 'git' | 'repository' | 'dependency' | 'backend' | 'complete'
+  stageIndex: number
+  totalStages: number
+  progress: number
+  message: string
+  details?: {
+    checkInfo?: any // 可以是 EnvironmentCheckResult, RepositoryCheckResult, 或 DependencyCheckResult
+    currentMirror?: string
+    mirrorProgress?: { current: number; total: number }
+    downloadSpeed?: number
+    downloadSize?: number
+    operationDesc?: string
+  }
 }
 
 export type InitializationProgressCallback = (progress: InitializationProgress) => void
 
 export interface InitializationResult {
-    success: boolean
-    error?: string
-    completedStages: string[]
-    failedStage?: string
+  success: boolean
+  error?: string
+  completedStages: string[]
+  failedStage?: string
 }
 
 // ==================== 初始化服务类 ====================
 
 export class InitializationService {
-    private appRoot: string
-    private mirrorService: MirrorService
-    private backendService: BackendService
-    private targetBranch: string
+  private appRoot: string
+  private mirrorService: MirrorService
+  private backendService: BackendService
+  private targetBranch: string
 
-    constructor(appRoot: string, targetBranch: string = 'dev') {
-        this.appRoot = appRoot
-        this.mirrorService = new MirrorService(appRoot)
-        this.backendService = new BackendService(appRoot, this.mirrorService)
-        this.targetBranch = targetBranch
-    }
+  constructor(appRoot: string, targetBranch: string = 'dev') {
+    this.appRoot = appRoot
+    this.mirrorService = new MirrorService(appRoot)
+    this.backendService = new BackendService(appRoot, this.mirrorService)
+    this.targetBranch = targetBranch
+  }
 
-    /**
-     * 执行完整的初始化流程
-     */
-    async initialize(onProgress?: InitializationProgressCallback, startBackend: boolean = true): Promise<InitializationResult> {
-        const completedStages: string[] = []
-        const totalStages = startBackend ? 7 : 6
+  /**
+   * 执行完整的初始化流程
+   */
+  async initialize(
+    onProgress?: InitializationProgressCallback,
+    startBackend: boolean = true
+  ): Promise<InitializationResult> {
+    const completedStages: string[] = []
+    const totalStages = startBackend ? 7 : 6
 
-        try {
-            // 阶段 1: 初始化镜像源配置
-            onProgress?.({
-                stage: 'mirror',
-                stageIndex: 1,
-                totalStages,
-                progress: 0,
-                message: '正在初始化镜像源配置...'
-            })
+    try {
+      // 阶段 1: 初始化镜像源配置
+      onProgress?.({
+        stage: 'mirror',
+        stageIndex: 1,
+        totalStages,
+        progress: 0,
+        message: '正在初始化镜像源配置...',
+      })
 
-            await this.mirrorService.initialize()
-            completedStages.push('mirror')
+      await this.mirrorService.initialize()
+      completedStages.push('mirror')
 
-            onProgress?.({
-                stage: 'mirror',
-                stageIndex: 1,
-                totalStages,
-                progress: 100,
-                message: '镜像源配置初始化完成'
-            })
+      onProgress?.({
+        stage: 'mirror',
+        stageIndex: 1,
+        totalStages,
+        progress: 100,
+        message: '镜像源配置初始化完成',
+      })
 
-            // 阶段 2: 安装 Python
-            onProgress?.({
-                stage: 'python',
-                stageIndex: 2,
-                totalStages,
-                progress: 0,
-                message: '正在安装 Python...'
-            })
+      // 阶段 2: 安装 Python
+      onProgress?.({
+        stage: 'python',
+        stageIndex: 2,
+        totalStages,
+        progress: 0,
+        message: '正在安装 Python...',
+      })
 
-            const pythonInstaller = new PythonInstaller(this.appRoot, this.mirrorService)
-            const pythonResult = await pythonInstaller.install((installProgress) => {
-                onProgress?.({
-                    stage: 'python',
-                    stageIndex: 2,
-                    totalStages,
-                    progress: installProgress.progress,
-                    message: installProgress.message,
-                    details: installProgress.details
-                })
-            })
+      const pythonInstaller = new PythonInstaller(this.appRoot, this.mirrorService)
+      const pythonResult = await pythonInstaller.install(installProgress => {
+        onProgress?.({
+          stage: 'python',
+          stageIndex: 2,
+          totalStages,
+          progress: installProgress.progress,
+          message: installProgress.message,
+          details: installProgress.details,
+        })
+      })
 
-            if (!pythonResult.success) {
-                return {
-                    success: false,
-                    error: pythonResult.error,
-                    completedStages,
-                    failedStage: 'python'
-                }
-            }
-
-            completedStages.push('python')
-
-            // 阶段 3: 安装 Pip
-            onProgress?.({
-                stage: 'pip',
-                stageIndex: 3,
-                totalStages,
-                progress: 0,
-                message: '正在安装 Pip...'
-            })
-
-            const pipInstaller = new PipInstaller(this.appRoot, this.mirrorService)
-            const pipResult = await pipInstaller.install((installProgress) => {
-                onProgress?.({
-                    stage: 'pip',
-                    stageIndex: 3,
-                    totalStages,
-                    progress: installProgress.progress,
-                    message: installProgress.message,
-                    details: installProgress.details
-                })
-            })
-
-            if (!pipResult.success) {
-                return {
-                    success: false,
-                    error: pipResult.error,
-                    completedStages,
-                    failedStage: 'pip'
-                }
-            }
-
-            completedStages.push('pip')
-
-            // 阶段 4: 安装 Git
-            onProgress?.({
-                stage: 'git',
-                stageIndex: 4,
-                totalStages,
-                progress: 0,
-                message: '正在安装 Git...'
-            })
-
-            const gitInstaller = new GitInstaller(this.appRoot, this.mirrorService)
-            const gitResult = await gitInstaller.install((installProgress) => {
-                onProgress?.({
-                    stage: 'git',
-                    stageIndex: 4,
-                    totalStages,
-                    progress: installProgress.progress,
-                    message: installProgress.message,
-                    details: installProgress.details
-                })
-            })
-
-            if (!gitResult.success) {
-                return {
-                    success: false,
-                    error: gitResult.error,
-                    completedStages,
-                    failedStage: 'git'
-                }
-            }
-
-            completedStages.push('git')
-
-            // 阶段 5: 拉取源码
-            onProgress?.({
-                stage: 'repository',
-                stageIndex: 5,
-                totalStages,
-                progress: 0,
-                message: '正在拉取源码...'
-            })
-
-            const repositoryService = new RepositoryService(this.appRoot, this.mirrorService, this.targetBranch)
-            const repoResult = await repositoryService.pullRepository((repoProgress) => {
-                onProgress?.({
-                    stage: 'repository',
-                    stageIndex: 5,
-                    totalStages,
-                    progress: repoProgress.progress,
-                    message: repoProgress.message,
-                    details: repoProgress.details
-                })
-            })
-
-            if (!repoResult.success) {
-                return {
-                    success: false,
-                    error: repoResult.error,
-                    completedStages,
-                    failedStage: 'repository'
-                }
-            }
-
-            completedStages.push('repository')
-
-            // 阶段 6: 安装依赖
-            onProgress?.({
-                stage: 'dependency',
-                stageIndex: 6,
-                totalStages,
-                progress: 0,
-                message: '正在安装依赖...'
-            })
-
-            const dependencyService = new DependencyService(this.appRoot, this.mirrorService)
-            const depResult = await dependencyService.installDependencies((depProgress) => {
-                onProgress?.({
-                    stage: 'dependency',
-                    stageIndex: 6,
-                    totalStages,
-                    progress: depProgress.progress,
-                    message: depProgress.message,
-                    details: depProgress.details
-                })
-            })
-
-            if (!depResult.success) {
-                return {
-                    success: false,
-                    error: depResult.error,
-                    completedStages,
-                    failedStage: 'dependency'
-                }
-            }
-
-            completedStages.push('dependency')
-
-            // 阶段 7: 启动后端（可选）
-            if (startBackend) {
-                onProgress?.({
-                    stage: 'backend',
-                    stageIndex: 7,
-                    totalStages,
-                    progress: 0,
-                    message: '正在启动后端服务...'
-                })
-
-                const backendResult = await this.backendService.startBackend()
-
-                if (!backendResult.success) {
-                    return {
-                        success: false,
-                        error: backendResult.error,
-                        completedStages,
-                        failedStage: 'backend'
-                    }
-                }
-
-                const status = this.backendService.getStatus()
-                onProgress?.({
-                    stage: 'backend',
-                    stageIndex: 7,
-                    totalStages,
-                    progress: 100,
-                    message: `后端服务已启动，PID: ${status.pid}`
-                })
-
-                completedStages.push('backend')
-            }
-
-            // 完成
-            onProgress?.({
-                stage: 'complete',
-                stageIndex: totalStages,
-                totalStages,
-                progress: 100,
-                message: '初始化完成'
-            })
-
-            return {
-                success: true,
-                completedStages
-            }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`初始化失败: ${errorMsg}`)
-
-            return {
-                success: false,
-                error: errorMsg,
-                completedStages
-            }
+      if (!pythonResult.success) {
+        return {
+          success: false,
+          error: pythonResult.error,
+          completedStages,
+          failedStage: 'python',
         }
-    }
+      }
 
-    /**
-     * 仅更新源码和依赖（用于已初始化的环境）
-     */
-    async updateOnly(onProgress?: InitializationProgressCallback): Promise<InitializationResult> {
-        const completedStages: string[] = []
-        const totalStages = 2
+      completedStages.push('python')
 
-        try {
-            // 初始化镜像源配置
-            await this.mirrorService.initialize()
+      // 阶段 3: 安装 Pip
+      onProgress?.({
+        stage: 'pip',
+        stageIndex: 3,
+        totalStages,
+        progress: 0,
+        message: '正在安装 Pip...',
+      })
 
-            // 阶段 1: 拉取源码
-            onProgress?.({
-                stage: 'repository',
-                stageIndex: 1,
-                totalStages,
-                progress: 0,
-                message: '正在更新源码...'
-            })
+      const pipInstaller = new PipInstaller(this.appRoot, this.mirrorService)
+      const pipResult = await pipInstaller.install(installProgress => {
+        onProgress?.({
+          stage: 'pip',
+          stageIndex: 3,
+          totalStages,
+          progress: installProgress.progress,
+          message: installProgress.message,
+          details: installProgress.details,
+        })
+      })
 
-            const repositoryService = new RepositoryService(this.appRoot, this.mirrorService, this.targetBranch)
-            const repoResult = await repositoryService.pullRepository((repoProgress) => {
-                onProgress?.({
-                    stage: 'repository',
-                    stageIndex: 1,
-                    totalStages,
-                    progress: repoProgress.progress,
-                    message: repoProgress.message,
-                    details: repoProgress.details
-                })
-            })
-
-            if (!repoResult.success) {
-                return {
-                    success: false,
-                    error: repoResult.error,
-                    completedStages,
-                    failedStage: 'repository'
-                }
-            }
-
-            completedStages.push('repository')
-
-            // 阶段 2: 安装依赖
-            onProgress?.({
-                stage: 'dependency',
-                stageIndex: 2,
-                totalStages,
-                progress: 0,
-                message: '正在更新依赖...'
-            })
-
-            const dependencyService = new DependencyService(this.appRoot, this.mirrorService)
-            const depResult = await dependencyService.installDependencies((depProgress) => {
-                onProgress?.({
-                    stage: 'dependency',
-                    stageIndex: 2,
-                    totalStages,
-                    progress: depProgress.progress,
-                    message: depProgress.message,
-                    details: depProgress.details
-                })
-            })
-
-            if (!depResult.success) {
-                return {
-                    success: false,
-                    error: depResult.error,
-                    completedStages,
-                    failedStage: 'dependency'
-                }
-            }
-
-            completedStages.push('dependency')
-
-            // 完成
-            onProgress?.({
-                stage: 'complete',
-                stageIndex: totalStages,
-                totalStages,
-                progress: 100,
-                message: '更新完成'
-            })
-
-            return {
-                success: true,
-                completedStages
-            }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`更新失败: ${errorMsg}`)
-
-            return {
-                success: false,
-                error: errorMsg,
-                completedStages
-            }
+      if (!pipResult.success) {
+        return {
+          success: false,
+          error: pipResult.error,
+          completedStages,
+          failedStage: 'pip',
         }
-    }
+      }
 
-    /**
-     * 获取镜像源服务实例（用于外部访问）
-     */
-    getMirrorService(): MirrorService {
-        return this.mirrorService
-    }
+      completedStages.push('pip')
 
-    /**
-     * 获取后端服务实例（用于外部访问）
-     */
-    getBackendService(): BackendService {
-        return this.backendService
+      // 阶段 4: 安装 Git
+      onProgress?.({
+        stage: 'git',
+        stageIndex: 4,
+        totalStages,
+        progress: 0,
+        message: '正在安装 Git...',
+      })
+
+      const gitInstaller = new GitInstaller(this.appRoot, this.mirrorService)
+      const gitResult = await gitInstaller.install(installProgress => {
+        onProgress?.({
+          stage: 'git',
+          stageIndex: 4,
+          totalStages,
+          progress: installProgress.progress,
+          message: installProgress.message,
+          details: installProgress.details,
+        })
+      })
+
+      if (!gitResult.success) {
+        return {
+          success: false,
+          error: gitResult.error,
+          completedStages,
+          failedStage: 'git',
+        }
+      }
+
+      completedStages.push('git')
+
+      // 阶段 5: 拉取源码
+      onProgress?.({
+        stage: 'repository',
+        stageIndex: 5,
+        totalStages,
+        progress: 0,
+        message: '正在拉取源码...',
+      })
+
+      const repositoryService = new RepositoryService(
+        this.appRoot,
+        this.mirrorService,
+        this.targetBranch
+      )
+      const repoResult = await repositoryService.pullRepository(repoProgress => {
+        onProgress?.({
+          stage: 'repository',
+          stageIndex: 5,
+          totalStages,
+          progress: repoProgress.progress,
+          message: repoProgress.message,
+          details: repoProgress.details,
+        })
+      })
+
+      if (!repoResult.success) {
+        return {
+          success: false,
+          error: repoResult.error,
+          completedStages,
+          failedStage: 'repository',
+        }
+      }
+
+      completedStages.push('repository')
+
+      // 阶段 6: 安装依赖
+      onProgress?.({
+        stage: 'dependency',
+        stageIndex: 6,
+        totalStages,
+        progress: 0,
+        message: '正在安装依赖...',
+      })
+
+      const dependencyService = new DependencyService(this.appRoot, this.mirrorService)
+      const depResult = await dependencyService.installDependencies(depProgress => {
+        onProgress?.({
+          stage: 'dependency',
+          stageIndex: 6,
+          totalStages,
+          progress: depProgress.progress,
+          message: depProgress.message,
+          details: depProgress.details,
+        })
+      })
+
+      if (!depResult.success) {
+        return {
+          success: false,
+          error: depResult.error,
+          completedStages,
+          failedStage: 'dependency',
+        }
+      }
+
+      completedStages.push('dependency')
+
+      // 阶段 7: 启动后端（可选）
+      if (startBackend) {
+        onProgress?.({
+          stage: 'backend',
+          stageIndex: 7,
+          totalStages,
+          progress: 0,
+          message: '正在启动后端服务...',
+        })
+
+        const backendResult = await this.backendService.startBackend()
+
+        if (!backendResult.success) {
+          return {
+            success: false,
+            error: backendResult.error,
+            completedStages,
+            failedStage: 'backend',
+          }
+        }
+
+        const status = this.backendService.getStatus()
+        onProgress?.({
+          stage: 'backend',
+          stageIndex: 7,
+          totalStages,
+          progress: 100,
+          message: `后端服务已启动，PID: ${status.pid}`,
+        })
+
+        completedStages.push('backend')
+      }
+
+      // 完成
+      onProgress?.({
+        stage: 'complete',
+        stageIndex: totalStages,
+        totalStages,
+        progress: 100,
+        message: '初始化完成',
+      })
+
+      return {
+        success: true,
+        completedStages,
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`初始化失败: ${errorMsg}`)
+
+      return {
+        success: false,
+        error: errorMsg,
+        completedStages,
+      }
     }
+  }
+
+  /**
+   * 仅更新源码和依赖（用于已初始化的环境）
+   */
+  async updateOnly(onProgress?: InitializationProgressCallback): Promise<InitializationResult> {
+    const completedStages: string[] = []
+    const totalStages = 2
+
+    try {
+      // 初始化镜像源配置
+      await this.mirrorService.initialize()
+
+      // 阶段 1: 拉取源码
+      onProgress?.({
+        stage: 'repository',
+        stageIndex: 1,
+        totalStages,
+        progress: 0,
+        message: '正在更新源码...',
+      })
+
+      const repositoryService = new RepositoryService(
+        this.appRoot,
+        this.mirrorService,
+        this.targetBranch
+      )
+      const repoResult = await repositoryService.pullRepository(repoProgress => {
+        onProgress?.({
+          stage: 'repository',
+          stageIndex: 1,
+          totalStages,
+          progress: repoProgress.progress,
+          message: repoProgress.message,
+          details: repoProgress.details,
+        })
+      })
+
+      if (!repoResult.success) {
+        return {
+          success: false,
+          error: repoResult.error,
+          completedStages,
+          failedStage: 'repository',
+        }
+      }
+
+      completedStages.push('repository')
+
+      // 阶段 2: 安装依赖
+      onProgress?.({
+        stage: 'dependency',
+        stageIndex: 2,
+        totalStages,
+        progress: 0,
+        message: '正在更新依赖...',
+      })
+
+      const dependencyService = new DependencyService(this.appRoot, this.mirrorService)
+      const depResult = await dependencyService.installDependencies(depProgress => {
+        onProgress?.({
+          stage: 'dependency',
+          stageIndex: 2,
+          totalStages,
+          progress: depProgress.progress,
+          message: depProgress.message,
+          details: depProgress.details,
+        })
+      })
+
+      if (!depResult.success) {
+        return {
+          success: false,
+          error: depResult.error,
+          completedStages,
+          failedStage: 'dependency',
+        }
+      }
+
+      completedStages.push('dependency')
+
+      // 完成
+      onProgress?.({
+        stage: 'complete',
+        stageIndex: totalStages,
+        totalStages,
+        progress: 100,
+        message: '更新完成',
+      })
+
+      return {
+        success: true,
+        completedStages,
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`更新失败: ${errorMsg}`)
+
+      return {
+        success: false,
+        error: errorMsg,
+        completedStages,
+      }
+    }
+  }
+
+  /**
+   * 获取镜像源服务实例（用于外部访问）
+   */
+  getMirrorService(): MirrorService {
+    return this.mirrorService
+  }
+
+  /**
+   * 获取后端服务实例（用于外部访问）
+   */
+  getBackendService(): BackendService {
+    return this.backendService
+  }
 }

--- a/frontend/electron/services/mirrorService.ts
+++ b/frontend/electron/services/mirrorService.ts
@@ -15,445 +15,453 @@ const logger = getLogger('镜像源服务')
 // ==================== 类型定义 ====================
 
 export interface MirrorSource {
-    key: string
-    name: string
-    url: string
-    type: 'official' | 'mirror'
-    description: string
+  key: string
+  name: string
+  url: string
+  type: 'official' | 'mirror'
+  description: string
 }
 
 export interface MirrorConfig {
-    python: MirrorSource[]
-    get_pip: MirrorSource[]
-    git: MirrorSource[]
-    repo: MirrorSource[]
-    pip_mirror: MirrorSource[]
+  python: MirrorSource[]
+  get_pip: MirrorSource[]
+  git: MirrorSource[]
+  repo: MirrorSource[]
+  pip_mirror: MirrorSource[]
 }
 
 export interface ApiEndpoints {
-    local: string
-    websocket: string
+  local: string
+  websocket: string
 }
 
 export interface CloudMirrorConfig {
-    mirrors: MirrorConfig
-    apiEndpoints?: ApiEndpoints  // API 端点配置
+  mirrors: MirrorConfig
+  apiEndpoints?: ApiEndpoints // API 端点配置
 }
 
 export interface LocalConfigCache {
-    config: CloudMirrorConfig
-    etag?: string  // 用于判断配置是否需要更新
-    lastUpdated: string  // 最后更新时间
+  config: CloudMirrorConfig
+  etag?: string // 用于判断配置是否需要更新
+  lastUpdated: string // 最后更新时间
 }
 
 // ==================== 默认配置 ====================
 
 const DEFAULT_API_ENDPOINTS: ApiEndpoints = {
-    local: 'http://127.0.0.1:36163',
-    websocket: 'ws://127.0.0.1:36163',
+  local: 'http://127.0.0.1:36163',
+  websocket: 'ws://127.0.0.1:36163',
 }
 
 const DEFAULT_MIRROR_CONFIG: MirrorConfig = {
-    python: [
-        {
-            key: 'aliyun',
-            name: '阿里云镜像',
-            url: 'https://mirrors.aliyun.com/python-release/windows/python-3.12.0-embed-amd64.zip',
-            type: 'mirror',
-            description: '阿里云镜像服务，国内访问速度快'
-        },
-        {
-            key: 'tsinghua',
-            name: '清华 TUNA 镜像',
-            url: 'https://mirrors.tuna.tsinghua.edu.cn/python/3.12.0/python-3.12.0-embed-amd64.zip',
-            type: 'mirror',
-            description: '清华大学开源软件镜像站，国内访问速度快'
-        },
-        {
-            key: 'huawei',
-            name: '华为云镜像',
-            url: 'https://mirrors.huaweicloud.com/repository/toolkit/python/3.12.0/python-3.12.0-embed-amd64.zip',
-            type: 'mirror',
-            description: '华为云镜像服务，国内访问稳定'
-        },
-        {
-            key: 'autonas',
-            name: 'AUTO-MAS 自建源',
-            url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/python-3.12.0-embed-amd64.zip',
-            type: 'mirror',
-            description: 'AUTO-MAS 自建下载站，国内访问速度快'
-        },
-        {
-            key: 'official',
-            name: 'Python 官方',
-            url: 'https://www.python.org/ftp/python/3.12.0/python-3.12.0-embed-amd64.zip',
-            type: 'official',
-            description: 'Python 官方下载源，在中国大陆连通性不佳'
-        }
-    ],
-    get_pip: [
-        {
-            key: 'autonas',
-            name: 'AUTO-MAS 自建源',
-            url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/get-pip.py',
-            type: 'mirror',
-            description: 'AUTO-MAS 自建下载站，国内访问速度快'
-        },
-        {
-            key: 'official',
-            name: '官方源',
-            url: 'https://bootstrap.pypa.io/get-pip.py',
-            type: 'official',
-            description: '官方源，在中国大陆连通性不佳'
-        }
-    ],
-    git: [
-        {
-            key: 'autonas',
-            name: 'AUTO-MAS 自建源',
-            url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/git.zip',
-            type: 'mirror',
-            description: 'AUTO-MAS 自建下载站，国内访问速度快'
-        }
-    ],
-    repo: [
-        {
-            key: 'cnb',
-            name: 'CNB 官方镜像',
-            url: 'https://cnb.cool/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'mirror',
-            description: 'CNB 镜像源，更新及时，国内访问速度快'
-        },
-        {
-            key: 'gitee 镜像源',
-            name: 'gitee',
-            url: 'https://gitee.com/auto-mas-project/AUTO-MAS.git',
-            type: 'mirror',
-            description: 'Gitee 镜像源，更新会有少许延迟'
-        },
-        {
-            key: 'ghproxy_cloudflare',
-            name: 'gh-proxy (Cloudflare)',
-            url: 'https://gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'mirror',
-            description: 'Cloudflare CDN 镜像，适合全球用户'
-        },
-        {
-            key: 'ghproxy_fastly',
-            name: 'gh-proxy (Fastly CDN)',
-            url: 'https://cdn.gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'mirror',
-            description: 'Fastly CDN 镜像服务'
-        },
-        {
-            key: 'ghproxy_edgeone',
-            name: 'gh-proxy (EdgeOne)',
-            url: 'https://edgeone.gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'mirror',
-            description: 'EdgeOne 镜像服务'
-        },
-        {
-            key: 'ghfast',
-            name: 'ghfast 镜像',
-            url: 'https://ghfast.top/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'mirror',
-            description: '第三方镜像服务'
-        },
-        {
-            key: 'github',
-            name: 'GitHub 官方',
-            url: 'https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
-            type: 'official',
-            description: '官方源，在中国大陆连通性不佳，可能需要科学上网'
-        }
-    ],
-    pip_mirror: [
-        {
-            key: 'aliyun',
-            name: '阿里云',
-            url: 'https://mirrors.aliyun.com/pypi/simple/',
-            type: 'mirror',
-            description: '阿里云 PyPI 镜像，国内访问速度快'
-        },
-        {
-            key: 'tsinghua',
-            name: '清华大学',
-            url: 'https://pypi.tuna.tsinghua.edu.cn/simple/',
-            type: 'mirror',
-            description: '清华大学 PyPI 镜像，国内访问速度快'
-        },
-        {
-            key: 'ustc',
-            name: '中科大',
-            url: 'https://pypi.mirrors.ustc.edu.cn/simple/',
-            type: 'mirror',
-            description: '中科大 PyPI 镜像，国内访问稳定'
-        },
-        {
-            key: 'official',
-            name: 'PyPI 官方',
-            url: 'https://pypi.org/simple/',
-            type: 'official',
-            description: 'PyPI 官方源，在中国大陆连通性不佳，下载速度慢'
-        }
-    ]
+  python: [
+    {
+      key: 'aliyun',
+      name: '阿里云镜像',
+      url: 'https://mirrors.aliyun.com/python-release/windows/python-3.12.0-embed-amd64.zip',
+      type: 'mirror',
+      description: '阿里云镜像服务，国内访问速度快',
+    },
+    {
+      key: 'tsinghua',
+      name: '清华 TUNA 镜像',
+      url: 'https://mirrors.tuna.tsinghua.edu.cn/python/3.12.0/python-3.12.0-embed-amd64.zip',
+      type: 'mirror',
+      description: '清华大学开源软件镜像站，国内访问速度快',
+    },
+    {
+      key: 'huawei',
+      name: '华为云镜像',
+      url: 'https://mirrors.huaweicloud.com/repository/toolkit/python/3.12.0/python-3.12.0-embed-amd64.zip',
+      type: 'mirror',
+      description: '华为云镜像服务，国内访问稳定',
+    },
+    {
+      key: 'autonas',
+      name: 'AUTO-MAS 自建源',
+      url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/python-3.12.0-embed-amd64.zip',
+      type: 'mirror',
+      description: 'AUTO-MAS 自建下载站，国内访问速度快',
+    },
+    {
+      key: 'official',
+      name: 'Python 官方',
+      url: 'https://www.python.org/ftp/python/3.12.0/python-3.12.0-embed-amd64.zip',
+      type: 'official',
+      description: 'Python 官方下载源，在中国大陆连通性不佳',
+    },
+  ],
+  get_pip: [
+    {
+      key: 'autonas',
+      name: 'AUTO-MAS 自建源',
+      url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/get-pip.py',
+      type: 'mirror',
+      description: 'AUTO-MAS 自建下载站，国内访问速度快',
+    },
+    {
+      key: 'official',
+      name: '官方源',
+      url: 'https://bootstrap.pypa.io/get-pip.py',
+      type: 'official',
+      description: '官方源，在中国大陆连通性不佳',
+    },
+  ],
+  git: [
+    {
+      key: 'autonas',
+      name: 'AUTO-MAS 自建源',
+      url: 'https://download.auto-mas.top/d/AUTO-MAS/Environment/git.zip',
+      type: 'mirror',
+      description: 'AUTO-MAS 自建下载站，国内访问速度快',
+    },
+  ],
+  repo: [
+    {
+      key: 'cnb',
+      name: 'CNB 官方镜像',
+      url: 'https://cnb.cool/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'mirror',
+      description: 'CNB 镜像源，更新及时，国内访问速度快',
+    },
+    {
+      key: 'gitee 镜像源',
+      name: 'gitee',
+      url: 'https://gitee.com/auto-mas-project/AUTO-MAS.git',
+      type: 'mirror',
+      description: 'Gitee 镜像源，更新会有少许延迟',
+    },
+    {
+      key: 'ghproxy_cloudflare',
+      name: 'gh-proxy (Cloudflare)',
+      url: 'https://gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'mirror',
+      description: 'Cloudflare CDN 镜像，适合全球用户',
+    },
+    {
+      key: 'ghproxy_fastly',
+      name: 'gh-proxy (Fastly CDN)',
+      url: 'https://cdn.gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'mirror',
+      description: 'Fastly CDN 镜像服务',
+    },
+    {
+      key: 'ghproxy_edgeone',
+      name: 'gh-proxy (EdgeOne)',
+      url: 'https://edgeone.gh-proxy.com/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'mirror',
+      description: 'EdgeOne 镜像服务',
+    },
+    {
+      key: 'ghfast',
+      name: 'ghfast 镜像',
+      url: 'https://ghfast.top/https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'mirror',
+      description: '第三方镜像服务',
+    },
+    {
+      key: 'github',
+      name: 'GitHub 官方',
+      url: 'https://github.com/AUTO-MAS-Project/AUTO-MAS.git',
+      type: 'official',
+      description: '官方源，在中国大陆连通性不佳，可能需要科学上网',
+    },
+  ],
+  pip_mirror: [
+    {
+      key: 'aliyun',
+      name: '阿里云',
+      url: 'https://mirrors.aliyun.com/pypi/simple/',
+      type: 'mirror',
+      description: '阿里云 PyPI 镜像，国内访问速度快',
+    },
+    {
+      key: 'tsinghua',
+      name: '清华大学',
+      url: 'https://pypi.tuna.tsinghua.edu.cn/simple/',
+      type: 'mirror',
+      description: '清华大学 PyPI 镜像，国内访问速度快',
+    },
+    {
+      key: 'ustc',
+      name: '中科大',
+      url: 'https://pypi.mirrors.ustc.edu.cn/simple/',
+      type: 'mirror',
+      description: '中科大 PyPI 镜像，国内访问稳定',
+    },
+    {
+      key: 'official',
+      name: 'PyPI 官方',
+      url: 'https://pypi.org/simple/',
+      type: 'official',
+      description: 'PyPI 官方源，在中国大陆连通性不佳，下载速度慢',
+    },
+  ],
 }
 
 // ==================== 镜像源管理类 ====================
 
 export class MirrorService {
-    private mirrorConfig: MirrorConfig
-    private apiEndpoints: ApiEndpoints
-    private localConfigPath: string
-    private currentEtag: string | undefined
+  private mirrorConfig: MirrorConfig
+  private apiEndpoints: ApiEndpoints
+  private localConfigPath: string
+  private currentEtag: string | undefined
 
-    constructor(appRoot: string) {
-        this.localConfigPath = path.join(appRoot, 'config', 'mirror_config.json')
-        this.mirrorConfig = { ...DEFAULT_MIRROR_CONFIG }
-        this.apiEndpoints = { ...DEFAULT_API_ENDPOINTS }
+  constructor(appRoot: string) {
+    this.localConfigPath = path.join(appRoot, 'config', 'mirror_config.json')
+    this.mirrorConfig = { ...DEFAULT_MIRROR_CONFIG }
+    this.apiEndpoints = { ...DEFAULT_API_ENDPOINTS }
+  }
+
+  /**
+   * 初始化镜像源配置
+   * 使用 ETag 机制判断是否需要更新配置
+   */
+  async initialize(): Promise<void> {
+    logger.info('=== 初始化镜像源配置 ===')
+
+    // 先加载本地缓存配置和 ETag
+    const localCache = this.loadLocalConfig()
+    if (localCache) {
+      this.mirrorConfig = localCache.config.mirrors
+      this.apiEndpoints = localCache.config.apiEndpoints || DEFAULT_API_ENDPOINTS
+      this.currentEtag = localCache.etag
+      logger.info('加载本地缓存配置')
+      logger.info(`ETag: ${this.currentEtag || '无'}`)
     }
 
-    /**
-     * 初始化镜像源配置
-     * 使用 ETag 机制判断是否需要更新配置
-     */
-    async initialize(): Promise<void> {
-        logger.info('=== 初始化镜像源配置 ===')
+    // 尝试从云端更新配置
+    try {
+      const result = await this.downloadCloudConfig(this.currentEtag)
 
-        // 先加载本地缓存配置和 ETag
-        const localCache = this.loadLocalConfig()
-        if (localCache) {
-            this.mirrorConfig = localCache.config.mirrors
-            this.apiEndpoints = localCache.config.apiEndpoints || DEFAULT_API_ENDPOINTS
-            this.currentEtag = localCache.etag
-            logger.info('加载本地缓存配置')
-            logger.info(`ETag: ${this.currentEtag || '无'}`)
+      if (result.status === 'updated') {
+        // 配置已更新
+        this.mirrorConfig = result.config!.mirrors
+        this.apiEndpoints = result.config!.apiEndpoints || DEFAULT_API_ENDPOINTS
+        this.currentEtag = result.etag
+        this.saveLocalConfig(result.config!, result.etag)
+        logger.info('云端配置已更新')
+        logger.info(`新 ETag: ${result.etag}`)
+      } else if (result.status === 'not-modified') {
+        // 配置未变化
+        logger.info('云端配置未变化，使用缓存')
+      } else {
+        // 下载失败，使用已加载的缓存或默认配置
+        if (!localCache) {
+          logger.info('使用默认镜像源配置')
+        }
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.warn(`检查云端配置失败: ${errorMsg}`)
+      if (!localCache) {
+        logger.info('使用默认镜像源配置')
+      }
+    }
+
+    logger.info(`API 端点: ${JSON.stringify(this.apiEndpoints)}`)
+  }
+
+  /**
+   * 从云端下载镜像源配置（支持 ETag 条件请求）
+   */
+  private downloadCloudConfig(
+    currentEtag?: string,
+    url?: string
+  ): Promise<{
+    status: 'updated' | 'not-modified' | 'error'
+    config?: CloudMirrorConfig
+    etag?: string
+  }> {
+    return new Promise(resolve => {
+      const targetUrl = url || 'https://api.auto-mas.top/file/Server/mirror.json'
+      logger.info(`正在检查云端配置: ${targetUrl}`)
+      if (currentEtag) {
+        logger.info(`当前 ETag: ${currentEtag}`)
+      }
+
+      const client = targetUrl.startsWith('https') ? https : http
+      const options: any = {
+        timeout: 10000,
+        headers: {},
+      }
+
+      // 如果有 ETag，添加 If-None-Match 头
+      if (currentEtag) {
+        options.headers['If-None-Match'] = currentEtag
+      }
+
+      const req = client.get(targetUrl, options, response => {
+        // 处理重定向 (301, 302, 307, 308)
+        if (response.statusCode && [301, 302, 307, 308].includes(response.statusCode)) {
+          const redirectUrl = response.headers.location
+          if (redirectUrl) {
+            logger.info(`跟随重定向: ${response.statusCode} -> ${redirectUrl}`)
+            req.destroy() // 销毁原请求
+            // 递归调用以跟随重定向，使用新的 URL
+            this.downloadCloudConfig(currentEtag, redirectUrl)
+              .then(resolve)
+              .catch(() => {
+                resolve({ status: 'error' })
+              })
+            return
+          }
         }
 
-        // 尝试从云端更新配置
-        try {
-            const result = await this.downloadCloudConfig(this.currentEtag)
+        const newEtag = response.headers['etag'] as string | undefined
 
-            if (result.status === 'updated') {
-                // 配置已更新
-                this.mirrorConfig = result.config!.mirrors
-                this.apiEndpoints = result.config!.apiEndpoints || DEFAULT_API_ENDPOINTS
-                this.currentEtag = result.etag
-                this.saveLocalConfig(result.config!, result.etag)
-                logger.info('云端配置已更新')
-                logger.info(`新 ETag: ${result.etag}`)
-            } else if (result.status === 'not-modified') {
-                // 配置未变化
-                logger.info('云端配置未变化，使用缓存')
-            } else {
-                // 下载失败，使用已加载的缓存或默认配置
-                if (!localCache) {
-                    logger.info('使用默认镜像源配置')
-                }
-            }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.warn(`检查云端配置失败: ${errorMsg}`)
-            if (!localCache) {
-                logger.info('使用默认镜像源配置')
-            }
+        // 304 Not Modified - 配置未变化
+        if (response.statusCode === 304) {
+          logger.info('云端配置未变化 (304 Not Modified)')
+          resolve({ status: 'not-modified' })
+          return
         }
 
-        logger.info(`API 端点: ${JSON.stringify(this.apiEndpoints)}`)
-    }
+        // 200 OK - 有新配置
+        if (response.statusCode === 200) {
+          let data = ''
+          response.on('data', chunk => {
+            data += chunk.toString()
+          })
 
-    /**
-     * 从云端下载镜像源配置（支持 ETag 条件请求）
-     */
-    private downloadCloudConfig(currentEtag?: string, url?: string): Promise<{
-        status: 'updated' | 'not-modified' | 'error'
-        config?: CloudMirrorConfig
-        etag?: string
-    }> {
-        return new Promise((resolve) => {
-            const targetUrl = url || 'https://api.auto-mas.top/file/Server/mirror.json'
-            logger.info(`正在检查云端配置: ${targetUrl}`)
-            if (currentEtag) {
-                logger.info(`当前 ETag: ${currentEtag}`)
-            }
+          response.on('end', () => {
+            try {
+              const config = JSON.parse(data) as CloudMirrorConfig
 
-            const client = targetUrl.startsWith('https') ? https : http
-            const options: any = {
-                timeout: 10000,
-                headers: {}
-            }
+              // 确保 apiEndpoints 存在
+              if (!config.apiEndpoints) {
+                config.apiEndpoints = { ...DEFAULT_API_ENDPOINTS }
+              }
 
-            // 如果有 ETag，添加 If-None-Match 头
-            if (currentEtag) {
-                options.headers['If-None-Match'] = currentEtag
-            }
+              logger.info(`云端配置下载成功`)
+              if (newEtag) {
+                logger.info(`ETag: ${newEtag}`)
+              }
 
-            const req = client.get(targetUrl, options, (response) => {
-                // 处理重定向 (301, 302, 307, 308)
-                if (response.statusCode && [301, 302, 307, 308].includes(response.statusCode)) {
-                    const redirectUrl = response.headers.location
-                    if (redirectUrl) {
-                        logger.info(`跟随重定向: ${response.statusCode} -> ${redirectUrl}`)
-                        req.destroy() // 销毁原请求
-                        // 递归调用以跟随重定向，使用新的 URL
-                        this.downloadCloudConfig(currentEtag, redirectUrl).then(resolve).catch(() => {
-                            resolve({ status: 'error' })
-                        })
-                        return
-                    }
-                }
-
-                const newEtag = response.headers['etag'] as string | undefined
-
-                // 304 Not Modified - 配置未变化
-                if (response.statusCode === 304) {
-                    logger.info('云端配置未变化 (304 Not Modified)')
-                    resolve({ status: 'not-modified' })
-                    return
-                }
-
-                // 200 OK - 有新配置
-                if (response.statusCode === 200) {
-                    let data = ''
-                    response.on('data', (chunk) => {
-                        data += chunk.toString()
-                    })
-
-                    response.on('end', () => {
-                        try {
-                            const config = JSON.parse(data) as CloudMirrorConfig
-
-                            // 确保 apiEndpoints 存在
-                            if (!config.apiEndpoints) {
-                                config.apiEndpoints = { ...DEFAULT_API_ENDPOINTS }
-                            }
-
-                            logger.info(`云端配置下载成功`)
-                            if (newEtag) {
-                                logger.info(`ETag: ${newEtag}`)
-                            }
-
-                            resolve({
-                                status: 'updated',
-                                config,
-                                etag: newEtag
-                            })
-                        } catch (error) {
-                            const errorMsg = error instanceof Error ? error.message : String(error)
-                            logger.error(`解析云端配置失败: ${errorMsg}`)
-                            resolve({ status: 'error' })
-                        }
-                    })
-                    return
-                }
-
-                // 其他状态码
-                logger.warn(`云端配置请求失败，状态码: ${response.statusCode}`)
-                resolve({ status: 'error' })
-            })
-
-            req.on('error', (error) => {
-                const errorMsg = error instanceof Error ? error.message : String(error)
-                logger.error(`云端配置请求错误: ${errorMsg}`)
-                resolve({ status: 'error' })
-            })
-
-            req.on('timeout', () => {
-                logger.warn('云端配置请求超时')
-                req.destroy()
-                resolve({ status: 'error' })
-            })
-        })
-    }
-
-    /**
-     * 保存配置到本地（包含 ETag）
-     */
-    private saveLocalConfig(config: CloudMirrorConfig, etag?: string): void {
-        try {
-            const configDir = path.dirname(this.localConfigPath)
-            if (!fs.existsSync(configDir)) {
-                fs.mkdirSync(configDir, { recursive: true })
-            }
-
-            const cache: LocalConfigCache = {
+              resolve({
+                status: 'updated',
                 config,
-                etag,
-                lastUpdated: new Date().toISOString()
+                etag: newEtag,
+              })
+            } catch (error) {
+              const errorMsg = error instanceof Error ? error.message : String(error)
+              logger.error(`解析云端配置失败: ${errorMsg}`)
+              resolve({ status: 'error' })
             }
-
-            fs.writeFileSync(this.localConfigPath, JSON.stringify(cache, null, 2), 'utf-8')
-            logger.info('镜像源配置已保存到本地')
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`保存本地配置失败: ${errorMsg}`)
+          })
+          return
         }
+
+        // 其他状态码
+        logger.warn(`云端配置请求失败，状态码: ${response.statusCode}`)
+        resolve({ status: 'error' })
+      })
+
+      req.on('error', error => {
+        const errorMsg = error instanceof Error ? error.message : String(error)
+        logger.error(`云端配置请求错误: ${errorMsg}`)
+        resolve({ status: 'error' })
+      })
+
+      req.on('timeout', () => {
+        logger.warn('云端配置请求超时')
+        req.destroy()
+        resolve({ status: 'error' })
+      })
+    })
+  }
+
+  /**
+   * 保存配置到本地（包含 ETag）
+   */
+  private saveLocalConfig(config: CloudMirrorConfig, etag?: string): void {
+    try {
+      const configDir = path.dirname(this.localConfigPath)
+      if (!fs.existsSync(configDir)) {
+        fs.mkdirSync(configDir, { recursive: true })
+      }
+
+      const cache: LocalConfigCache = {
+        config,
+        etag,
+        lastUpdated: new Date().toISOString(),
+      }
+
+      fs.writeFileSync(this.localConfigPath, JSON.stringify(cache, null, 2), 'utf-8')
+      logger.info('镜像源配置已保存到本地')
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`保存本地配置失败: ${errorMsg}`)
     }
+  }
 
-    /**
-     * 加载本地配置（包含 ETag）
-     */
-    private loadLocalConfig(): LocalConfigCache | null {
-        try {
-            if (!fs.existsSync(this.localConfigPath)) {
-                return null
-            }
-            const data = fs.readFileSync(this.localConfigPath, 'utf-8')
-            const parsed = JSON.parse(data)
+  /**
+   * 加载本地配置（包含 ETag）
+   */
+  private loadLocalConfig(): LocalConfigCache | null {
+    try {
+      if (!fs.existsSync(this.localConfigPath)) {
+        return null
+      }
+      const data = fs.readFileSync(this.localConfigPath, 'utf-8')
+      const parsed = JSON.parse(data)
 
-            // 兼容旧格式（直接是 CloudMirrorConfig）
-            if (parsed.mirrors && !parsed.config) {
-                logger.info('检测到旧格式配置，自动转换')
-                return {
-                    config: parsed as CloudMirrorConfig,
-                    lastUpdated: new Date().toISOString()
-                }
-            }
-
-            return parsed as LocalConfigCache
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`加载本地配置失败: ${errorMsg}`)
-            return null
-        }
-    }
-
-    /**
-     * 获取指定类型的镜像源列表
-     */
-    getMirrors(type: keyof MirrorConfig): MirrorSource[] {
-        return this.mirrorConfig[type] || []
-    }
-
-    /**
-     * 获取所有镜像源配置
-     */
-    getAllMirrors(): MirrorConfig {
-        return { ...this.mirrorConfig }
-    }
-
-    /**
-     * 获取 API 端点
-     */
-    getApiEndpoint(key: keyof ApiEndpoints): string {
-        return (this.apiEndpoints[key] || DEFAULT_API_ENDPOINTS[key]).replace('://localhost', '://127.0.0.1')
-    }
-
-    /**
-     * 获取所有 API 端点
-     */
-    getApiEndpoints(): ApiEndpoints {
+      // 兼容旧格式（直接是 CloudMirrorConfig）
+      if (parsed.mirrors && !parsed.config) {
+        logger.info('检测到旧格式配置，自动转换')
         return {
-            local: this.getApiEndpoint('local'),
-            websocket: this.getApiEndpoint('websocket')
+          config: parsed as CloudMirrorConfig,
+          lastUpdated: new Date().toISOString(),
         }
-    }
+      }
 
-    /**
-     * 更新 API 端点（运行时动态更新）
-     */
-    updateApiEndpoints(endpoints: Partial<ApiEndpoints>): void {
-        this.apiEndpoints = { ...this.apiEndpoints, ...endpoints }
-        logger.info(`API 端点已更新: ${JSON.stringify(this.apiEndpoints)}`)
+      return parsed as LocalConfigCache
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`加载本地配置失败: ${errorMsg}`)
+      return null
     }
+  }
+
+  /**
+   * 获取指定类型的镜像源列表
+   */
+  getMirrors(type: keyof MirrorConfig): MirrorSource[] {
+    return this.mirrorConfig[type] || []
+  }
+
+  /**
+   * 获取所有镜像源配置
+   */
+  getAllMirrors(): MirrorConfig {
+    return { ...this.mirrorConfig }
+  }
+
+  /**
+   * 获取 API 端点
+   */
+  getApiEndpoint(key: keyof ApiEndpoints): string {
+    return (this.apiEndpoints[key] || DEFAULT_API_ENDPOINTS[key]).replace(
+      '://localhost',
+      '://127.0.0.1'
+    )
+  }
+
+  /**
+   * 获取所有 API 端点
+   */
+  getApiEndpoints(): ApiEndpoints {
+    return {
+      local: this.getApiEndpoint('local'),
+      websocket: this.getApiEndpoint('websocket'),
+    }
+  }
+
+  /**
+   * 更新 API 端点（运行时动态更新）
+   */
+  updateApiEndpoints(endpoints: Partial<ApiEndpoints>): void {
+    this.apiEndpoints = { ...this.apiEndpoints, ...endpoints }
+    logger.info(`API 端点已更新: ${JSON.stringify(this.apiEndpoints)}`)
+  }
 }

--- a/frontend/electron/services/repositoryService.ts
+++ b/frontend/electron/services/repositoryService.ts
@@ -7,7 +7,11 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { spawn } from 'child_process'
 import { MirrorService, MirrorSource } from './mirrorService'
-import { MirrorRotationService, NetworkOperationCallback, NetworkOperationProgress } from './mirrorRotationService'
+import {
+  MirrorRotationService,
+  NetworkOperationCallback,
+  NetworkOperationProgress,
+} from './mirrorRotationService'
 
 // 导入日志服务
 import { getLogger } from './logger'
@@ -16,22 +20,22 @@ const logger = getLogger('仓库服务')
 // ==================== 类型定义 ====================
 
 export interface RepositoryCheckResult {
-    exists: boolean
-    isGitRepo: boolean
-    isHealthy: boolean
-    currentBranch?: string
+  exists: boolean
+  isGitRepo: boolean
+  isHealthy: boolean
+  currentBranch?: string
 }
 
 export interface RepositoryProgress {
-    stage: 'check' | 'pull' | 'deploy'
-    progress: number
-    message: string
-    details?: {
-        checkInfo?: RepositoryCheckResult
-        currentMirror?: string
-        mirrorProgress?: { current: number; total: number }
-        operationDesc?: string
-    }
+  stage: 'check' | 'pull' | 'deploy'
+  progress: number
+  message: string
+  details?: {
+    checkInfo?: RepositoryCheckResult
+    currentMirror?: string
+    mirrorProgress?: { current: number; total: number }
+    operationDesc?: string
+  }
 }
 
 export type RepositoryProgressCallback = (progress: RepositoryProgress) => void
@@ -39,638 +43,671 @@ export type RepositoryProgressCallback = (progress: RepositoryProgress) => void
 // ==================== 仓库服务类 ====================
 
 export class RepositoryService {
-    private appRoot: string
-    private repoPath: string
-    private gitExe: string
-    private mirrorService: MirrorService
-    private rotationService: MirrorRotationService
-    private targetBranch: string
+  private appRoot: string
+  private repoPath: string
+  private gitExe: string
+  private mirrorService: MirrorService
+  private rotationService: MirrorRotationService
+  private targetBranch: string
 
-    constructor(appRoot: string, mirrorService: MirrorService, targetBranch: string = 'dev') {
-        this.appRoot = appRoot
-        this.repoPath = path.join(appRoot, 'repo')
-        this.gitExe = path.join(appRoot, 'environment', 'git', 'bin', 'git.exe')
-        this.mirrorService = mirrorService
-        this.rotationService = new MirrorRotationService()
-        this.targetBranch = targetBranch
-    }
+  constructor(appRoot: string, mirrorService: MirrorService, targetBranch: string = 'dev') {
+    this.appRoot = appRoot
+    this.repoPath = path.join(appRoot, 'repo')
+    this.gitExe = path.join(appRoot, 'environment', 'git', 'bin', 'git.exe')
+    this.mirrorService = mirrorService
+    this.rotationService = new MirrorRotationService()
+    this.targetBranch = targetBranch
+  }
 
-    /**
-     * 源码拉取方法
-     */
-    async pullRepository(onProgress?: RepositoryProgressCallback, selectedMirror?: string): Promise<{ success: boolean; error?: string }> {
-        try {
-            // 第一步：环境检查
-            onProgress?.({
-                stage: 'check',
-                progress: 0,
-                message: '正在检查本地仓库...',
-                details: {}
-            })
-            const checkResult = await this.checkRepository()
-            logger.info(`仓库检查结果: ${JSON.stringify(checkResult)}`)
+  /**
+   * 源码拉取方法
+   */
+  async pullRepository(
+    onProgress?: RepositoryProgressCallback,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      // 第一步：环境检查
+      onProgress?.({
+        stage: 'check',
+        progress: 0,
+        message: '正在检查本地仓库...',
+        details: {},
+      })
+      const checkResult = await this.checkRepository()
+      logger.info(`仓库检查结果: ${JSON.stringify(checkResult)}`)
 
-            // 上报检查结果
-            onProgress?.({
-                stage: 'check',
-                progress: 100,
-                message: checkResult.exists ? '本地仓库已存在' : '本地仓库不存在',
-                details: {
-                    checkInfo: checkResult
-                }
-            })
+      // 上报检查结果
+      onProgress?.({
+        stage: 'check',
+        progress: 100,
+        message: checkResult.exists ? '本地仓库已存在' : '本地仓库不存在',
+        details: {
+          checkInfo: checkResult,
+        },
+      })
 
-            // 第二步：拉取仓库
-            onProgress?.({
-                stage: 'pull',
-                progress: 0,
-                message: '正在拉取仓库...',
-                details: {}
-            })
-            const pullResult = await this.pullOrCloneRepository(checkResult, (opProgress, mirrorName, mirrorIndex, totalMirrors) => {
-                onProgress?.({
-                    stage: 'pull',
-                    progress: opProgress.progress,
-                    message: opProgress.description,
-                    details: {
-                        currentMirror: mirrorName,
-                        mirrorProgress: { current: mirrorIndex + 1, total: totalMirrors },
-                        operationDesc: opProgress.description
-                    }
-                })
-            }, selectedMirror)
+      // 第二步：拉取仓库
+      onProgress?.({
+        stage: 'pull',
+        progress: 0,
+        message: '正在拉取仓库...',
+        details: {},
+      })
+      const pullResult = await this.pullOrCloneRepository(
+        checkResult,
+        (opProgress, mirrorName, mirrorIndex, totalMirrors) => {
+          onProgress?.({
+            stage: 'pull',
+            progress: opProgress.progress,
+            message: opProgress.description,
+            details: {
+              currentMirror: mirrorName,
+              mirrorProgress: { current: mirrorIndex + 1, total: totalMirrors },
+              operationDesc: opProgress.description,
+            },
+          })
+        },
+        selectedMirror
+      )
 
-            if (!pullResult.success) {
-                return { success: false, error: pullResult.error }
-            }
+      if (!pullResult.success) {
+        return { success: false, error: pullResult.error }
+      }
 
-            // 第三步：部署仓库
-            onProgress?.({
-                stage: 'deploy',
-                progress: 0,
-                message: '正在部署仓库...',
-                details: {}
-            })
-            const deployResult = await this.deployRepository((progress, message) => {
-                onProgress?.({
-                    stage: 'deploy',
-                    progress,
-                    message,
-                    details: {}
-                })
-            })
-
-            if (deployResult.success) {
-                onProgress?.({
-                    stage: 'deploy',
-                    progress: 100,
-                    message: '部署完成',
-                    details: {}
-                })
-            }
-
-            return deployResult
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`源码拉取失败: ${errorMsg}`)
-            return { success: false, error: errorMsg }
-        }
-    }
-
-    /**
-     * 检查本地仓库状态
-     */
-    private async checkRepository(): Promise<RepositoryCheckResult> {
-        logger.info('=== 检查本地仓库 ===')
-
-        // 检查 repo 文件夹是否存在
-        if (!fs.existsSync(this.repoPath)) {
-            logger.info('repo 文件夹不存在')
-            return { exists: false, isGitRepo: false, isHealthy: false }
-        }
-
-        // 检查是否为 Git 仓库
-        const gitDir = path.join(this.repoPath, '.git')
-        if (!fs.existsSync(gitDir)) {
-            logger.info('repo 文件夹存在但不是 Git 仓库')
-            // 清理无效的 repo 文件夹
-            fs.rmSync(this.repoPath, { recursive: true, force: true })
-            return { exists: false, isGitRepo: false, isHealthy: false }
-        }
-
-        // 检查 Git 仓库健康状态
-        try {
-            const isHealthy = await this.checkGitHealth()
-            const currentBranch = await this.getCurrentBranch()
-
-            if (isHealthy) {
-                logger.info(`本地仓库健康，当前分支: ${currentBranch}`)
-                return { exists: true, isGitRepo: true, isHealthy: true, currentBranch }
-            } else {
-                logger.warn('本地仓库存在问题，需要清理')
-                // 清理有问题的仓库
-                fs.rmSync(this.repoPath, { recursive: true, force: true })
-                return { exists: false, isGitRepo: false, isHealthy: false }
-            }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`检查仓库健康状态失败: ${errorMsg}`)
-            // 清理有问题的仓库
-            fs.rmSync(this.repoPath, { recursive: true, force: true })
-            return { exists: false, isGitRepo: false, isHealthy: false }
-        }
-    }
-
-    /**
-     * 检查 Git 仓库健康状态
-     */
-    private checkGitHealth(): Promise<boolean> {
-        return new Promise((resolve) => {
-            const proc = spawn(this.gitExe, ['status'], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            proc.on('close', (code) => {
-                resolve(code === 0)
-            })
-
-            proc.on('error', () => {
-                resolve(false)
-            })
+      // 第三步：部署仓库
+      onProgress?.({
+        stage: 'deploy',
+        progress: 0,
+        message: '正在部署仓库...',
+        details: {},
+      })
+      const deployResult = await this.deployRepository((progress, message) => {
+        onProgress?.({
+          stage: 'deploy',
+          progress,
+          message,
+          details: {},
         })
-    }
+      })
 
-    /**
-     * 获取当前分支
-     */
-    private getCurrentBranch(): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const proc = spawn(this.gitExe, ['branch', '--show-current'], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            let output = ''
-            proc.stdout?.on('data', (data) => {
-                output += data.toString()
-            })
-
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    resolve(output.trim() || 'unknown')
-                } else {
-                    reject(new Error('获取当前分支失败'))
-                }
-            })
-
-            proc.on('error', reject)
+      if (deployResult.success) {
+        onProgress?.({
+          stage: 'deploy',
+          progress: 100,
+          message: '部署完成',
+          details: {},
         })
+      }
+
+      return deployResult
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`源码拉取失败: ${errorMsg}`)
+      return { success: false, error: errorMsg }
+    }
+  }
+
+  /**
+   * 检查本地仓库状态
+   */
+  private async checkRepository(): Promise<RepositoryCheckResult> {
+    logger.info('=== 检查本地仓库 ===')
+
+    // 检查 repo 文件夹是否存在
+    if (!fs.existsSync(this.repoPath)) {
+      logger.info('repo 文件夹不存在')
+      return { exists: false, isGitRepo: false, isHealthy: false }
     }
 
-    /**
-     * 拉取或克隆仓库
-     */
-    private async pullOrCloneRepository(
-        checkResult: RepositoryCheckResult,
-        onProgress?: (progress: NetworkOperationProgress, mirrorName: string, mirrorIndex: number, totalMirrors: number) => void,
-        selectedMirror?: string
-    ): Promise<{ success: boolean; error?: string }> {
-        const mirrors = this.mirrorService.getMirrors('repo')
+    // 检查是否为 Git 仓库
+    const gitDir = path.join(this.repoPath, '.git')
+    if (!fs.existsSync(gitDir)) {
+      logger.info('repo 文件夹存在但不是 Git 仓库')
+      // 清理无效的 repo 文件夹
+      fs.rmSync(this.repoPath, { recursive: true, force: true })
+      return { exists: false, isGitRepo: false, isHealthy: false }
+    }
 
-        // 定义仓库拉取操作
-        const repoOperation: NetworkOperationCallback = async (mirror, onOpProgress) => {
-            if (checkResult.exists && checkResult.isGitRepo && checkResult.isHealthy) {
-                // 本地仓库已存在，执行更新
-                return await this.updateExistingRepository(mirror, onOpProgress)
-            } else {
-                // 本地仓库不存在，执行克隆
-                return await this.cloneNewRepository(mirror, onOpProgress)
-            }
+    // 检查 Git 仓库健康状态
+    try {
+      const isHealthy = await this.checkGitHealth()
+      const currentBranch = await this.getCurrentBranch()
+
+      if (isHealthy) {
+        logger.info(`本地仓库健康，当前分支: ${currentBranch}`)
+        return { exists: true, isGitRepo: true, isHealthy: true, currentBranch }
+      } else {
+        logger.warn('本地仓库存在问题，需要清理')
+        // 清理有问题的仓库
+        fs.rmSync(this.repoPath, { recursive: true, force: true })
+        return { exists: false, isGitRepo: false, isHealthy: false }
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`检查仓库健康状态失败: ${errorMsg}`)
+      // 清理有问题的仓库
+      fs.rmSync(this.repoPath, { recursive: true, force: true })
+      return { exists: false, isGitRepo: false, isHealthy: false }
+    }
+  }
+
+  /**
+   * 检查 Git 仓库健康状态
+   */
+  private checkGitHealth(): Promise<boolean> {
+    return new Promise(resolve => {
+      const proc = spawn(this.gitExe, ['status'], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+
+      proc.on('close', code => {
+        resolve(code === 0)
+      })
+
+      proc.on('error', () => {
+        resolve(false)
+      })
+    })
+  }
+
+  /**
+   * 获取当前分支
+   */
+  private getCurrentBranch(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(this.gitExe, ['branch', '--show-current'], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+
+      let output = ''
+      proc.stdout?.on('data', data => {
+        output += data.toString()
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          resolve(output.trim() || 'unknown')
+        } else {
+          reject(new Error('获取当前分支失败'))
+        }
+      })
+
+      proc.on('error', reject)
+    })
+  }
+
+  /**
+   * 拉取或克隆仓库
+   */
+  private async pullOrCloneRepository(
+    checkResult: RepositoryCheckResult,
+    onProgress?: (
+      progress: NetworkOperationProgress,
+      mirrorName: string,
+      mirrorIndex: number,
+      totalMirrors: number
+    ) => void,
+    selectedMirror?: string
+  ): Promise<{ success: boolean; error?: string }> {
+    const mirrors = this.mirrorService.getMirrors('repo')
+
+    // 定义仓库拉取操作
+    const repoOperation: NetworkOperationCallback = async (mirror, onOpProgress) => {
+      if (checkResult.exists && checkResult.isGitRepo && checkResult.isHealthy) {
+        // 本地仓库已存在，执行更新
+        return await this.updateExistingRepository(mirror, onOpProgress)
+      } else {
+        // 本地仓库不存在，执行克隆
+        return await this.cloneNewRepository(mirror, onOpProgress)
+      }
+    }
+
+    // 使用镜像源轮替
+    const result = await this.rotationService.execute(
+      mirrors,
+      repoOperation,
+      rotationProgress => {
+        onProgress?.(
+          rotationProgress.operationProgress,
+          rotationProgress.currentMirror.name,
+          rotationProgress.mirrorIndex,
+          rotationProgress.totalMirrors
+        )
+      },
+      selectedMirror
+    )
+
+    if (!result.success) {
+      return { success: false, error: result.error }
+    }
+
+    logger.info(`仓库拉取完成，使用镜像源: ${result.usedMirror?.name}`)
+    return { success: true }
+  }
+
+  /**
+   * 更新现有仓库
+   */
+  private async updateExistingRepository(
+    mirror: MirrorSource,
+    onProgress: (progress: NetworkOperationProgress) => void
+  ): Promise<{ success: boolean; error?: string }> {
+    logger.info('=== 更新现有仓库 ===')
+
+    try {
+      // 1. 确认目标分支是否存在
+      onProgress({ progress: 10, description: '检查目标分支...' })
+      const branchExists = await this.checkRemoteBranch(mirror.url, this.targetBranch)
+
+      if (!branchExists) {
+        return { success: false, error: `目标分支 ${this.targetBranch} 不存在` }
+      }
+
+      // 2. 配置远程仓库 URL
+      onProgress({ progress: 30, description: '配置远程仓库...' })
+      await this.configureRemote(mirror.url)
+
+      // 3. 配置浅克隆
+      onProgress({ progress: 50, description: '配置浅克隆...' })
+      await this.configureShallowClone()
+
+      // 4. 拉取最新提交
+      onProgress({ progress: 70, description: '拉取最新代码...' })
+      await this.fetchLatestCommit()
+
+      // 5. 切换到目标分支
+      onProgress({ progress: 90, description: '切换分支...' })
+      await this.checkoutBranch()
+
+      onProgress({ progress: 100, description: '拉取完成' })
+      return { success: true }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`更新仓库失败: ${errorMsg}`)
+      return { success: false, error: errorMsg }
+    }
+  }
+
+  /**
+   * 克隆新仓库
+   */
+  private async cloneNewRepository(
+    mirror: MirrorSource,
+    onProgress: (progress: NetworkOperationProgress) => void
+  ): Promise<{ success: boolean; error?: string }> {
+    logger.info('=== 克隆新仓库 ===')
+
+    try {
+      // 1. 确认目标分支是否存在
+      onProgress({ progress: 10, description: '检查目标分支...' })
+      const branchExists = await this.checkRemoteBranch(mirror.url, this.targetBranch)
+
+      if (!branchExists) {
+        return { success: false, error: `目标分支 ${this.targetBranch} 不存在` }
+      }
+
+      // 2. 克隆指定分支的最新提交
+      onProgress({ progress: 30, description: '克隆仓库...' })
+      await this.cloneRepository(mirror.url)
+
+      onProgress({ progress: 100, description: '克隆完成' })
+      return { success: true }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`克隆仓库失败: ${errorMsg}`)
+      return { success: false, error: errorMsg }
+    }
+  }
+
+  /**
+   * 检查远程分支是否存在
+   */
+  private checkRemoteBranch(repoUrl: string, branch: string): Promise<boolean> {
+    return new Promise(resolve => {
+      const proc = spawn(this.gitExe, ['ls-remote', '--heads', repoUrl, branch], {
+        stdio: 'pipe',
+      })
+
+      // 设置 30 秒超时
+      const timeout = setTimeout(() => {
+        logger.warn('检查远程分支超时，终止进程')
+        proc.kill()
+        resolve(false)
+      }, 30000)
+
+      let output = ''
+      proc.stdout?.on('data', data => {
+        output += data.toString()
+      })
+
+      proc.on('close', code => {
+        clearTimeout(timeout)
+        if (code === 0) {
+          const exists = output.includes(`refs/heads/${branch}`)
+          resolve(exists)
+        } else {
+          resolve(false)
+        }
+      })
+
+      proc.on('error', () => {
+        clearTimeout(timeout)
+        resolve(false)
+      })
+    })
+  }
+
+  /**
+   * 配置远程仓库
+   */
+  private configureRemote(repoUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(this.gitExe, ['remote', 'set-url', 'origin', repoUrl], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          logger.info('远程仓库配置完成')
+          resolve()
+        } else {
+          reject(new Error('配置远程仓库失败'))
+        }
+      })
+
+      proc.on('error', reject)
+    })
+  }
+
+  /**
+   * 配置浅克隆
+   */
+  private async configureShallowClone(): Promise<void> {
+    // 清除现有的 fetch 配置
+    await new Promise<void>(resolve => {
+      const proc = spawn(this.gitExe, ['config', '--unset-all', 'remote.origin.fetch'], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+      proc.on('close', () => resolve())
+      proc.on('error', () => resolve())
+    })
+
+    // 设置只拉取目标分支
+    await new Promise<void>((resolve, reject) => {
+      const refspec = `+refs/heads/${this.targetBranch}:refs/remotes/origin/${this.targetBranch}`
+      const proc = spawn(this.gitExe, ['config', '--add', 'remote.origin.fetch', refspec], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          logger.info('浅克隆配置完成')
+          resolve()
+        } else {
+          reject(new Error('配置浅克隆失败'))
+        }
+      })
+
+      proc.on('error', reject)
+    })
+  }
+
+  /**
+   * 拉取最新提交
+   */
+  private fetchLatestCommit(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(
+        this.gitExe,
+        ['fetch', 'origin', this.targetBranch, '--depth=1', '--no-tags'],
+        {
+          cwd: this.repoPath,
+          stdio: 'pipe',
+        }
+      )
+
+      // 设置 60 秒超时（fetch 可能需要更长时间）
+      const timeout = setTimeout(() => {
+        logger.warn('拉取最新提交超时，终止进程')
+        proc.kill()
+        reject(new Error('拉取最新提交超时'))
+      }, 60000)
+
+      proc.stdout?.on('data', data => {
+        logger.info(`fetch: ${data.toString().trim()}`)
+      })
+
+      proc.on('close', code => {
+        clearTimeout(timeout)
+        if (code === 0) {
+          logger.info('拉取最新提交完成')
+          resolve()
+        } else {
+          reject(new Error('拉取最新提交失败'))
+        }
+      })
+
+      proc.on('error', error => {
+        clearTimeout(timeout)
+        reject(error)
+      })
+    })
+  }
+
+  /**
+   * 切换分支
+   */
+  private checkoutBranch(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(
+        this.gitExe,
+        ['checkout', '-B', this.targetBranch, `origin/${this.targetBranch}`],
+        {
+          cwd: this.repoPath,
+          stdio: 'pipe',
+        }
+      )
+
+      proc.on('close', code => {
+        if (code === 0) {
+          logger.info('切换分支完成')
+          resolve()
+        } else {
+          reject(new Error('切换分支失败'))
+        }
+      })
+
+      proc.on('error', reject)
+    })
+  }
+
+  /**
+   * 克隆仓库
+   */
+  private cloneRepository(repoUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // 确保 repo 目录不存在
+      if (fs.existsSync(this.repoPath)) {
+        fs.rmSync(this.repoPath, { recursive: true, force: true })
+      }
+
+      const proc = spawn(
+        this.gitExe,
+        [
+          'clone',
+          '--single-branch',
+          '--depth=1',
+          '--branch',
+          this.targetBranch,
+          repoUrl,
+          this.repoPath,
+        ],
+        {
+          stdio: 'pipe',
+        }
+      )
+
+      // 设置 120 秒超时（clone 可能需要较长时间）
+      const timeout = setTimeout(() => {
+        logger.warn('克隆仓库超时，终止进程')
+        proc.kill()
+        reject(new Error('克隆仓库超时'))
+      }, 120000)
+
+      proc.stdout?.on('data', data => {
+        logger.info(`clone: ${data.toString().trim()}`)
+      })
+
+      proc.on('close', code => {
+        clearTimeout(timeout)
+        if (code === 0) {
+          logger.info('克隆仓库完成')
+          resolve()
+        } else {
+          reject(new Error('克隆仓库失败'))
+        }
+      })
+
+      proc.on('error', error => {
+        clearTimeout(timeout)
+        reject(error)
+      })
+    })
+  }
+
+  /**
+   * 部署仓库
+   */
+  private async deployRepository(
+    onProgress?: (progress: number, message: string) => void
+  ): Promise<{ success: boolean; error?: string }> {
+    logger.info('=== 部署仓库 ===')
+
+    try {
+      // 1. 优化仓库存储
+      onProgress?.(30, '优化仓库存储...')
+      logger.info('优化仓库存储...')
+      await this.optimizeStorage()
+
+      // 2. 复制到根目录
+      onProgress?.(60, '复制文件到根目录...')
+      logger.info('复制文件到根目录...')
+      await this.copyToRoot()
+
+      onProgress?.(100, '部署完成')
+      logger.info('仓库部署完成')
+      return { success: true }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`部署仓库失败: ${errorMsg}`)
+      return { success: false, error: errorMsg }
+    }
+  }
+
+  /**
+   * 优化仓库存储
+   */
+  private async optimizeStorage(): Promise<void> {
+    // 删除 reflog
+    await new Promise<void>(resolve => {
+      const proc = spawn(this.gitExe, ['reflog', 'expire', '--expire=now', '--all'], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+      proc.on('close', () => {
+        logger.info('reflog 清理完成')
+        resolve()
+      })
+      proc.on('error', () => resolve())
+    })
+
+    // 垃圾回收
+    await new Promise<void>(resolve => {
+      const proc = spawn(this.gitExe, ['gc', '--aggressive', '--prune=now'], {
+        cwd: this.repoPath,
+        stdio: 'pipe',
+      })
+      proc.on('close', () => {
+        logger.info('垃圾回收完成')
+        resolve()
+      })
+      proc.on('error', () => resolve())
+    })
+  }
+
+  /**
+   * 复制文件到根目录
+   */
+  private async copyToRoot(): Promise<void> {
+    const itemsToCopy = [
+      '.git',
+      'app',
+      'res',
+      'main.py',
+      'requirements.txt',
+      'LICENSE',
+      'README.md',
+    ]
+
+    for (const item of itemsToCopy) {
+      const srcPath = path.join(this.repoPath, item)
+      const dstPath = path.join(this.appRoot, item)
+
+      if (!fs.existsSync(srcPath)) {
+        logger.warn(`源文件不存在，跳过: ${item}`)
+        continue
+      }
+
+      try {
+        // 删除目标文件/目录
+        if (fs.existsSync(dstPath)) {
+          if (fs.statSync(dstPath).isDirectory()) {
+            fs.rmSync(dstPath, { recursive: true, force: true })
+          } else {
+            fs.unlinkSync(dstPath)
+          }
         }
 
-        // 使用镜像源轮替
-        const result = await this.rotationService.execute(mirrors, repoOperation, (rotationProgress) => {
-            onProgress?.(
-                rotationProgress.operationProgress,
-                rotationProgress.currentMirror.name,
-                rotationProgress.mirrorIndex,
-                rotationProgress.totalMirrors
-            )
-        }, selectedMirror)
-
-        if (!result.success) {
-            return { success: false, error: result.error }
+        // 复制文件/目录
+        if (fs.statSync(srcPath).isDirectory()) {
+          this.copyDirectory(srcPath, dstPath)
+        } else {
+          fs.copyFileSync(srcPath, dstPath)
         }
 
-        logger.info(`仓库拉取完成，使用镜像源: ${result.usedMirror?.name}`)
-        return { success: true }
+        logger.info(`复制完成: ${item}`)
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error)
+        logger.error(`复制失败: ${item}, 错误信息: ${errorMsg}`)
+        throw error
+      }
+    }
+  }
+
+  /**
+   * 递归复制目录
+   */
+  private copyDirectory(src: string, dest: string): void {
+    if (!fs.existsSync(dest)) {
+      fs.mkdirSync(dest, { recursive: true })
     }
 
-    /**
-     * 更新现有仓库
-     */
-    private async updateExistingRepository(
-        mirror: MirrorSource,
-        onProgress: (progress: NetworkOperationProgress) => void
-    ): Promise<{ success: boolean; error?: string }> {
-        logger.info('=== 更新现有仓库 ===')
+    const entries = fs.readdirSync(src, { withFileTypes: true })
+    for (const entry of entries) {
+      const srcPath = path.join(src, entry.name)
+      const destPath = path.join(dest, entry.name)
 
-        try {
-            // 1. 确认目标分支是否存在
-            onProgress({ progress: 10, description: '检查目标分支...' })
-            const branchExists = await this.checkRemoteBranch(mirror.url, this.targetBranch)
-
-            if (!branchExists) {
-                return { success: false, error: `目标分支 ${this.targetBranch} 不存在` }
-            }
-
-            // 2. 配置远程仓库 URL
-            onProgress({ progress: 30, description: '配置远程仓库...' })
-            await this.configureRemote(mirror.url)
-
-            // 3. 配置浅克隆
-            onProgress({ progress: 50, description: '配置浅克隆...' })
-            await this.configureShallowClone()
-
-            // 4. 拉取最新提交
-            onProgress({ progress: 70, description: '拉取最新代码...' })
-            await this.fetchLatestCommit()
-
-            // 5. 切换到目标分支
-            onProgress({ progress: 90, description: '切换分支...' })
-            await this.checkoutBranch()
-
-            onProgress({ progress: 100, description: '拉取完成' })
-            return { success: true }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`更新仓库失败: ${errorMsg}`)
-            return { success: false, error: errorMsg }
-        }
+      if (entry.isDirectory()) {
+        this.copyDirectory(srcPath, destPath)
+      } else {
+        fs.copyFileSync(srcPath, destPath)
+      }
     }
-
-    /**
-     * 克隆新仓库
-     */
-    private async cloneNewRepository(
-        mirror: MirrorSource,
-        onProgress: (progress: NetworkOperationProgress) => void
-    ): Promise<{ success: boolean; error?: string }> {
-        logger.info('=== 克隆新仓库 ===')
-
-        try {
-            // 1. 确认目标分支是否存在
-            onProgress({ progress: 10, description: '检查目标分支...' })
-            const branchExists = await this.checkRemoteBranch(mirror.url, this.targetBranch)
-
-            if (!branchExists) {
-                return { success: false, error: `目标分支 ${this.targetBranch} 不存在` }
-            }
-
-            // 2. 克隆指定分支的最新提交
-            onProgress({ progress: 30, description: '克隆仓库...' })
-            await this.cloneRepository(mirror.url)
-
-            onProgress({ progress: 100, description: '克隆完成' })
-            return { success: true }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`克隆仓库失败: ${errorMsg}`)
-            return { success: false, error: errorMsg }
-        }
-    }
-
-    /**
-     * 检查远程分支是否存在
-     */
-    private checkRemoteBranch(repoUrl: string, branch: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            const proc = spawn(this.gitExe, ['ls-remote', '--heads', repoUrl, branch], {
-                stdio: 'pipe'
-            })
-
-            // 设置 30 秒超时
-            const timeout = setTimeout(() => {
-                logger.warn('检查远程分支超时，终止进程')
-                proc.kill()
-                resolve(false)
-            }, 30000)
-
-            let output = ''
-            proc.stdout?.on('data', (data) => {
-                output += data.toString()
-            })
-
-            proc.on('close', (code) => {
-                clearTimeout(timeout)
-                if (code === 0) {
-                    const exists = output.includes(`refs/heads/${branch}`)
-                    resolve(exists)
-                } else {
-                    resolve(false)
-                }
-            })
-
-            proc.on('error', () => {
-                clearTimeout(timeout)
-                resolve(false)
-            })
-        })
-    }
-
-    /**
-     * 配置远程仓库
-     */
-    private configureRemote(repoUrl: string): Promise<void> {
-        return new Promise((resolve, reject) => {
-            const proc = spawn(this.gitExe, ['remote', 'set-url', 'origin', repoUrl], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    logger.info('远程仓库配置完成')
-                    resolve()
-                } else {
-                    reject(new Error('配置远程仓库失败'))
-                }
-            })
-
-            proc.on('error', reject)
-        })
-    }
-
-    /**
-     * 配置浅克隆
-     */
-    private async configureShallowClone(): Promise<void> {
-        // 清除现有的 fetch 配置
-        await new Promise<void>((resolve) => {
-            const proc = spawn(this.gitExe, ['config', '--unset-all', 'remote.origin.fetch'], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-            proc.on('close', () => resolve())
-            proc.on('error', () => resolve())
-        })
-
-        // 设置只拉取目标分支
-        await new Promise<void>((resolve, reject) => {
-            const refspec = `+refs/heads/${this.targetBranch}:refs/remotes/origin/${this.targetBranch}`
-            const proc = spawn(this.gitExe, ['config', '--add', 'remote.origin.fetch', refspec], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    logger.info('浅克隆配置完成')
-                    resolve()
-                } else {
-                    reject(new Error('配置浅克隆失败'))
-                }
-            })
-
-            proc.on('error', reject)
-        })
-    }
-
-    /**
-     * 拉取最新提交
-     */
-    private fetchLatestCommit(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            const proc = spawn(this.gitExe, [
-                'fetch',
-                'origin',
-                this.targetBranch,
-                '--depth=1',
-                '--no-tags'
-            ], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            // 设置 60 秒超时（fetch 可能需要更长时间）
-            const timeout = setTimeout(() => {
-                logger.warn('拉取最新提交超时，终止进程')
-                proc.kill()
-                reject(new Error('拉取最新提交超时'))
-            }, 60000)
-
-            proc.stdout?.on('data', (data) => {
-                logger.info(`fetch: ${data.toString().trim()}`)
-            })
-
-            proc.on('close', (code) => {
-                clearTimeout(timeout)
-                if (code === 0) {
-                    logger.info('拉取最新提交完成')
-                    resolve()
-                } else {
-                    reject(new Error('拉取最新提交失败'))
-                }
-            })
-
-            proc.on('error', (error) => {
-                clearTimeout(timeout)
-                reject(error)
-            })
-        })
-    }
-
-    /**
-     * 切换分支
-     */
-    private checkoutBranch(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            const proc = spawn(this.gitExe, ['checkout', '-B', this.targetBranch, `origin/${this.targetBranch}`], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-
-            proc.on('close', (code) => {
-                if (code === 0) {
-                    logger.info('切换分支完成')
-                    resolve()
-                } else {
-                    reject(new Error('切换分支失败'))
-                }
-            })
-
-            proc.on('error', reject)
-        })
-    }
-
-    /**
-     * 克隆仓库
-     */
-    private cloneRepository(repoUrl: string): Promise<void> {
-        return new Promise((resolve, reject) => {
-            // 确保 repo 目录不存在
-            if (fs.existsSync(this.repoPath)) {
-                fs.rmSync(this.repoPath, { recursive: true, force: true })
-            }
-
-            const proc = spawn(this.gitExe, [
-                'clone',
-                '--single-branch',
-                '--depth=1',
-                '--branch',
-                this.targetBranch,
-                repoUrl,
-                this.repoPath
-            ], {
-                stdio: 'pipe'
-            })
-
-            // 设置 120 秒超时（clone 可能需要较长时间）
-            const timeout = setTimeout(() => {
-                logger.warn('克隆仓库超时，终止进程')
-                proc.kill()
-                reject(new Error('克隆仓库超时'))
-            }, 120000)
-
-            proc.stdout?.on('data', (data) => {
-                logger.info(`clone: ${data.toString().trim()}`)
-            })
-
-            proc.on('close', (code) => {
-                clearTimeout(timeout)
-                if (code === 0) {
-                    logger.info('克隆仓库完成')
-                    resolve()
-                } else {
-                    reject(new Error('克隆仓库失败'))
-                }
-            })
-
-            proc.on('error', (error) => {
-                clearTimeout(timeout)
-                reject(error)
-            })
-        })
-    }
-
-    /**
-     * 部署仓库
-     */
-    private async deployRepository(onProgress?: (progress: number, message: string) => void): Promise<{ success: boolean; error?: string }> {
-        logger.info('=== 部署仓库 ===')
-
-        try {
-            // 1. 优化仓库存储
-            onProgress?.(30, '优化仓库存储...')
-            logger.info('优化仓库存储...')
-            await this.optimizeStorage()
-
-            // 2. 复制到根目录
-            onProgress?.(60, '复制文件到根目录...')
-            logger.info('复制文件到根目录...')
-            await this.copyToRoot()
-
-            onProgress?.(100, '部署完成')
-            logger.info('仓库部署完成')
-            return { success: true }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`部署仓库失败: ${errorMsg}`)
-            return { success: false, error: errorMsg }
-        }
-    }
-
-    /**
-     * 优化仓库存储
-     */
-    private async optimizeStorage(): Promise<void> {
-        // 删除 reflog
-        await new Promise<void>((resolve) => {
-            const proc = spawn(this.gitExe, ['reflog', 'expire', '--expire=now', '--all'], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-            proc.on('close', () => {
-                logger.info('reflog 清理完成')
-                resolve()
-            })
-            proc.on('error', () => resolve())
-        })
-
-        // 垃圾回收
-        await new Promise<void>((resolve) => {
-            const proc = spawn(this.gitExe, ['gc', '--aggressive', '--prune=now'], {
-                cwd: this.repoPath,
-                stdio: 'pipe'
-            })
-            proc.on('close', () => {
-                logger.info('垃圾回收完成')
-                resolve()
-            })
-            proc.on('error', () => resolve())
-        })
-    }
-
-    /**
-     * 复制文件到根目录
-     */
-    private async copyToRoot(): Promise<void> {
-        const itemsToCopy = ['.git', 'app', 'res', 'main.py', 'requirements.txt', 'LICENSE', 'README.md']
-
-        for (const item of itemsToCopy) {
-            const srcPath = path.join(this.repoPath, item)
-            const dstPath = path.join(this.appRoot, item)
-
-            if (!fs.existsSync(srcPath)) {
-                logger.warn(`源文件不存在，跳过: ${item}`)
-                continue
-            }
-
-            try {
-                // 删除目标文件/目录
-                if (fs.existsSync(dstPath)) {
-                    if (fs.statSync(dstPath).isDirectory()) {
-                        fs.rmSync(dstPath, { recursive: true, force: true })
-                    } else {
-                        fs.unlinkSync(dstPath)
-                    }
-                }
-
-                // 复制文件/目录
-                if (fs.statSync(srcPath).isDirectory()) {
-                    this.copyDirectory(srcPath, dstPath)
-                } else {
-                    fs.copyFileSync(srcPath, dstPath)
-                }
-
-                logger.info(`复制完成: ${item}`)
-            } catch (error) {
-                const errorMsg = error instanceof Error ? error.message : String(error)
-                logger.error(`复制失败: ${item}, 错误信息: ${errorMsg}`)
-                throw error
-            }
-        }
-    }
-
-    /**
-     * 递归复制目录
-     */
-    private copyDirectory(src: string, dest: string): void {
-        if (!fs.existsSync(dest)) {
-            fs.mkdirSync(dest, { recursive: true })
-        }
-
-        const entries = fs.readdirSync(src, { withFileTypes: true })
-        for (const entry of entries) {
-            const srcPath = path.join(src, entry.name)
-            const destPath = path.join(dest, entry.name)
-
-            if (entry.isDirectory()) {
-                this.copyDirectory(srcPath, destPath)
-            } else {
-                fs.copyFileSync(srcPath, destPath)
-            }
-        }
-    }
+  }
 }

--- a/frontend/src/components/ExtraScriptSection.vue
+++ b/frontend/src/components/ExtraScriptSection.vue
@@ -14,15 +14,29 @@
       </template>
       <a-row :gutter="24" align="middle">
         <a-col :span="4">
-          <a-switch v-model:checked="formData.Info.IfScriptBeforeTask" :disabled="loading" size="default"
-            @change="emitSave('Info.IfScriptBeforeTask', formData.Info.IfScriptBeforeTask)" />
+          <a-switch
+            v-model:checked="formData.Info.IfScriptBeforeTask"
+            :disabled="loading"
+            size="default"
+            @change="emitSave('Info.IfScriptBeforeTask', formData.Info.IfScriptBeforeTask)"
+          />
         </a-col>
         <a-col :span="20">
           <a-input-group compact class="path-input-group">
-            <a-input v-model:value="formData.Info.ScriptBeforeTask" placeholder="请选择脚本文件"
-              :disabled="loading || !formData.Info.IfScriptBeforeTask" size="large" class="path-input" readonly />
-            <a-button size="large" :disabled="loading || !formData.Info.IfScriptBeforeTask" class="path-button"
-              @click="selectScriptBeforeTask">
+            <a-input
+              v-model:value="formData.Info.ScriptBeforeTask"
+              placeholder="请选择脚本文件"
+              :disabled="loading || !formData.Info.IfScriptBeforeTask"
+              size="large"
+              class="path-input"
+              readonly
+            />
+            <a-button
+              size="large"
+              :disabled="loading || !formData.Info.IfScriptBeforeTask"
+              class="path-button"
+              @click="selectScriptBeforeTask"
+            >
               <template #icon>
                 <FileOutlined />
               </template>
@@ -43,15 +57,29 @@
       </template>
       <a-row :gutter="24" align="middle">
         <a-col :span="4">
-          <a-switch v-model:checked="formData.Info.IfScriptAfterTask" :disabled="loading" size="default"
-            @change="emitSave('Info.IfScriptAfterTask', formData.Info.IfScriptAfterTask)" />
+          <a-switch
+            v-model:checked="formData.Info.IfScriptAfterTask"
+            :disabled="loading"
+            size="default"
+            @change="emitSave('Info.IfScriptAfterTask', formData.Info.IfScriptAfterTask)"
+          />
         </a-col>
         <a-col :span="20">
           <a-input-group compact class="path-input-group">
-            <a-input v-model:value="formData.Info.ScriptAfterTask" placeholder="请选择脚本文件"
-              :disabled="loading || !formData.Info.IfScriptAfterTask" size="large" class="path-input" readonly />
-            <a-button size="large" :disabled="loading || !formData.Info.IfScriptAfterTask" class="path-button"
-              @click="selectScriptAfterTask">
+            <a-input
+              v-model:value="formData.Info.ScriptAfterTask"
+              placeholder="请选择脚本文件"
+              :disabled="loading || !formData.Info.IfScriptAfterTask"
+              size="large"
+              class="path-input"
+              readonly
+            />
+            <a-button
+              size="large"
+              :disabled="loading || !formData.Info.IfScriptAfterTask"
+              class="path-button"
+              @click="selectScriptAfterTask"
+            >
               <template #icon>
                 <FileOutlined />
               </template>

--- a/frontend/src/components/GlobalPowerCountdown.vue
+++ b/frontend/src/components/GlobalPowerCountdown.vue
@@ -1,7 +1,17 @@
 <template>
   <!-- 电源操作倒计时弹窗 - 使用 Ant Design Vue Modal -->
-  <a-modal v-model:open="visible" :title="null" :footer="null" :closable="false" :keyboard="false"
-    :mask-closable="false" :mask="{ blur: true }" :width="480" centered wrap-class-name="power-countdown-modal">
+  <a-modal
+    v-model:open="visible"
+    :title="null"
+    :footer="null"
+    :closable="false"
+    :keyboard="false"
+    :mask-closable="false"
+    :mask="{ blur: true }"
+    :width="480"
+    centered
+    wrap-class-name="power-countdown-modal"
+  >
     <div class="countdown-content">
       <div class="warning-icon">⚠️</div>
       <h2 class="countdown-title">{{ title }}</h2>
@@ -13,9 +23,14 @@
       <div v-else class="countdown-timer">
         <span class="countdown-text">等待后端倒计时...</span>
       </div>
-      <a-progress v-if="countdown !== undefined" :percent="Math.max(0, Math.min(100, ((60 - countdown) / 60) * 100))"
-        :show-info="false" :stroke-color="(countdown || 0) <= 10 ? '#ff4d4f' : '#1890ff'" :stroke-width="8"
-        class="countdown-progress" />
+      <a-progress
+        v-if="countdown !== undefined"
+        :percent="Math.max(0, Math.min(100, ((60 - countdown) / 60) * 100))"
+        :show-info="false"
+        :stroke-color="(countdown || 0) <= 10 ? '#ff4d4f' : '#1890ff'"
+        :stroke-width="8"
+        class="countdown-progress"
+      />
       <div class="countdown-actions">
         <a-button type="primary" size="large" class="cancel-button" @click="handleCancel">
           取消操作
@@ -242,7 +257,6 @@ onUnmounted(() => {
 
 /* 动画效果 */
 @keyframes pulse {
-
   0%,
   100% {
     transform: scale(1);

--- a/frontend/src/components/LogHighlightSettings.vue
+++ b/frontend/src/components/LogHighlightSettings.vue
@@ -7,17 +7,17 @@ import { message } from 'ant-design-vue'
 
 const { isDark } = useTheme()
 const {
-    lightColors,
-    darkColors,
-    styles,
-    editorConfig,
-    defaultLightColors,
-    defaultDarkColors,
-    setLightColors,
-    setDarkColors,
-    setStyles,
-    setEditorConfig,
-    resetToDefaults,
+  lightColors,
+  darkColors,
+  styles,
+  editorConfig,
+  defaultLightColors,
+  defaultDarkColors,
+  setLightColors,
+  setDarkColors,
+  setStyles,
+  setEditorConfig,
+  resetToDefaults,
 } = useLogHighlight()
 
 // 当前编辑的主题
@@ -25,104 +25,104 @@ const editingTheme = ref<'light' | 'dark'>(isDark.value ? 'dark' : 'light')
 
 // 当前编辑的颜色
 const currentColors = computed(() =>
-    editingTheme.value === 'light' ? lightColors.value : darkColors.value
+  editingTheme.value === 'light' ? lightColors.value : darkColors.value
 )
 
 // 颜色配置项分组
 const colorGroups: {
-    title: string
-    items: { key: keyof LogHighlightColors; label: string; description: string }[]
+  title: string
+  items: { key: keyof LogHighlightColors; label: string; description: string }[]
 }[] = [
-        {
-            title: '时间相关',
-            items: [
-                { key: 'timestamp', label: '时间戳', description: '完整的日期时间格式' },
-                { key: 'date', label: '日期', description: '单独的日期格式' },
-            ]
-        },
-        {
-            title: '日志级别',
-            items: [
-                { key: 'error', label: '错误', description: 'ERROR/FATAL/CRITICAL 级别' },
-                { key: 'warning', label: '警告', description: 'WARN/WARNING 级别' },
-                { key: 'info', label: '信息', description: 'INFO/NOTICE 级别' },
-                { key: 'debug', label: '调试', description: 'DEBUG 级别' },
-                { key: 'trace', label: '追踪', description: 'TRACE/VERBOSE 级别' },
-            ]
-        },
-        {
-            title: '结构元素',
-            items: [
-                { key: 'module', label: '模块名', description: '方括号内的模块/线程名' },
-                { key: 'bracket', label: '括号内容', description: '圆括号内的内容' },
-            ]
-        },
-        {
-            title: '网络相关',
-            items: [
-                { key: 'ip', label: 'IP 地址', description: 'IPv4 地址' },
-                { key: 'url', label: 'URL', description: 'HTTP/HTTPS 链接' },
-                { key: 'port', label: '端口', description: '端口号' },
-            ]
-        },
-        {
-            title: '文件系统',
-            items: [
-                { key: 'path', label: '文件路径', description: '完整的文件路径' },
-                { key: 'filename', label: '文件名', description: '带扩展名的文件名' },
-            ]
-        },
-        {
-            title: '数据类型',
-            items: [
-                { key: 'number', label: '数字', description: '整数、小数、科学计数法' },
-                { key: 'string', label: '字符串', description: '引号包裹的字符串' },
-                { key: 'boolean', label: '布尔值', description: 'true/false/null' },
-                { key: 'uuid', label: 'UUID', description: 'UUID 格式的标识符' },
-            ]
-        },
-        {
-            title: '关键词',
-            items: [
-                { key: 'errorKeyword', label: '错误关键词', description: 'Exception/Error/Failed 等' },
-                { key: 'success', label: '成功关键词', description: 'Success/Complete/Done 等' },
-            ]
-        },
-        {
-            title: '特殊内容',
-            items: [
-                { key: 'stackTrace', label: '堆栈跟踪', description: 'Java/Python 堆栈信息' },
-                { key: 'json', label: 'JSON', description: 'JSON 对象/数组' },
-                { key: 'variable', label: '变量', description: 'key=value 格式的变量名' },
-                { key: 'operator', label: '操作符', description: '= < > ! 等操作符' },
-            ]
-        },
-    ]
+  {
+    title: '时间相关',
+    items: [
+      { key: 'timestamp', label: '时间戳', description: '完整的日期时间格式' },
+      { key: 'date', label: '日期', description: '单独的日期格式' },
+    ],
+  },
+  {
+    title: '日志级别',
+    items: [
+      { key: 'error', label: '错误', description: 'ERROR/FATAL/CRITICAL 级别' },
+      { key: 'warning', label: '警告', description: 'WARN/WARNING 级别' },
+      { key: 'info', label: '信息', description: 'INFO/NOTICE 级别' },
+      { key: 'debug', label: '调试', description: 'DEBUG 级别' },
+      { key: 'trace', label: '追踪', description: 'TRACE/VERBOSE 级别' },
+    ],
+  },
+  {
+    title: '结构元素',
+    items: [
+      { key: 'module', label: '模块名', description: '方括号内的模块/线程名' },
+      { key: 'bracket', label: '括号内容', description: '圆括号内的内容' },
+    ],
+  },
+  {
+    title: '网络相关',
+    items: [
+      { key: 'ip', label: 'IP 地址', description: 'IPv4 地址' },
+      { key: 'url', label: 'URL', description: 'HTTP/HTTPS 链接' },
+      { key: 'port', label: '端口', description: '端口号' },
+    ],
+  },
+  {
+    title: '文件系统',
+    items: [
+      { key: 'path', label: '文件路径', description: '完整的文件路径' },
+      { key: 'filename', label: '文件名', description: '带扩展名的文件名' },
+    ],
+  },
+  {
+    title: '数据类型',
+    items: [
+      { key: 'number', label: '数字', description: '整数、小数、科学计数法' },
+      { key: 'string', label: '字符串', description: '引号包裹的字符串' },
+      { key: 'boolean', label: '布尔值', description: 'true/false/null' },
+      { key: 'uuid', label: 'UUID', description: 'UUID 格式的标识符' },
+    ],
+  },
+  {
+    title: '关键词',
+    items: [
+      { key: 'errorKeyword', label: '错误关键词', description: 'Exception/Error/Failed 等' },
+      { key: 'success', label: '成功关键词', description: 'Success/Complete/Done 等' },
+    ],
+  },
+  {
+    title: '特殊内容',
+    items: [
+      { key: 'stackTrace', label: '堆栈跟踪', description: 'Java/Python 堆栈信息' },
+      { key: 'json', label: 'JSON', description: 'JSON 对象/数组' },
+      { key: 'variable', label: '变量', description: 'key=value 格式的变量名' },
+      { key: 'operator', label: '操作符', description: '= < > ! 等操作符' },
+    ],
+  },
+]
 
 // 更新颜色
 const updateColor = (key: keyof LogHighlightColors, value: string) => {
-    const colorValue = value.replace('#', '')
-    if (editingTheme.value === 'light') {
-        setLightColors({ [key]: colorValue })
-    } else {
-        setDarkColors({ [key]: colorValue })
-    }
+  const colorValue = value.replace('#', '')
+  if (editingTheme.value === 'light') {
+    setLightColors({ [key]: colorValue })
+  } else {
+    setDarkColors({ [key]: colorValue })
+  }
 }
 
 // 重置为默认
 const handleReset = () => {
-    resetToDefaults()
-    message.success('已重置为默认配置')
+  resetToDefaults()
+  message.success('已重置为默认配置')
 }
 
 // 重置单个颜色
 const resetSingleColor = (key: keyof LogHighlightColors) => {
-    const defaultColors = editingTheme.value === 'light' ? defaultLightColors : defaultDarkColors
-    if (editingTheme.value === 'light') {
-        setLightColors({ [key]: defaultColors[key] })
-    } else {
-        setDarkColors({ [key]: defaultColors[key] })
-    }
+  const defaultColors = editingTheme.value === 'light' ? defaultLightColors : defaultDarkColors
+  if (editingTheme.value === 'light') {
+    setLightColors({ [key]: defaultColors[key] })
+  } else {
+    setDarkColors({ [key]: defaultColors[key] })
+  }
 }
 
 // 字体大小选项
@@ -133,415 +133,499 @@ const lineHeightOptions = [1.2, 1.4, 1.5, 1.6, 1.8, 2.0]
 </script>
 
 <template>
-    <div class="log-highlight-settings">
-        <a-row :gutter="24">
-            <a-col :span="12">
-                <div class="form-item-vertical">
-                    <div class="form-label-wrapper">
-                        <span class="form-label">字体大小</span>
-                    </div>
-                    <a-select :value="editorConfig.fontSize" size="large" style="width: 100%"
-                        @change="(v: number) => setEditorConfig({ fontSize: v })">
-                        <a-select-option v-for="size in fontSizeOptions" :key="size" :value="size">
-                            {{ size }}px
-                        </a-select-option>
-                    </a-select>
-                </div>
-            </a-col>
-            <a-col :span="12">
-                <div class="form-item-vertical">
-                    <div class="form-label-wrapper">
-                        <span class="form-label">行高</span>
-                    </div>
-                    <a-select :value="editorConfig.lineHeight" size="large" style="width: 100%"
-                        @change="(v: number) => setEditorConfig({ lineHeight: v })">
-                        <a-select-option v-for="h in lineHeightOptions" :key="h" :value="h">
-                            {{ h }}
-                        </a-select-option>
-                    </a-select>
-                </div>
-            </a-col>
-            <a-col :span="24">
-                <div class="form-item-vertical text-style-item">
-                    <div class="form-label-wrapper">
-                        <span class="form-label">文字强调</span>
-                    </div>
-                    <div class="checkbox-row">
-                        <a-checkbox :checked="styles.timestampBold"
-                            @change="(e: any) => setStyles({ timestampBold: e.target.checked })">
-                            时间戳加粗
-                        </a-checkbox>
-                        <a-checkbox :checked="styles.levelBold"
-                            @change="(e: any) => setStyles({ levelBold: e.target.checked })">
-                            日志级别加粗
-                        </a-checkbox>
-                        <a-checkbox :checked="styles.keywordBold"
-                            @change="(e: any) => setStyles({ keywordBold: e.target.checked })">
-                            关键词加粗
-                        </a-checkbox>
-                        <a-checkbox :checked="styles.urlUnderline"
-                            @change="(e: any) => setStyles({ urlUnderline: e.target.checked })">
-                            URL 下划线
-                        </a-checkbox>
-                    </div>
-                </div>
-            </a-col>
-        </a-row>
+  <div class="log-highlight-settings">
+    <a-row :gutter="24">
+      <a-col :span="12">
+        <div class="form-item-vertical">
+          <div class="form-label-wrapper">
+            <span class="form-label">字体大小</span>
+          </div>
+          <a-select
+            :value="editorConfig.fontSize"
+            size="large"
+            style="width: 100%"
+            @change="(v: number) => setEditorConfig({ fontSize: v })"
+          >
+            <a-select-option v-for="size in fontSizeOptions" :key="size" :value="size">
+              {{ size }}px
+            </a-select-option>
+          </a-select>
+        </div>
+      </a-col>
+      <a-col :span="12">
+        <div class="form-item-vertical">
+          <div class="form-label-wrapper">
+            <span class="form-label">行高</span>
+          </div>
+          <a-select
+            :value="editorConfig.lineHeight"
+            size="large"
+            style="width: 100%"
+            @change="(v: number) => setEditorConfig({ lineHeight: v })"
+          >
+            <a-select-option v-for="h in lineHeightOptions" :key="h" :value="h">
+              {{ h }}
+            </a-select-option>
+          </a-select>
+        </div>
+      </a-col>
+      <a-col :span="24">
+        <div class="form-item-vertical text-style-item">
+          <div class="form-label-wrapper">
+            <span class="form-label">文字强调</span>
+          </div>
+          <div class="checkbox-row">
+            <a-checkbox
+              :checked="styles.timestampBold"
+              @change="(e: any) => setStyles({ timestampBold: e.target.checked })"
+            >
+              时间戳加粗
+            </a-checkbox>
+            <a-checkbox
+              :checked="styles.levelBold"
+              @change="(e: any) => setStyles({ levelBold: e.target.checked })"
+            >
+              日志级别加粗
+            </a-checkbox>
+            <a-checkbox
+              :checked="styles.keywordBold"
+              @change="(e: any) => setStyles({ keywordBold: e.target.checked })"
+            >
+              关键词加粗
+            </a-checkbox>
+            <a-checkbox
+              :checked="styles.urlUnderline"
+              @change="(e: any) => setStyles({ urlUnderline: e.target.checked })"
+            >
+              URL 下划线
+            </a-checkbox>
+          </div>
+        </div>
+      </a-col>
+    </a-row>
 
-        <a-collapse class="advanced-settings" :bordered="false">
-            <a-collapse-panel key="highlight">
-                <template #header>
-                    <div class="advanced-settings-header">
-                        <span class="advanced-settings-title">高亮颜色与预览设置区域</span>
-                    </div>
-                </template>
+    <a-collapse class="advanced-settings" :bordered="false">
+      <a-collapse-panel key="highlight">
+        <template #header>
+          <div class="advanced-settings-header">
+            <span class="advanced-settings-title">高亮颜色与预览设置区域</span>
+          </div>
+        </template>
 
         <!-- 颜色配置 -->
         <div class="config-section">
-            <div class="log-section-header">
-                <div class="section-title">颜色配置</div>
-                <div class="section-actions">
-                    <a-radio-group v-model:value="editingTheme" button-style="solid" size="small">
-                        <a-radio-button value="light">浅色主题</a-radio-button>
-                        <a-radio-button value="dark">深色主题</a-radio-button>
-                    </a-radio-group>
-                    <a-button size="small" @click="handleReset">
-                        <template #icon>
-                            <ReloadOutlined />
-                        </template>
-                        重置全部
-                    </a-button>
-                </div>
+          <div class="log-section-header">
+            <div class="section-title">颜色配置</div>
+            <div class="section-actions">
+              <a-radio-group v-model:value="editingTheme" button-style="solid" size="small">
+                <a-radio-button value="light">浅色主题</a-radio-button>
+                <a-radio-button value="dark">深色主题</a-radio-button>
+              </a-radio-group>
+              <a-button size="small" @click="handleReset">
+                <template #icon>
+                  <ReloadOutlined />
+                </template>
+                重置全部
+              </a-button>
             </div>
+          </div>
 
-            <div v-for="group in colorGroups" :key="group.title" class="color-group">
-                <div class="group-title">{{ group.title }}</div>
-                <div class="color-grid">
-                    <div v-for="item in group.items" :key="item.key" class="color-item">
-                        <div class="color-info">
-                            <span class="color-label">{{ item.label }}</span>
-                            <a-tooltip :title="item.description">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <div class="color-controls">
-                            <input type="color" :value="'#' + currentColors[item.key]" class="color-picker"
-                                @input="(e: Event) => updateColor(item.key, (e.target as HTMLInputElement).value)" />
-                            <span class="color-value">#{{ currentColors[item.key] }}</span>
-                            <a-button size="small" type="text" @click="resetSingleColor(item.key)" title="重置此颜色">
-                                <template #icon>
-                                    <ReloadOutlined />
-                                </template>
-                            </a-button>
-                        </div>
-                    </div>
+          <div v-for="group in colorGroups" :key="group.title" class="color-group">
+            <div class="group-title">{{ group.title }}</div>
+            <div class="color-grid">
+              <div v-for="item in group.items" :key="item.key" class="color-item">
+                <div class="color-info">
+                  <span class="color-label">{{ item.label }}</span>
+                  <a-tooltip :title="item.description">
+                    <QuestionCircleOutlined class="help-icon" />
+                  </a-tooltip>
                 </div>
+                <div class="color-controls">
+                  <input
+                    type="color"
+                    :value="'#' + currentColors[item.key]"
+                    class="color-picker"
+                    @input="
+                      (e: Event) => updateColor(item.key, (e.target as HTMLInputElement).value)
+                    "
+                  />
+                  <span class="color-value">#{{ currentColors[item.key] }}</span>
+                  <a-button
+                    size="small"
+                    type="text"
+                    title="重置此颜色"
+                    @click="resetSingleColor(item.key)"
+                  >
+                    <template #icon>
+                      <ReloadOutlined />
+                    </template>
+                  </a-button>
+                </div>
+              </div>
             </div>
+          </div>
         </div>
 
         <!-- 预览 -->
         <div class="config-section">
-            <div class="section-title">预览效果</div>
-            <div class="preview-content" :class="editingTheme === 'dark' ? 'preview-dark' : 'preview-light'" :style="{
-                fontSize: editorConfig.fontSize + 'px',
-                lineHeight: editorConfig.lineHeight
-            }">
-                <div class="preview-line">
-                    <span
-                        :style="{ color: '#' + currentColors.timestamp, fontWeight: styles.timestampBold ? 'bold' : 'normal' }">2024-12-09
-                        10:30:45.123</span>
-                    <span
-                        :style="{ color: '#' + currentColors.info, fontWeight: styles.levelBold ? 'bold' : 'normal' }">
-                        INFO
-                    </span>
-                    <span :style="{ color: '#' + currentColors.module }">[MainModule]</span>
-                    <span> 应用启动成功，端口</span>
-                    <span :style="{ color: '#' + currentColors.port }">:8080</span>
-                </div>
-                <div class="preview-line">
-                    <span
-                        :style="{ color: '#' + currentColors.timestamp, fontWeight: styles.timestampBold ? 'bold' : 'normal' }">2024-12-09
-                        10:30:46.456</span>
-                    <span
-                        :style="{ color: '#' + currentColors.warning, fontWeight: styles.levelBold ? 'bold' : 'normal' }">
-                        WARN </span>
-                    <span :style="{ color: '#' + currentColors.module }">[Network]</span>
-                    <span> 连接超时，IP: </span>
-                    <span :style="{ color: '#' + currentColors.ip }">192.168.1.100</span>
-                    <span :style="{ color: '#' + currentColors.variable }"> retries</span>
-                    <span :style="{ color: '#' + currentColors.operator }">=</span>
-                    <span :style="{ color: '#' + currentColors.number }">3</span>
-                </div>
-                <div class="preview-line">
-                    <span
-                        :style="{ color: '#' + currentColors.timestamp, fontWeight: styles.timestampBold ? 'bold' : 'normal' }">2024-12-09
-                        10:30:47.789</span>
-                    <span
-                        :style="{ color: '#' + currentColors.error, fontWeight: styles.levelBold ? 'bold' : 'normal' }">
-                        ERROR
-                    </span>
-                    <span :style="{ color: '#' + currentColors.module }">[Database]</span>
-                    <span
-                        :style="{ color: '#' + currentColors.errorKeyword, fontWeight: styles.keywordBold ? 'bold' : 'normal' }">
-                        Exception</span>
-                    <span>: 连接失败 </span>
-                    <span :style="{ color: '#' + currentColors.string }">"Connection refused"</span>
-                </div>
-                <div class="preview-line">
-                    <span :style="{ color: '#' + currentColors.stackTrace }"> at
-                        com.example.Database.connect(Database.java:42)</span>
-                </div>
-                <div class="preview-line">
-                    <span
-                        :style="{ color: '#' + currentColors.timestamp, fontWeight: styles.timestampBold ? 'bold' : 'normal' }">2024-12-09
-                        10:30:48.000</span>
-                    <span :style="{ color: '#' + currentColors.debug }"> DEBUG </span>
-                    <span :style="{ color: '#' + currentColors.module }">[Task]</span>
-                    <span> UUID: </span>
-                    <span :style="{ color: '#' + currentColors.uuid }">550e8400-e29b-41d4-a716-446655440000</span>
-                </div>
-                <div class="preview-line">
-                    <span
-                        :style="{ color: '#' + currentColors.timestamp, fontWeight: styles.timestampBold ? 'bold' : 'normal' }">2024-12-09
-                        10:30:49.123</span>
-                    <span :style="{ color: '#' + currentColors.trace }"> TRACE </span>
-                    <span :style="{ color: '#' + currentColors.module }">[HTTP]</span>
-                    <span> 请求 </span>
-                    <span
-                        :style="{ color: '#' + currentColors.url, textDecoration: styles.urlUnderline ? 'underline' : 'none' }">https://api.example.com/data</span>
-                    <span
-                        :style="{ color: '#' + currentColors.success, fontWeight: styles.keywordBold ? 'bold' : 'normal' }">
-                        Success</span>
-                </div>
-                <div class="preview-line">
-                    <span :style="{ color: '#' + currentColors.trace }"> TRACE </span>
-                    <span> 响应: </span>
-                    <span :style="{ color: '#' + currentColors.json }">{"status": "ok", "count": 42}</span>
-                    <span> enabled</span>
-                    <span :style="{ color: '#' + currentColors.operator }">=</span>
-                    <span :style="{ color: '#' + currentColors.boolean }">true</span>
-                </div>
+          <div class="section-title">预览效果</div>
+          <div
+            class="preview-content"
+            :class="editingTheme === 'dark' ? 'preview-dark' : 'preview-light'"
+            :style="{
+              fontSize: editorConfig.fontSize + 'px',
+              lineHeight: editorConfig.lineHeight,
+            }"
+          >
+            <div class="preview-line">
+              <span
+                :style="{
+                  color: '#' + currentColors.timestamp,
+                  fontWeight: styles.timestampBold ? 'bold' : 'normal',
+                }"
+                >2024-12-09 10:30:45.123</span
+              >
+              <span
+                :style="{
+                  color: '#' + currentColors.info,
+                  fontWeight: styles.levelBold ? 'bold' : 'normal',
+                }"
+              >
+                INFO
+              </span>
+              <span :style="{ color: '#' + currentColors.module }">[MainModule]</span>
+              <span> 应用启动成功，端口</span>
+              <span :style="{ color: '#' + currentColors.port }">:8080</span>
             </div>
+            <div class="preview-line">
+              <span
+                :style="{
+                  color: '#' + currentColors.timestamp,
+                  fontWeight: styles.timestampBold ? 'bold' : 'normal',
+                }"
+                >2024-12-09 10:30:46.456</span
+              >
+              <span
+                :style="{
+                  color: '#' + currentColors.warning,
+                  fontWeight: styles.levelBold ? 'bold' : 'normal',
+                }"
+              >
+                WARN
+              </span>
+              <span :style="{ color: '#' + currentColors.module }">[Network]</span>
+              <span> 连接超时，IP: </span>
+              <span :style="{ color: '#' + currentColors.ip }">192.168.1.100</span>
+              <span :style="{ color: '#' + currentColors.variable }"> retries</span>
+              <span :style="{ color: '#' + currentColors.operator }">=</span>
+              <span :style="{ color: '#' + currentColors.number }">3</span>
+            </div>
+            <div class="preview-line">
+              <span
+                :style="{
+                  color: '#' + currentColors.timestamp,
+                  fontWeight: styles.timestampBold ? 'bold' : 'normal',
+                }"
+                >2024-12-09 10:30:47.789</span
+              >
+              <span
+                :style="{
+                  color: '#' + currentColors.error,
+                  fontWeight: styles.levelBold ? 'bold' : 'normal',
+                }"
+              >
+                ERROR
+              </span>
+              <span :style="{ color: '#' + currentColors.module }">[Database]</span>
+              <span
+                :style="{
+                  color: '#' + currentColors.errorKeyword,
+                  fontWeight: styles.keywordBold ? 'bold' : 'normal',
+                }"
+              >
+                Exception</span
+              >
+              <span>: 连接失败 </span>
+              <span :style="{ color: '#' + currentColors.string }">"Connection refused"</span>
+            </div>
+            <div class="preview-line">
+              <span :style="{ color: '#' + currentColors.stackTrace }">
+                at com.example.Database.connect(Database.java:42)</span
+              >
+            </div>
+            <div class="preview-line">
+              <span
+                :style="{
+                  color: '#' + currentColors.timestamp,
+                  fontWeight: styles.timestampBold ? 'bold' : 'normal',
+                }"
+                >2024-12-09 10:30:48.000</span
+              >
+              <span :style="{ color: '#' + currentColors.debug }"> DEBUG </span>
+              <span :style="{ color: '#' + currentColors.module }">[Task]</span>
+              <span> UUID: </span>
+              <span :style="{ color: '#' + currentColors.uuid }"
+                >550e8400-e29b-41d4-a716-446655440000</span
+              >
+            </div>
+            <div class="preview-line">
+              <span
+                :style="{
+                  color: '#' + currentColors.timestamp,
+                  fontWeight: styles.timestampBold ? 'bold' : 'normal',
+                }"
+                >2024-12-09 10:30:49.123</span
+              >
+              <span :style="{ color: '#' + currentColors.trace }"> TRACE </span>
+              <span :style="{ color: '#' + currentColors.module }">[HTTP]</span>
+              <span> 请求 </span>
+              <span
+                :style="{
+                  color: '#' + currentColors.url,
+                  textDecoration: styles.urlUnderline ? 'underline' : 'none',
+                }"
+                >https://api.example.com/data</span
+              >
+              <span
+                :style="{
+                  color: '#' + currentColors.success,
+                  fontWeight: styles.keywordBold ? 'bold' : 'normal',
+                }"
+              >
+                Success</span
+              >
+            </div>
+            <div class="preview-line">
+              <span :style="{ color: '#' + currentColors.trace }"> TRACE </span>
+              <span> 响应: </span>
+              <span :style="{ color: '#' + currentColors.json }"
+                >{"status": "ok", "count": 42}</span
+              >
+              <span> enabled</span>
+              <span :style="{ color: '#' + currentColors.operator }">=</span>
+              <span :style="{ color: '#' + currentColors.boolean }">true</span>
+            </div>
+          </div>
         </div>
-            </a-collapse-panel>
-        </a-collapse>
-    </div>
+      </a-collapse-panel>
+    </a-collapse>
+  </div>
 </template>
 
 <style scoped>
 .log-highlight-settings {
-    padding: 0;
+  padding: 0;
 }
 
 .config-section {
-    margin-bottom: 20px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid var(--ant-color-border-secondary);
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--ant-color-border-secondary);
 }
 
 .config-section:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
+  border-bottom: none;
+  margin-bottom: 0;
 }
 
 .log-section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
 }
 
 .section-title {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--ant-color-text);
-    margin-bottom: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ant-color-text);
+  margin-bottom: 12px;
 }
 
 .log-section-header .section-title {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .section-actions {
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .advanced-settings {
-    overflow: hidden;
-    margin-top: 4px;
-    background: var(--ant-color-bg-container);
-    border: 1px solid var(--ant-color-border);
-    border-radius: 8px;
+  overflow: hidden;
+  margin-top: 4px;
+  background: var(--ant-color-bg-container);
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px;
 }
 
 .advanced-settings :deep(.ant-collapse-header) {
-    align-items: center;
-    padding: 12px 16px;
-    transition: background-color 0.2s ease;
+  align-items: center;
+  padding: 12px 16px;
+  transition: background-color 0.2s ease;
 }
 
 .advanced-settings :deep(.ant-collapse-header:hover) {
-    background: var(--ant-color-primary-bg);
+  background: var(--ant-color-primary-bg);
 }
 
 .advanced-settings :deep(.ant-collapse-item) {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .advanced-settings :deep(.ant-collapse-content) {
-    background: transparent;
-    border-top-color: var(--ant-color-border-secondary);
+  background: transparent;
+  border-top-color: var(--ant-color-border-secondary);
 }
 
 .advanced-settings :deep(.ant-collapse-content-box) {
-    padding: 16px;
+  padding: 16px;
 }
 
 .advanced-settings-header {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
 }
 
 .advanced-settings-title {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--ant-color-text);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ant-color-text);
 }
 
 .advanced-settings-description {
-    font-size: 13px;
-    color: var(--ant-color-text-secondary);
+  font-size: 13px;
+  color: var(--ant-color-text-secondary);
 }
 
 .checkbox-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    min-height: 40px;
-    gap: 8px 24px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  min-height: 40px;
+  gap: 8px 24px;
 }
 
 .checkbox-row :deep(.ant-checkbox-wrapper) {
-    font-size: 14px;
-    margin-inline-start: 0;
+  font-size: 14px;
+  margin-inline-start: 0;
 }
 
 /* 原有颜色配置样式 */
 .config-item {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .config-label {
-    font-size: 12px;
-    color: var(--ant-color-text-secondary);
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
 }
 
 .color-group {
-    margin-bottom: 16px;
+  margin-bottom: 16px;
 }
 
 .color-group:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .group-title {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--ant-color-text-secondary);
-    margin-bottom: 8px;
-    padding-left: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ant-color-text-secondary);
+  margin-bottom: 8px;
+  padding-left: 4px;
 }
 
 .color-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
 }
 
 .color-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 6px 10px;
-    background: var(--ant-color-bg-container);
-    border: 1px solid var(--ant-color-border);
-    border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--ant-color-bg-container);
+  border: 1px solid var(--ant-color-border);
+  border-radius: 4px;
 }
 
 .color-info {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .color-label {
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--ant-color-text);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ant-color-text);
 }
 
 .help-icon {
-    color: var(--ant-color-text-secondary);
-    font-size: 11px;
+  color: var(--ant-color-text-secondary);
+  font-size: 11px;
 }
 
 .color-controls {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .color-picker {
-    width: 28px;
-    height: 20px;
-    padding: 0;
-    border: 1px solid var(--ant-color-border);
-    border-radius: 3px;
-    cursor: pointer;
-    background: transparent;
+  width: 28px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 3px;
+  cursor: pointer;
+  background: transparent;
 }
 
 .color-picker::-webkit-color-swatch-wrapper {
-    padding: 1px;
+  padding: 1px;
 }
 
 .color-picker::-webkit-color-swatch {
-    border: none;
-    border-radius: 2px;
+  border: none;
+  border-radius: 2px;
 }
 
 .color-value {
-    font-family: monospace;
-    font-size: 11px;
-    color: var(--ant-color-text-secondary);
-    min-width: 55px;
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--ant-color-text-secondary);
+  min-width: 55px;
 }
 
 .preview-content {
-    padding: 12px;
-    border-radius: 6px;
-    overflow-x: auto;
-    font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 }
 
 .preview-light {
-    background: #ffffff;
-    color: #333333;
-    border: 1px solid #d9d9d9;
+  background: #ffffff;
+  color: #333333;
+  border: 1px solid #d9d9d9;
 }
 
 .preview-dark {
-    background: #1e1e1e;
-    color: #d4d4d4;
-    border: 1px solid #424242;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border: 1px solid #424242;
 }
 
 .preview-line {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 </style>

--- a/frontend/src/components/NoticeModal.vue
+++ b/frontend/src/components/NoticeModal.vue
@@ -1,14 +1,36 @@
 <template>
-  <a-modal v-model:open="visible" title="系统公告" :width="800" :footer="null" :closable="false" :mask-closable="false"
-    class="notice-modal">
+  <a-modal
+    v-model:open="visible"
+    title="系统公告"
+    :width="800"
+    :footer="null"
+    :closable="false"
+    :mask-closable="false"
+    class="notice-modal"
+  >
     <div v-if="notices.length > 0" class="notice-container">
       <!-- 公告标签页 - 竖直布局 -->
-      <a-tabs v-model:active-key="activeNoticeKey" tab-position="left" class="notice-tabs"
-        :tab-bar-style="{ width: '200px' }">
-        <a-tab-pane v-for="(content, title) in noticeData" :key="title" :tab="title" class="notice-tab-pane">
+      <a-tabs
+        v-model:active-key="activeNoticeKey"
+        tab-position="left"
+        class="notice-tabs"
+        :tab-bar-style="{ width: '200px' }"
+      >
+        <a-tab-pane
+          v-for="(content, title) in noticeData"
+          :key="title"
+          :tab="title"
+          class="notice-tab-pane"
+        >
           <div class="notice-content">
-            <div ref="markdownContentRef" class="markdown-content" @click="handleLinkClick"
-              v-html="renderMarkdown(content)"></div>
+            <!-- eslint-disable vue/no-v-html 公告内容来自 MAS 后端 markdown，属可信内容 -->
+            <div
+              ref="markdownContentRef"
+              class="markdown-content"
+              @click="handleLinkClick"
+              v-html="renderMarkdown(content)"
+            ></div>
+            <!-- eslint-enable vue/no-v-html -->
           </div>
         </a-tab-pane>
       </a-tabs>
@@ -20,7 +42,12 @@
         </div>
 
         <div class="notice-actions">
-          <a-button type="primary" :loading="confirming" class="confirm-button" @click="confirmNotices">
+          <a-button
+            type="primary"
+            :loading="confirming"
+            class="confirm-button"
+            @click="confirmNotices"
+          >
             我知道了
           </a-button>
         </div>

--- a/frontend/src/components/TaskTree.vue
+++ b/frontend/src/components/TaskTree.vue
@@ -33,8 +33,12 @@
               <span class="no-users-text">暂无用户</span>
             </div>
           </div>
-          <div v-for="(user, index) in script.user_list" :key="`user-${script.script_id}-${user.user_id}`"
-            class="user-item" :class="{ 'last-item': index === script.user_list.length - 1 }">
+          <div
+            v-for="(user, index) in script.user_list"
+            :key="`user-${script.script_id}-${user.user_id}`"
+            class="user-item"
+            :class="{ 'last-item': index === script.user_list.length - 1 }"
+          >
             <div class="user-content">
               <span class="user-name">{{ user.name }}</span>
               <a-tag :color="getStatusColor(user.status)" size="small" class="status-tag">
@@ -145,8 +149,10 @@ watch(
   (newData, oldData) => {
     const newScriptCount = newData?.length ?? 0
     const oldScriptCount = oldData?.length ?? 0
-    const newUserCount = newData?.reduce((total, script) => total + (script.user_list?.length || 0), 0) ?? 0
-    const oldUserCount = oldData?.reduce((total, script) => total + (script.user_list?.length || 0), 0) ?? 0
+    const newUserCount =
+      newData?.reduce((total, script) => total + (script.user_list?.length || 0), 0) ?? 0
+    const oldUserCount =
+      oldData?.reduce((total, script) => total + (script.user_list?.length || 0), 0) ?? 0
 
     if (newScriptCount !== oldScriptCount || newUserCount !== oldUserCount) {
       logger.debug(
@@ -223,17 +229,21 @@ defineExpose({
 .script-header {
   cursor: pointer;
   padding: 12px 16px;
-  background: linear-gradient(135deg,
-      var(--ant-color-fill-quaternary) 0%,
-      var(--ant-color-fill-tertiary) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--ant-color-fill-quaternary) 0%,
+    var(--ant-color-fill-tertiary) 100%
+  );
   /* 保留hover过渡，但减少时间 */
   transition: background 0.1s ease;
 }
 
 .script-header:hover {
-  background: linear-gradient(135deg,
-      var(--ant-color-fill-tertiary) 0%,
-      var(--ant-color-fill-secondary) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--ant-color-fill-tertiary) 0%,
+    var(--ant-color-fill-secondary) 100%
+  );
 }
 
 .script-content {

--- a/frontend/src/components/UpdateModal.vue
+++ b/frontend/src/components/UpdateModal.vue
@@ -11,11 +11,13 @@
     <div class="update-container">
       <!-- 更新内容展示 -->
       <div class="update-content">
+        <!-- eslint-disable vue/no-v-html 更新说明来自 MAS 后端 markdown，属可信内容 -->
         <div
           ref="markdownContentRef"
           class="markdown-content"
           v-html="renderMarkdown(updateContent)"
         ></div>
+        <!-- eslint-enable vue/no-v-html -->
       </div>
 
       <!-- 操作按钮 -->

--- a/frontend/src/components/WebSocketMessageListener.vue
+++ b/frontend/src/components/WebSocketMessageListener.vue
@@ -1,15 +1,27 @@
 <template>
   <!-- 应用内弹窗组件 -->
-  <Modal v-model:open="isModalOpen" :title="currentModal?.title || '操作提示'" :closable="false" :maskClosable="false"
-    :keyboard="true" centered @ok="handleOk" @cancel="handleCancel">
+  <Modal
+    v-model:open="isModalOpen"
+    :title="currentModal?.title || '操作提示'"
+    :closable="false"
+    :mask-closable="false"
+    :keyboard="true"
+    centered
+    @ok="handleOk"
+    @cancel="handleCancel"
+  >
     <p class="modal-message">{{ currentModal?.message || '' }}</p>
     <!-- 显示队列中还有多少待处理的弹窗 -->
     <p v-if="modalQueue.length > 0" class="modal-queue-hint">
       还有 {{ modalQueue.length }} 条消息待处理
     </p>
     <template #footer>
-      <Button v-for="(option, index) in (currentModal?.options || ['确定', '取消'])" :key="index"
-        :type="index === 0 ? 'primary' : 'default'" @click="handleChoice(index === 0)">
+      <Button
+        v-for="(option, index) in currentModal?.options || ['确定', '取消']"
+        :key="index"
+        :type="index === 0 ? 'primary' : 'default'"
+        @click="handleChoice(index === 0)"
+      >
         {{ option }}
       </Button>
     </template>
@@ -94,7 +106,9 @@ const showNextModal = async () => {
   if (modalQueue.value.length > 0) {
     // 从队列头部取出下一个弹窗
     const nextModal = modalQueue.value.shift()!
-    logger.info(`显示队列中的下一个弹窗: ${nextModal.messageId}, 剩余队列: ${modalQueue.value.length}`)
+    logger.info(
+      `显示队列中的下一个弹窗: ${nextModal.messageId}, 剩余队列: ${modalQueue.value.length}`
+    )
 
     // 激活窗口
     await focusWindow()
@@ -142,12 +156,18 @@ const showQuestion = async (questionData: any) => {
 const handleMessage = (message: WebSocketBaseMessage) => {
   try {
     // 只打印摘要信息，避免打印完整消息内容
-    const dataSize = message.data ? (typeof message.data === 'string' ? message.data.length : JSON.stringify(message.data).length) : 0
-    logger.info(`收到Message类型消息: ${JSON.stringify({
-      type: message.type,
-      id: message.id,
-      dataSize: `${dataSize} bytes`
-    })}`)
+    const dataSize = message.data
+      ? typeof message.data === 'string'
+        ? message.data.length
+        : JSON.stringify(message.data).length
+      : 0
+    logger.info(
+      `收到Message类型消息: ${JSON.stringify({
+        type: message.type,
+        id: message.id,
+        dataSize: `${dataSize} bytes`,
+      })}`
+    )
 
     // 解析消息数据
     if (message.data) {
@@ -180,9 +200,7 @@ const handleObjectMessage = (data: any) => {
   logger.debug(`处理对象消息: ${JSON.stringify(data)}`)
 
   // 检查是否为Question类型的消息
-  logger.debug(
-    `检查消息类型 - data.type: ${data.type}, data.message_id: ${data.message_id}`
-  )
+  logger.debug(`检查消息类型 - data.type: ${data.type}, data.message_id: ${data.message_id}`)
 
   if (data.type === 'Question') {
     logger.info('发现Question类型消息')
@@ -251,8 +269,8 @@ onMounted(() => {
   logger.info(`订阅ID: ${subscriptionId}`)
   logger.info(`订阅过滤器: ${JSON.stringify({ type: 'Message' })}`)
 
-    // 暴露调试接口到 window 对象（仅用于开发调试）
-    ; (window as any).__debugShowQuestion = showQuestion
+  // 暴露调试接口到 window 对象（仅用于开发调试）
+  ;(window as any).__debugShowQuestion = showQuestion
   logger.debug('已暴露调试接口: window.__debugShowQuestion')
 })
 

--- a/frontend/src/components/devtools/BackendLaunchPage.vue
+++ b/frontend/src/components/devtools/BackendLaunchPage.vue
@@ -16,13 +16,21 @@
 
       <!-- 控制按钮 -->
       <div class="action-buttons">
-        <button :disabled="isLoading || isBackendRunning" class="action-btn start-btn" @click="startBackend">
+        <button
+          :disabled="isLoading || isBackendRunning"
+          class="action-btn start-btn"
+          @click="startBackend"
+        >
           <span v-if="isLoading" class="loading-spinner">⏳</span>
           <span v-else>▶️</span>
           启动后端
         </button>
 
-        <button :disabled="isLoading || !isBackendRunning" class="action-btn stop-btn" @click="stopBackend">
+        <button
+          :disabled="isLoading || !isBackendRunning"
+          class="action-btn stop-btn"
+          @click="stopBackend"
+        >
           <span v-if="isLoading" class="loading-spinner">⏳</span>
           <span v-else>⏹️</span>
           停止后端
@@ -36,7 +44,11 @@
       </div>
 
       <!-- 操作结果显示 -->
-      <div v-if="lastResult" class="result-card" :class="{ success: lastResult.success, error: !lastResult.success }">
+      <div
+        v-if="lastResult"
+        class="result-card"
+        :class="{ success: lastResult.success, error: !lastResult.success }"
+      >
         <div class="result-title">
           {{ lastResult.success ? '操作成功' : '❌ 操作失败' }}
         </div>
@@ -134,15 +146,21 @@
 
       <!-- WebSocket控制按钮 -->
       <div class="ws-actions">
-        <button :disabled="isWsReconnecting || connectionInfo.isAutoReconnecting" class="action-btn reconnect-btn"
-          @click="handleManualReconnect">
+        <button
+          :disabled="isWsReconnecting || connectionInfo.isAutoReconnecting"
+          class="action-btn reconnect-btn"
+          @click="handleManualReconnect"
+        >
           <span v-if="isWsReconnecting" class="loading-spinner">⏳</span>
           <span v-else>🔄</span>
           {{ isWsReconnecting ? '重连中...' : '手动重连' }}
         </button>
 
-        <button :disabled="connectionInfo.isAutoReconnecting" class="action-btn reset-btn"
-          @click="handleResetReconnect">
+        <button
+          :disabled="connectionInfo.isAutoReconnecting"
+          class="action-btn reset-btn"
+          @click="handleResetReconnect"
+        >
           🔧 重置重连状态
         </button>
 
@@ -255,7 +273,6 @@ const updateWsStatus = () => {
 
 // 处理WebSocket消息
 const handleWsMessage = (message: WebSocketBaseMessage) => {
-
   // 添加到消息列表
   wsMessages.value.unshift({
     timestamp: new Date().toLocaleTimeString(),

--- a/frontend/src/components/devtools/EnvironmentPage.vue
+++ b/frontend/src/components/devtools/EnvironmentPage.vue
@@ -73,7 +73,11 @@ const updateTime = () => {
 
 // 获取内存信息
 const updateMemoryInfo = () => {
-  const memory = performance.memory
+  const memory = (
+    performance as unknown as {
+      memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number }
+    }
+  ).memory
   if (memory) {
     const used = Math.round(memory.usedJSHeapSize / 1024 / 1024)
     const total = Math.round(memory.totalJSHeapSize / 1024 / 1024)

--- a/frontend/src/components/devtools/QuickNavPage.vue
+++ b/frontend/src/components/devtools/QuickNavPage.vue
@@ -4,8 +4,12 @@
     <div class="debug-section">
       <h4>🎯 手动导航</h4>
       <div class="manual-nav">
-        <input v-model="manualPath" placeholder="输入路径 (例: /home, /scripts)" class="path-input"
-          @keyup.enter="navigateToManualPath" />
+        <input
+          v-model="manualPath"
+          placeholder="输入路径 (例: /home, /scripts)"
+          class="path-input"
+          @keyup.enter="navigateToManualPath"
+        />
         <button class="nav-go-btn" @click="navigateToManualPath">跳转</button>
       </div>
     </div>
@@ -14,9 +18,14 @@
     <div class="debug-section">
       <h4>🚀 快捷导航</h4>
       <div class="quick-nav">
-        <button v-for="route in commonRoutes" :key="route.path" class="nav-btn"
-          :class="{ active: currentRoute.path === route.path }" @click="navigateTo(route.path)">
-          {{ route.title }}
+        <button
+          v-for="navRoute in commonRoutes"
+          :key="navRoute.path"
+          class="nav-btn"
+          :class="{ active: currentRoute.path === navRoute.path }"
+          @click="navigateTo(navRoute.path)"
+        >
+          {{ navRoute.title }}
         </button>
       </div>
     </div>
@@ -111,7 +120,7 @@ const navigateToManualPath = () => {
 const openDevtool = () => {
   try {
     if ((window as any).electronAPI?.openDevTools) {
-      ; (window as any).electronAPI.openDevTools()
+      ;(window as any).electronAPI.openDevTools()
       logger.info('开发者工具已打开')
     } else {
       logger.warn('开发者工具API不可用')

--- a/frontend/src/components/devtools/index.vue
+++ b/frontend/src/components/devtools/index.vue
@@ -1,6 +1,10 @@
 <template>
-  <div v-if="isDev" class="debug-panel" :class="{ collapsed: isCollapsed, dragging: isDragging }"
-    :style="{ left: `${panelPosition.x}px`, top: `${panelPosition.y}px` }">
+  <div
+    v-if="isDev"
+    class="debug-panel"
+    :class="{ collapsed: isCollapsed, dragging: isDragging }"
+    :style="{ left: `${panelPosition.x}px`, top: `${panelPosition.y}px` }"
+  >
     <div class="debug-header">
       <span class="debug-title drag-handle" @mousedown="startDrag">
         调试面板 <span v-if="isDragging" class="drag-indicator">📌</span>
@@ -15,8 +19,13 @@
     <div v-if="!isCollapsed" class="debug-content" @mousedown.stop>
       <!-- 页面切换选项卡 -->
       <div class="debug-tabs">
-        <button v-for="tab in tabs" :key="tab.key" class="tab-btn" :class="{ active: activeTab === tab.key }"
-          @click="setActiveTab(tab.key)">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          class="tab-btn"
+          :class="{ active: activeTab === tab.key }"
+          @click="setActiveTab(tab.key)"
+        >
           {{ tab.icon }} {{ tab.title }}
         </button>
       </div>
@@ -52,8 +61,8 @@ const tabs = [
 // 开发环境检测
 const isDev = ref(
   process.env.NODE_ENV === 'development' ||
-  (import.meta as any).env?.DEV === true ||
-  window.location.hostname === 'localhost'
+    (import.meta as any).env?.DEV === true ||
+    window.location.hostname === 'localhost'
 )
 
 // 面板状态

--- a/frontend/src/composables/useGameSignAccountApi.ts
+++ b/frontend/src/composables/useGameSignAccountApi.ts
@@ -3,82 +3,85 @@ import { message } from 'ant-design-vue'
 import { Service, type GameSignAccountGroupConfig } from '@/api'
 
 export function useGameSignAccountApi() {
-    const loading = ref(false)
-    const logger = window.electronAPI.getLogger('签到账号API')
+  const loading = ref(false)
+  const logger = window.electronAPI.getLogger('签到账号API')
 
-    /**
-     * 添加账号组
-     */
-    const addAccount = async (): Promise<{ accountId: string; data: GameSignAccountGroupConfig } | null> => {
-        loading.value = true
-        try {
-            const response = await Service.addGameSignAccountApiToolsSignAccountAddPost()
-            if (response.code !== 200) {
-                throw new Error(response.message || '添加账号组失败')
-            }
-            if (!response.accountId || !response.data) {
-                throw new Error('添加账号组失败：服务端响应缺少账号信息')
-            }
-            logger.info('账号组添加成功')
-            return { accountId: response.accountId, data: response.data }
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`添加账号组失败: ${errorMsg}`)
-            message.error('添加账号组失败')
-            return null
-        } finally {
-            loading.value = false
-        }
+  /**
+   * 添加账号组
+   */
+  const addAccount = async (): Promise<{
+    accountId: string
+    data: GameSignAccountGroupConfig
+  } | null> => {
+    loading.value = true
+    try {
+      const response = await Service.addGameSignAccountApiToolsSignAccountAddPost()
+      if (response.code !== 200) {
+        throw new Error(response.message || '添加账号组失败')
+      }
+      if (!response.accountId || !response.data) {
+        throw new Error('添加账号组失败：服务端响应缺少账号信息')
+      }
+      logger.info('账号组添加成功')
+      return { accountId: response.accountId, data: response.data }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`添加账号组失败: ${errorMsg}`)
+      message.error('添加账号组失败')
+      return null
+    } finally {
+      loading.value = false
     }
+  }
 
-    /**
-     * 更新账号组
-     */
-    const updateAccount = async (
-        accountId: string,
-        data: GameSignAccountGroupConfig
-    ): Promise<void> => {
-        try {
-            const response = await Service.updateGameSignAccountApiToolsSignAccountUpdatePost({
-                accountId,
-                data,
-            })
-            if (response.code !== 200) {
-                throw new Error(response.message || '更新账号组失败')
-            }
-            logger.info('账号组更新成功')
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`更新账号组失败: ${errorMsg}`)
-            throw error
-        }
+  /**
+   * 更新账号组
+   */
+  const updateAccount = async (
+    accountId: string,
+    data: GameSignAccountGroupConfig
+  ): Promise<void> => {
+    try {
+      const response = await Service.updateGameSignAccountApiToolsSignAccountUpdatePost({
+        accountId,
+        data,
+      })
+      if (response.code !== 200) {
+        throw new Error(response.message || '更新账号组失败')
+      }
+      logger.info('账号组更新成功')
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`更新账号组失败: ${errorMsg}`)
+      throw error
     }
+  }
 
-    /**
-     * 使用塔吉多账号密码一次性换取并保存 Token。
-     * 密码只在本次请求中存在，不写入前端状态或日志。
-     */
-    const loginTaygedo = async (
-        accountId: string,
-        phone: string,
-        password: string,
-    ): Promise<void> => {
-        try {
-            const response = await Service.loginTaygedoApiToolsSignAccountTaygedoLoginPost({
-                accountId,
-                phone,
-                password,
-            })
-            if (Number(response.code) !== 200 || response.status !== 'success') {
-                throw new Error(response.message || '塔吉多账号密码登录失败')
-            }
-            message.success(response.message || '塔吉多登录成功，Token 已保存')
-        } catch (error) {
-            logger.error('塔吉多账号密码登录失败')
-            message.error(error instanceof Error ? error.message : '塔吉多账号密码登录失败')
-            throw error
-        }
+  /**
+   * 使用塔吉多账号密码一次性换取并保存 Token。
+   * 密码只在本次请求中存在，不写入前端状态或日志。
+   */
+  const loginTaygedo = async (
+    accountId: string,
+    phone: string,
+    password: string
+  ): Promise<void> => {
+    try {
+      const response = await Service.loginTaygedoApiToolsSignAccountTaygedoLoginPost({
+        accountId,
+        phone,
+        password,
+      })
+      if (Number(response.code) !== 200 || response.status !== 'success') {
+        throw new Error(response.message || '塔吉多账号密码登录失败')
+      }
+      message.success(response.message || '塔吉多登录成功，Token 已保存')
+    } catch (error) {
+      logger.error('塔吉多账号密码登录失败')
+      message.error(error instanceof Error ? error.message : '塔吉多账号密码登录失败')
+      throw error
     }
+  }
 
   /**
    * 使用森空岛手机号密码一次性换取并保存凭据。
@@ -102,36 +105,36 @@ export function useGameSignAccountApi() {
     }
   }
 
-    /**
-     * 删除账号组
-     */
-    const deleteAccount = async (accountId: string): Promise<void> => {
-        loading.value = true
-        try {
-            const response = await Service.deleteGameSignAccountApiToolsSignAccountDeletePost({
-                accountId,
-            })
-            if (response.code !== 200) {
-                throw new Error(response.message || '删除账号组失败')
-            }
-            logger.info('账号组删除成功')
-            message.success('账号组已删除')
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`删除账号组失败: ${errorMsg}`)
-            message.error('删除账号组失败')
-            throw error
-        } finally {
-            loading.value = false
-        }
+  /**
+   * 删除账号组
+   */
+  const deleteAccount = async (accountId: string): Promise<void> => {
+    loading.value = true
+    try {
+      const response = await Service.deleteGameSignAccountApiToolsSignAccountDeletePost({
+        accountId,
+      })
+      if (response.code !== 200) {
+        throw new Error(response.message || '删除账号组失败')
+      }
+      logger.info('账号组删除成功')
+      message.success('账号组已删除')
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`删除账号组失败: ${errorMsg}`)
+      message.error('删除账号组失败')
+      throw error
+    } finally {
+      loading.value = false
     }
+  }
 
-    return {
-        loading,
-        addAccount,
-        updateAccount,
-        loginTaygedo,
+  return {
+    loading,
+    addAccount,
+    updateAccount,
+    loginTaygedo,
     loginSkland,
-        deleteAccount,
-    }
+    deleteAccount,
+  }
 }

--- a/frontend/src/composables/useStatusTag.ts
+++ b/frontend/src/composables/useStatusTag.ts
@@ -4,65 +4,65 @@ import { computed, type ComputedRef } from 'vue'
  * 状态标签接口定义
  */
 export interface StatusTag {
-    text: string
-    color: string
+  text: string
+  color: string
 }
 
 /**
  * 通用状态标签解析和管理 Composable
- * 
+ *
  * 该模块提供了一套完整的状态标签（Status Tag）管理方案，用于解析、序列化和显示状态标签。
  * 状态标签通常由后端以JSON字符串格式返回，格式为：{"text": "标签文本", "color": "颜色"}
- * 
+ *
  * 主要功能：
  * - 解析单个或多个状态标签
  * - 序列化标签为JSON字符串
  * - 提供Vue响应式的composable函数
  * - 自动适配深色模式（通过Ant Design Vue的Tag组件）
- * 
+ *
  * 使用示例：
- * 
+ *
  * 1. 基础解析：
  * ```typescript
  * import { parseStatusTag } from '@/composables/useStatusTag'
- * 
+ *
  * const status = '{"text": "运行中", "color": "green"}'
  * const tag = parseStatusTag(status, { text: '未启用', color: 'default' })
  * // 返回: { text: '运行中', color: 'green' }
  * ```
- * 
+ *
  * 2. 在组件中使用（推荐）：
  * ```vue
  * <script setup>
  * import { useStatusTag, createStatusTag } from '@/composables/useStatusTag'
- * 
+ *
  * const statusTag = useStatusTag(
  *   () => config.value.Status,
  *   createStatusTag('未启用', 'default')
  * )
  * </script>
- * 
+ *
  * <template>
  *   <a-tag v-if="statusTag" :color="statusTag.color">
  *     {{ statusTag.text }}
  *   </a-tag>
  * </template>
  * ```
- * 
+ *
  * 3. 解析标签列表：
  * ```typescript
  * import { parseStatusTagList } from '@/composables/useStatusTag'
- * 
+ *
  * const statusList = '[{"text": "状态1", "color": "blue"}, {"text": "状态2", "color": "green"}]'
  * const tags = parseStatusTagList(statusList)
  * // 返回: [{ text: '状态1', color: 'blue' }, { text: '状态2', color: 'green' }]
  * ```
- * 
+ *
  * 支持的颜色值：
  * - Ant Design预设颜色：success, processing, error, warning, default
  * - 标准颜色：blue, green, red, orange, cyan, purple, pink, magenta, volcano, geekblue, lime, gold
  * - 自定义十六进制颜色：#1890ff
- * 
+ *
  * 注意事项：
  * - Ant Design Vue的Tag组件会自动适配深色模式，无需手动处理
  * - 后端返回的Status字段应为JSON字符串或'-'（表示使用默认值）
@@ -76,27 +76,27 @@ export interface StatusTag {
  * @returns StatusTag对象或null
  */
 export function parseStatusTag(
-    status: string | null | undefined,
-    defaultTag: StatusTag | null = null
+  status: string | null | undefined,
+  defaultTag: StatusTag | null = null
 ): StatusTag | null {
-    if (!status) return defaultTag
+  if (!status) return defaultTag
 
-    if (status === '-') {
-        return defaultTag
-    }
+  if (status === '-') {
+    return defaultTag
+  }
 
-    try {
-        const tag = JSON.parse(status) as StatusTag
-        // 确保必需字段存在
-        if (!tag.text) {
-            console.warn('解析状态标签时缺少text字段:', status)
-            return defaultTag
-        }
-        return tag
-    } catch (error) {
-        console.error('解析状态标签失败:', error, 'status=', status)
-        return defaultTag || { text: '未知', color: 'default' }
+  try {
+    const tag = JSON.parse(status) as StatusTag
+    // 确保必需字段存在
+    if (!tag.text) {
+      console.warn('解析状态标签时缺少text字段:', status)
+      return defaultTag
     }
+    return tag
+  } catch (error) {
+    console.error('解析状态标签失败:', error, 'status=', status)
+    return defaultTag || { text: '未知', color: 'default' }
+  }
 }
 
 /**
@@ -106,48 +106,48 @@ export function parseStatusTag(
  * @returns StatusTag对象数组
  */
 export function parseStatusTagList(
-    statusList: string | string[] | null | undefined,
-    defaultTags: StatusTag[] = []
+  statusList: string | string[] | null | undefined,
+  defaultTags: StatusTag[] = []
 ): StatusTag[] {
-    if (!statusList) {
+  if (!statusList) {
+    return defaultTags
+  }
+
+  try {
+    // 如果是字符串，尝试解析
+    if (typeof statusList === 'string') {
+      if (statusList === '-') {
         return defaultTags
+      }
+
+      const parsed = JSON.parse(statusList)
+
+      // 如果解析结果是数组
+      if (Array.isArray(parsed)) {
+        return parsed.filter((tag): tag is StatusTag => {
+          return tag && typeof tag.text === 'string'
+        })
+      }
+
+      // 如果解析结果是单个对象
+      if (parsed && typeof parsed.text === 'string') {
+        return [parsed as StatusTag]
+      }
+
+      return defaultTags
     }
 
-    try {
-        // 如果是字符串，尝试解析
-        if (typeof statusList === 'string') {
-            if (statusList === '-') {
-                return defaultTags
-            }
-
-            const parsed = JSON.parse(statusList)
-
-            // 如果解析结果是数组
-            if (Array.isArray(parsed)) {
-                return parsed.filter((tag): tag is StatusTag => {
-                    return tag && typeof tag.text === 'string'
-                })
-            }
-
-            // 如果解析结果是单个对象
-            if (parsed && typeof parsed.text === 'string') {
-                return [parsed as StatusTag]
-            }
-
-            return defaultTags
-        }
-
-        // 如果已经是数组，处理每个元素
-        if (Array.isArray(statusList)) {
-            return statusList
-                .map(item => parseStatusTag(item, null))
-                .filter((tag): tag is StatusTag => tag !== null)
-        }
-
-        return defaultTags
-    } catch {
-        return defaultTags
+    // 如果已经是数组，处理每个元素
+    if (Array.isArray(statusList)) {
+      return statusList
+        .map(item => parseStatusTag(item, null))
+        .filter((tag): tag is StatusTag => tag !== null)
     }
+
+    return defaultTags
+  } catch {
+    return defaultTags
+  }
 }
 
 /**
@@ -156,7 +156,7 @@ export function parseStatusTagList(
  * @returns JSON字符串
  */
 export function serializeStatusTag(tag: StatusTag): string {
-    return JSON.stringify(tag)
+  return JSON.stringify(tag)
 }
 
 /**
@@ -165,7 +165,7 @@ export function serializeStatusTag(tag: StatusTag): string {
  * @returns JSON字符串
  */
 export function serializeStatusTagList(tags: StatusTag[]): string {
-    return JSON.stringify(tags)
+  return JSON.stringify(tags)
 }
 
 /**
@@ -175,10 +175,10 @@ export function serializeStatusTagList(tags: StatusTag[]): string {
  * @returns 计算属性，返回解析后的StatusTag或null
  */
 export function useStatusTag(
-    statusGetter: () => string | null | undefined,
-    defaultTag: StatusTag | null = null
+  statusGetter: () => string | null | undefined,
+  defaultTag: StatusTag | null = null
 ): ComputedRef<StatusTag | null> {
-    return computed(() => parseStatusTag(statusGetter(), defaultTag))
+  return computed(() => parseStatusTag(statusGetter(), defaultTag))
 }
 
 /**
@@ -188,10 +188,10 @@ export function useStatusTag(
  * @returns 计算属性，返回解析后的StatusTag数组
  */
 export function useStatusTagList(
-    statusListGetter: () => string | string[] | null | undefined,
-    defaultTags: StatusTag[] = []
+  statusListGetter: () => string | string[] | null | undefined,
+  defaultTags: StatusTag[] = []
 ): ComputedRef<StatusTag[]> {
-    return computed(() => parseStatusTagList(statusListGetter(), defaultTags))
+  return computed(() => parseStatusTagList(statusListGetter(), defaultTags))
 }
 
 /**
@@ -204,5 +204,5 @@ export function useStatusTagList(
  * createStatusTag('已停止', '#ff0000')
  */
 export function createStatusTag(text: string, color: string): StatusTag {
-    return { text, color }
+  return { text, color }
 }

--- a/frontend/src/composables/useVersionService.ts
+++ b/frontend/src/composables/useVersionService.ts
@@ -22,79 +22,81 @@ const isTitlebarPolling = ref(false)
  * 获取前端版本和更新信息（用于标题栏显示）
  */
 const getAppVersion = async () => {
-    try {
-        const ver = await requestUpdateCheck(false)
-        updateInfo.value = ver
-        return ver
-    } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`获取前端版本失败: ${errorMsg}`)
-        return null
-    }
+  try {
+    const ver = await requestUpdateCheck(false)
+    updateInfo.value = ver
+    return ver
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`获取前端版本失败: ${errorMsg}`)
+    return null
+  }
 }
 
 /**
  * 获取后端版本信息（用于标题栏显示）
  */
 export const getBackendVersion = async () => {
-    try {
-        backendUpdateInfo.value = await Service.getGitVersionApiInfoVersionPost()
-    } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`获取后端版本失败: ${errorMsg}`)
-    }
+  try {
+    backendUpdateInfo.value = await Service.getGitVersionApiInfoVersionPost()
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`获取后端版本失败: ${errorMsg}`)
+  }
 }
 
 /**
  * 执行一次标题栏版本信息检查
  */
 const pollTitlebarVersionOnce = async () => {
-    if (isTitlebarPolling.value) return
-    isTitlebarPolling.value = true
+  if (isTitlebarPolling.value) return
+  isTitlebarPolling.value = true
 
-    try {
-        const [appRes, backendRes] = await Promise.allSettled([getAppVersion(), getBackendVersion()])
+  try {
+    const [appRes, backendRes] = await Promise.allSettled([getAppVersion(), getBackendVersion()])
 
-        if (appRes.status === 'rejected') {
-            const errorMsg = appRes.reason instanceof Error ? appRes.reason.message : String(appRes.reason)
-            logger.error(`获取前端版本失败: ${errorMsg}`)
-        }
-        if (backendRes.status === 'rejected') {
-            const errorMsg = backendRes.reason instanceof Error ? backendRes.reason.message : String(backendRes.reason)
-            logger.error(`获取后端版本失败: ${errorMsg}`)
-        }
-    } finally {
-        isTitlebarPolling.value = false
+    if (appRes.status === 'rejected') {
+      const errorMsg =
+        appRes.reason instanceof Error ? appRes.reason.message : String(appRes.reason)
+      logger.error(`获取前端版本失败: ${errorMsg}`)
     }
+    if (backendRes.status === 'rejected') {
+      const errorMsg =
+        backendRes.reason instanceof Error ? backendRes.reason.message : String(backendRes.reason)
+      logger.error(`获取后端版本失败: ${errorMsg}`)
+    }
+  } finally {
+    isTitlebarPolling.value = false
+  }
 }
 
 /**
  * 启动标题栏版本信息定时检查（10分钟一次）
  */
 export const startTitlebarVersionCheck = () => {
-    if (titlebarPollTimer) {
-        logger.warn('标题栏版本检查定时器已存在，跳过启动')
-        return
-    }
+  if (titlebarPollTimer) {
+    logger.warn('标题栏版本检查定时器已存在，跳过启动')
+    return
+  }
 
-    logger.info('启动标题栏版本信息定时检查（每10分钟）')
+  logger.info('启动标题栏版本信息定时检查（每10分钟）')
 
-    // 首次检查在后台执行，不阻塞应用进入主页
-    void pollTitlebarVersionOnce()
+  // 首次检查在后台执行，不阻塞应用进入主页
+  void pollTitlebarVersionOnce()
 
-    // 启动定时器
-    titlebarPollTimer = window.setInterval(pollTitlebarVersionOnce, TITLEBAR_POLL_MS)
+  // 启动定时器
+  titlebarPollTimer = window.setInterval(pollTitlebarVersionOnce, TITLEBAR_POLL_MS)
 }
 
 /**
  * 停止标题栏版本信息定时检查
  */
 export const stopTitlebarVersionCheck = () => {
-    if (titlebarPollTimer) {
-        clearInterval(titlebarPollTimer)
-        titlebarPollTimer = null
-        logger.info('停止标题栏版本信息定时检查')
-    }
+  if (titlebarPollTimer) {
+    clearInterval(titlebarPollTimer)
+    titlebarPollTimer = null
+    logger.info('停止标题栏版本信息定时检查')
+  }
 }
 
 // ========== 版本更新检查相关（4小时）==========

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -243,5 +243,11 @@ export interface ElectronAPI {
 declare global {
   interface Window {
     electronAPI: ElectronAPI
+    /** 调试用:由 WebSocketMessageListener 挂载的消息弹窗触发接口 */
+    __debugShowQuestion?: (questionData: Record<string, unknown>) => Promise<void>
+    /** 调试用:调度中心调试信息输出 */
+    debugScheduler?: () => void
+    /** 调试用:WebSocket 连接测试 */
+    testWebSocketConnection?: () => Promise<void>
   }
 }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -1,75 +1,75 @@
 // 自定义Webhook配置
 export interface CustomWebhook {
-    id: string
-    name: string
-    url: string
-    template: string
-    enabled: boolean
-    headers?: Record<string, string>
-    method?: 'POST' | 'GET'
+  id: string
+  name: string
+  url: string
+  template: string
+  enabled: boolean
+  headers?: Record<string, string>
+  method?: 'POST' | 'GET'
 }
 
 // 设置相关类型定义
 export interface SettingsData {
-    UI: {
-        IfShowTray: boolean
-        IfToTray: boolean
-        IfHideCloseButton: boolean
-    }
-    Function: {
-        HistoryRetentionTime: number
-        IfAgreeBilibili: boolean
-        IfAllowSleep: boolean
-        IfSilence: boolean
-        IfBlockAd: boolean
-    }
-    Notify: {
-        SendTaskResultTime: string
-        IfSendStatistic: boolean
-        IfSendSixStar: boolean
-        IfPushPlyer: boolean
-        IfSendMail: boolean
-        IfKoishiSupport: boolean
-        KoishiServerAddress: string
-        KoishiToken: string
-        SMTPServerAddress: string
-        AuthorizationCode: string
-        FromAddress: string
-        ToAddress: string
-        IfServerChan: boolean
-        ServerChanKey: string
-        ServerChanChannel: string
-        ServerChanTag: string
-        CustomWebhooks: CustomWebhook[]
-    }
-    Update: {
-        IfAutoUpdate: boolean
-        Source: string
-        Channel: string
-        ProxyAddress: string
-        MirrorChyanCDK: string
-    }
-    Start: {
-        IfSelfStart: boolean
-        IfMinimizeDirectly: boolean
-    }
-    Voice: {
-        Enabled: boolean
-        Type: string
-    }
+  UI: {
+    IfShowTray: boolean
+    IfToTray: boolean
+    IfHideCloseButton: boolean
+  }
+  Function: {
+    HistoryRetentionTime: number
+    IfAgreeBilibili: boolean
+    IfAllowSleep: boolean
+    IfSilence: boolean
+    IfBlockAd: boolean
+  }
+  Notify: {
+    SendTaskResultTime: string
+    IfSendStatistic: boolean
+    IfSendSixStar: boolean
+    IfPushPlyer: boolean
+    IfSendMail: boolean
+    IfKoishiSupport: boolean
+    KoishiServerAddress: string
+    KoishiToken: string
+    SMTPServerAddress: string
+    AuthorizationCode: string
+    FromAddress: string
+    ToAddress: string
+    IfServerChan: boolean
+    ServerChanKey: string
+    ServerChanChannel: string
+    ServerChanTag: string
+    CustomWebhooks: CustomWebhook[]
+  }
+  Update: {
+    IfAutoUpdate: boolean
+    Source: string
+    Channel: string
+    ProxyAddress: string
+    MirrorChyanCDK: string
+  }
+  Start: {
+    IfSelfStart: boolean
+    IfMinimizeDirectly: boolean
+  }
+  Voice: {
+    Enabled: boolean
+    Type: string
+  }
 }
 
 // 获取设置API响应
 export interface GetSettingsResponse {
-    code: number
-    status: string
-    message: string
-    data: SettingsData
+  code: number
+  status: string
+  message: string
+  data: SettingsData
 }
 
 // 更新设置API响应
 export interface UpdateSettingsResponse {
-    code: number
-    status: string
-    message: string
+  code: number
+  status: string
+  message: string
 }

--- a/frontend/src/views/EditView/Script/GeneralScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/GeneralScriptEdit.vue
@@ -53,8 +53,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.name" placeholder="请输入脚本名称" size="large" class="modern-input"
-                  @blur="handleChange('Info', 'Name', formData.name)" />
+                <a-input
+                  v-model:value="formData.name"
+                  placeholder="请输入脚本名称"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Info', 'Name', formData.name)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="16">
@@ -68,8 +73,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.rootPath" placeholder="请选择脚本根目录" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.rootPath"
+                    placeholder="请选择脚本根目录"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectRootPath">
                     <template #icon>
                       <FolderOpenOutlined />
@@ -99,8 +109,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.scriptPath" placeholder="请选择脚本主程序文件" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.scriptPath"
+                    placeholder="请选择脚本主程序文件"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectScriptPath">
                     <template #icon>
                       <FileOutlined />
@@ -120,8 +135,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="generalConfig.Script.Arguments" placeholder="请输入脚本启动参数" size="large"
-                  class="modern-input" @blur="handleChange('Script', 'Arguments', generalConfig.Script.Arguments)" />
+                <a-input
+                  v-model:value="generalConfig.Script.Arguments"
+                  placeholder="请输入脚本启动参数"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Script', 'Arguments', generalConfig.Script.Arguments)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="6">
@@ -134,8 +154,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Script.IfTrackProcess" size="large"
-                  @change="handleChange('Script', 'IfTrackProcess', $event)">
+                <a-select
+                  v-model:value="generalConfig.Script.IfTrackProcess"
+                  size="large"
+                  @change="handleChange('Script', 'IfTrackProcess', $event)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -147,27 +170,36 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="要追踪的进程名称，打开脚本后启动任务管理器，在目标脚本进程右键，选择转到详细信息，填入名称栏中的内容即可，无法确认时可以留空">
+                  <a-tooltip
+                    title="要追踪的进程名称，打开脚本后启动任务管理器，在目标脚本进程右键，选择转到详细信息，填入名称栏中的内容即可，无法确认时可以留空"
+                  >
                     <span class="form-label">
                       被追踪进程的名称
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="generalConfig.Script.TrackProcessName" placeholder="请输入要追踪的进程名称" size="large"
-                  class="modern-input" @blur="
+                <a-input
+                  v-model:value="generalConfig.Script.TrackProcessName"
+                  placeholder="请输入要追踪的进程名称"
+                  size="large"
+                  class="modern-input"
+                  @blur="
                     handleChange(
                       'Script',
                       'TrackProcessName',
                       generalConfig.Script.TrackProcessName
                     )
-                    " />
+                  "
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="要追踪的进程可执行文件路径，打开脚本后启动任务管理器，在目标脚本进程右键，选择「打开文件所在位置」，即可定位到可执行文件路径，无法确认时可以留空">
+                  <a-tooltip
+                    title="要追踪的进程可执行文件路径，打开脚本后启动任务管理器，在目标脚本进程右键，选择「打开文件所在位置」，即可定位到可执行文件路径，无法确认时可以留空"
+                  >
                     <span class="form-label">
                       被追踪进程的文件路径
                       <QuestionCircleOutlined class="help-icon" />
@@ -175,15 +207,25 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="generalConfig.Script.TrackProcessExe" placeholder="请选择进程可执行文件路径" size="large"
-                    class="path-input" readonly />
+                  <a-input
+                    v-model:value="generalConfig.Script.TrackProcessExe"
+                    placeholder="请选择进程可执行文件路径"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectTrackProcessExe">
                     <template #icon>
                       <FileOutlined />
                     </template>
                     选择文件
                   </a-button>
-                  <a-button size="large" class="path-clear-icon-btn" aria-label="清空路径" @click="clearTrackProcessExe">
+                  <a-button
+                    size="large"
+                    class="path-clear-icon-btn"
+                    aria-label="清空路径"
+                    @click="clearTrackProcessExe"
+                  >
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -195,21 +237,27 @@
               <a-form-item>
                 <template #label>
                   <a-tooltip
-                    title="要追踪的进程启动命令行参数，打开脚本后启动任务管理器，在目标脚本进程右键，选择「转到详细信息」，填入命令行栏中的内容即可，命令行栏不存在可以在标题栏右键，选择「选择列」，勾选命令行，无法确认时可以留空">
+                    title="要追踪的进程启动命令行参数，打开脚本后启动任务管理器，在目标脚本进程右键，选择「转到详细信息」，填入命令行栏中的内容即可，命令行栏不存在可以在标题栏右键，选择「选择列」，勾选命令行，无法确认时可以留空"
+                  >
                     <span class="form-label">
                       追踪进程命令行参数
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="generalConfig.Script.TrackProcessCmdline" placeholder="请输入进程启动命令行参数"
-                  size="large" class="modern-input" @blur="
+                <a-input
+                  v-model:value="generalConfig.Script.TrackProcessCmdline"
+                  placeholder="请输入进程启动命令行参数"
+                  size="large"
+                  class="modern-input"
+                  @blur="
                     handleChange(
                       'Script',
                       'TrackProcessCmdline',
                       generalConfig.Script.TrackProcessCmdline
                     )
-                    " />
+                  "
+                />
               </a-form-item>
             </a-col>
           </a-row>
@@ -217,10 +265,13 @@
             <a-col :span="12">
               <a-form-item name="configPath" :rules="rules.configPath">
                 <template #label>
-                  <a-tooltip :title="generalConfig.Script.ConfigPathMode === 'Folder'
-                    ? '脚本配置文件所在的文件夹路径'
-                    : '脚本配置文件的路径'
-                    ">
+                  <a-tooltip
+                    :title="
+                      generalConfig.Script.ConfigPathMode === 'Folder'
+                        ? '脚本配置文件所在的文件夹路径'
+                        : '脚本配置文件的路径'
+                    "
+                  >
                     <span class="form-label">
                       配置文件路径
                       <QuestionCircleOutlined class="help-icon" />
@@ -228,10 +279,17 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.configPath" :placeholder="generalConfig.Script.ConfigPathMode === 'Folder'
-                    ? '请选择配置文件夹'
-                    : '请选择配置文件'
-                    " size="large" class="path-input" readonly />
+                  <a-input
+                    v-model:value="formData.configPath"
+                    :placeholder="
+                      generalConfig.Script.ConfigPathMode === 'Folder'
+                        ? '请选择配置文件夹'
+                        : '请选择配置文件'
+                    "
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectConfigPath">
                     <template #icon>
                       <FolderOpenOutlined v-if="generalConfig.Script.ConfigPathMode === 'Folder'" />
@@ -254,8 +312,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Script.ConfigPathMode" size="large"
-                  @change="handleChange('Script', 'ConfigPathMode', $event)">
+                <a-select
+                  v-model:value="generalConfig.Script.ConfigPathMode"
+                  size="large"
+                  @change="handleChange('Script', 'ConfigPathMode', $event)"
+                >
                   <a-select-option value="File">单文件</a-select-option>
                   <a-select-option value="Folder">文件夹</a-select-option>
                 </a-select>
@@ -271,8 +332,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Script.UpdateConfigMode" size="large"
-                  @change="handleChange('Script', 'UpdateConfigMode', $event)">
+                <a-select
+                  v-model:value="generalConfig.Script.UpdateConfigMode"
+                  size="large"
+                  @change="handleChange('Script', 'UpdateConfigMode', $event)"
+                >
                   <a-select-option value="Never">从不</a-select-option>
                   <a-select-option value="Success">成功时</a-select-option>
                   <a-select-option value="Failure">失败时</a-select-option>
@@ -293,8 +357,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.logPath" placeholder="请选择日志文件" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.logPath"
+                    placeholder="请选择日志文件"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectLogPath">
                     <template #icon>
                       <FolderOpenOutlined />
@@ -309,26 +378,39 @@
                 <template #label>
                   <span class="form-label">
                     日志文件名格式
-                    <a-tooltip title="指示实时生成日志文件名的格式（strptime 格式），文件名固定时留空">
+                    <a-tooltip
+                      title="指示实时生成日志文件名的格式（strptime 格式），文件名固定时留空"
+                    >
                       <QuestionCircleOutlined class="help-icon" />
                     </a-tooltip>
-                    <a-tooltip title="针对 mxu 按日期+自增序号命名的日志：末尾加 ****** 启用mxu日志前缀匹配（如 %Y-%m-%d******）">
-                      <QuestionCircleOutlined class="help-icon" style="margin-left: 2px;" />
+                    <a-tooltip
+                      title="针对 mxu 按日期+自增序号命名的日志：末尾加 ****** 启用mxu日志前缀匹配（如 %Y-%m-%d******）"
+                    >
+                      <QuestionCircleOutlined class="help-icon" style="margin-left: 2px" />
                     </a-tooltip>
                   </span>
                 </template>
-                <a-input v-model:value="generalConfig.Script.LogPathFormat" placeholder="日志文件名格式，文件名固定时留空" size="large"
-                  class="modern-input" @blur="
+                <a-input
+                  v-model:value="generalConfig.Script.LogPathFormat"
+                  placeholder="日志文件名格式，文件名固定时留空"
+                  size="large"
+                  class="modern-input"
+                  @blur="
                     handleChange('Script', 'LogPathFormat', generalConfig.Script.LogPathFormat)
-                    " />
+                  "
+                />
               </a-form-item>
             </a-col>
           </a-row>
 
           <a-row :gutter="24">
             <a-col :span="12">
-              <LogTimestampSelector v-model:form-data="formData" :log-file-path="formData.logPath"
-                :handle-change="handleChange" :rules="rules" />
+              <LogTimestampSelector
+                v-model:form-data="formData"
+                :log-file-path="formData.logPath"
+                :handle-change="handleChange"
+                :rules="rules"
+              />
             </a-col>
             <a-col :span="12">
               <a-form-item name="logTimeFormat" :rules="rules.logTimeFormat">
@@ -340,13 +422,19 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.logTimeFormat" placeholder="请输入脚本日志时间戳格式" size="large"
-                  class="modern-input" @blur="handleChange('Script', 'LogTimeFormat', formData.logTimeFormat)" />
+                <a-input
+                  v-model:value="formData.logTimeFormat"
+                  placeholder="请输入脚本日志时间戳格式"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Script', 'LogTimeFormat', formData.logTimeFormat)"
+                />
                 <div class="format-preview">
                   示例：<span class="format-preview-value">{{ logTimeFormatPreview }}</span>
                 </div>
                 <div v-if="hasFractionalSecondToken" class="format-preview-tip">
-                  提示：%f 同时支持 3 位毫秒（如 123）和 6 位微秒（如 123456），会按日志中的位数自动识别。
+                  提示：%f 同时支持 3 位毫秒（如 123）和 6 位微秒（如
+                  123456），会按日志中的位数自动识别。
                 </div>
               </a-form-item>
             </a-col>
@@ -357,15 +445,21 @@
               <a-form-item>
                 <template #label>
                   <a-tooltip
-                    title="若填写，且日志文本信息中任意任务成功日志先于任务异常日志出现，则视为任务成功，否则若脚本进程结束时，日志文本信息中不存在任何任务成功日志，则视为任务失败；若留空，且在脚本进程结束时，日志文本信息中不存在任意任务异常日志，则视为任务成功">
+                    title="若填写，且日志文本信息中任意任务成功日志先于任务异常日志出现，则视为任务成功，否则若脚本进程结束时，日志文本信息中不存在任何任务成功日志，则视为任务失败；若留空，且在脚本进程结束时，日志文本信息中不存在任意任务异常日志，则视为任务成功"
+                  >
                     <span class="form-label">
                       任务成功日志
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="generalConfig.Script.SuccessLog" placeholder="请输入脚本成功日志，以「 | 」进行分割" size="large"
-                  class="modern-input" @blur="handleChange('Script', 'SuccessLog', generalConfig.Script.SuccessLog)" />
+                <a-input
+                  v-model:value="generalConfig.Script.SuccessLog"
+                  placeholder="请输入脚本成功日志，以「 | 」进行分割"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Script', 'SuccessLog', generalConfig.Script.SuccessLog)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="12">
@@ -378,8 +472,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.errorLog" placeholder="请输入脚本失败日志，以「 | 」进行分割" size="large"
-                  class="modern-input" @blur="handleChange('Script', 'ErrorLog', formData.errorLog)" />
+                <a-input
+                  v-model:value="formData.errorLog"
+                  placeholder="请输入脚本失败日志，以「 | 」进行分割"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Script', 'ErrorLog', formData.errorLog)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
@@ -401,8 +500,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Game.Enabled" size="large"
-                  @change="handleChange('Game', 'Enabled', $event)">
+                <a-select
+                  v-model:value="generalConfig.Game.Enabled"
+                  size="large"
+                  @change="handleChange('Game', 'Enabled', $event)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -418,7 +520,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Game.Type" size="large" @change="handleGameTypeChange">
+                <a-select
+                  v-model:value="generalConfig.Game.Type"
+                  size="large"
+                  @change="handleGameTypeChange"
+                >
                   <a-select-option value="Emulator">模拟器</a-select-option>
                   <a-select-option value="Client">PC客户端</a-select-option>
                   <a-select-option value="URL">URL协议(如Starward)</a-select-option>
@@ -437,8 +543,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="generalConfig.Game.Path" placeholder="请选择游戏的可执行文件" size="large"
-                    class="path-input" readonly />
+                  <a-input
+                    v-model:value="generalConfig.Game.Path"
+                    placeholder="请选择游戏的可执行文件"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectGamePath">
                     <template #icon>
                       <FileOutlined />
@@ -459,9 +570,18 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Game.EmulatorId" size="large" placeholder="请选择模拟器"
-                  :loading="emulatorLoading" @change="handleEmulatorChange">
-                  <a-select-option v-for="item in emulatorOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-model:value="generalConfig.Game.EmulatorId"
+                  size="large"
+                  placeholder="请选择模拟器"
+                  :loading="emulatorLoading"
+                  @change="handleEmulatorChange"
+                >
+                  <a-select-option
+                    v-for="item in emulatorOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -479,8 +599,12 @@
                   </a-tooltip>
                 </template>
                 <a-input-group class="path-input-group">
-                  <a-input v-model:value="generalConfig.Game.URL" placeholder="请输入URL参数，如：starward://startgame/xxxx"
-                    size="large" @blur="handleChange('Game', 'URL', generalConfig.Game.URL)" />
+                  <a-input
+                    v-model:value="generalConfig.Game.URL"
+                    placeholder="请输入URL参数，如：starward://startgame/xxxx"
+                    size="large"
+                    @blur="handleChange('Game', 'URL', generalConfig.Game.URL)"
+                  />
                 </a-input-group>
               </a-form-item>
             </a-col>
@@ -488,10 +612,13 @@
             <a-col v-if="generalConfig.Game.Type === 'Emulator'" :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip :title="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading
-                    ? '不支持自动扫描实例的模拟器，请手动输入实例信息'
-                    : '选择模拟器的具体实例'
-                    ">
+                  <a-tooltip
+                    :title="
+                      emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading
+                        ? '不支持自动扫描实例的模拟器，请手动输入实例信息'
+                        : '选择模拟器的具体实例'
+                    "
+                  >
                     <span class="form-label">
                       模拟器实例
                       <QuestionCircleOutlined class="help-icon" />
@@ -499,18 +626,33 @@
                   </a-tooltip>
                 </template>
                 <!-- 当API返回空列表时显示输入框 -->
-                <a-input v-if="
-                  emulatorDeviceOptions.length === 0 &&
-                  !emulatorDeviceLoading &&
-                  generalConfig.Game.EmulatorId
-                " v-model:value="generalConfig.Game.EmulatorIndex" size="large" placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
+                <a-input
+                  v-if="
+                    emulatorDeviceOptions.length === 0 &&
+                    !emulatorDeviceLoading &&
+                    generalConfig.Game.EmulatorId
+                  "
+                  v-model:value="generalConfig.Game.EmulatorIndex"
+                  size="large"
+                  placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
                   class="modern-input"
-                  @blur="handleChange('Game', 'EmulatorIndex', generalConfig.Game.EmulatorIndex)" />
+                  @blur="handleChange('Game', 'EmulatorIndex', generalConfig.Game.EmulatorIndex)"
+                />
                 <!-- 正常情况下显示下拉框 -->
-                <a-select v-else v-model:value="generalConfig.Game.EmulatorIndex" size="large" placeholder="请先选择模拟器"
-                  :loading="emulatorDeviceLoading" :disabled="!generalConfig.Game.EmulatorId"
-                  @change="handleChange('Game', 'EmulatorIndex', $event)">
-                  <a-select-option v-for="item in emulatorDeviceOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-else
+                  v-model:value="generalConfig.Game.EmulatorIndex"
+                  size="large"
+                  placeholder="请先选择模拟器"
+                  :loading="emulatorDeviceLoading"
+                  :disabled="!generalConfig.Game.EmulatorId"
+                  @change="handleChange('Game', 'EmulatorIndex', $event)"
+                >
+                  <a-select-option
+                    v-for="item in emulatorDeviceOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -530,8 +672,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="generalConfig.Game.Arguments" placeholder="请输入启动参数" size="large"
-                  class="modern-input" @blur="handleChange('Game', 'Arguments', generalConfig.Game.Arguments)" />
+                <a-input
+                  v-model:value="generalConfig.Game.Arguments"
+                  placeholder="请输入启动参数"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Game', 'Arguments', generalConfig.Game.Arguments)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -544,9 +691,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="generalConfig.Game.WaitTime" :min="0" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Game', 'WaitTime', generalConfig.Game.WaitTime)" />
+                <a-input-number
+                  v-model:value="generalConfig.Game.WaitTime"
+                  :min="0"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Game', 'WaitTime', generalConfig.Game.WaitTime)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -559,8 +712,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="generalConfig.Game.IfForceClose" size="large"
-                  @change="handleChange('Game', 'IfForceClose', $event)">
+                <a-select
+                  v-model:value="generalConfig.Game.IfForceClose"
+                  size="large"
+                  @change="handleChange('Game', 'IfForceClose', $event)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -574,15 +730,22 @@
           <a-col :span="8">
             <a-form-item>
               <template #label>
-                <a-tooltip title="进程名称，如StarRail.exe，必须填写否则可能无法正确监测进程状态。开启游戏后，打开任务管理器查看程序详细信息即可获得。">
+                <a-tooltip
+                  title="进程名称，如StarRail.exe，必须填写否则可能无法正确监测进程状态。开启游戏后，打开任务管理器查看程序详细信息即可获得。"
+                >
                   <span class="form-label">
                     进程名称
                     <QuestionCircleOutlined class="help-icon" />
                   </span>
                 </a-tooltip>
               </template>
-              <a-input v-model:value="generalConfig.Game.ProcessName" placeholder="比如 StarRail.exe" size="large"
-                class="modern-input" @blur="handleChange('Game', 'ProcessName', generalConfig.Game.ProcessName)" />
+              <a-input
+                v-model:value="generalConfig.Game.ProcessName"
+                placeholder="比如 StarRail.exe"
+                size="large"
+                class="modern-input"
+                @blur="handleChange('Game', 'ProcessName', generalConfig.Game.ProcessName)"
+              />
             </a-form-item>
           </a-col>
         </a-row>
@@ -595,16 +758,24 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限">
+                  <a-tooltip
+                    title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限"
+                  >
                     <span class="form-label">
                       单日代理次数上限
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="generalConfig.Run.ProxyTimesLimit" :min="0" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'ProxyTimesLimit', generalConfig.Run.ProxyTimesLimit)" />
+                <a-input-number
+                  v-model:value="generalConfig.Run.ProxyTimesLimit"
+                  :min="0"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'ProxyTimesLimit', generalConfig.Run.ProxyTimesLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -617,9 +788,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="generalConfig.Run.RunTimesLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimesLimit', generalConfig.Run.RunTimesLimit)" />
+                <a-input-number
+                  v-model:value="generalConfig.Run.RunTimesLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimesLimit', generalConfig.Run.RunTimesLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -632,9 +809,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="generalConfig.Run.RunTimeLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimeLimit', generalConfig.Run.RunTimeLimit)" />
+                <a-input-number
+                  v-model:value="generalConfig.Run.RunTimeLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimeLimit', generalConfig.Run.RunTimeLimit)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
@@ -644,29 +827,61 @@
   </div>
 
   <!-- 上传脚本弹窗 -->
-  <a-modal v-model:open="uploadModalVisible" title="上传脚本配置到云端" :confirm-loading="uploadLoading" width="600px"
-    :mask-closable="false" @ok="handleUpload" @cancel="handleUploadCancel">
-    <a-form ref="uploadFormRef" :model="uploadForm" :rules="uploadRules" layout="vertical" class="upload-form">
+  <a-modal
+    v-model:open="uploadModalVisible"
+    title="上传脚本配置到云端"
+    :confirm-loading="uploadLoading"
+    width="600px"
+    :mask-closable="false"
+    @ok="handleUpload"
+    @cancel="handleUploadCancel"
+  >
+    <a-form
+      ref="uploadFormRef"
+      :model="uploadForm"
+      :rules="uploadRules"
+      layout="vertical"
+      class="upload-form"
+    >
       <a-form-item name="config_name" label="配置名称">
-        <a-input v-model:value="uploadForm.config_name" placeholder="为您的脚本配置起一个易于识别的名称" size="large" :maxlength="50"
-          show-count class="modern-input" />
+        <a-input
+          v-model:value="uploadForm.config_name"
+          placeholder="为您的脚本配置起一个易于识别的名称"
+          size="large"
+          :maxlength="50"
+          show-count
+          class="modern-input"
+        />
       </a-form-item>
 
       <a-form-item name="author" label="作者">
-        <a-input v-model:value="uploadForm.author" placeholder="请输入作者名称" size="large" :maxlength="30" show-count
-          class="modern-input" />
+        <a-input
+          v-model:value="uploadForm.author"
+          placeholder="请输入作者名称"
+          size="large"
+          :maxlength="30"
+          show-count
+          class="modern-input"
+        />
       </a-form-item>
 
       <a-form-item name="description" label="描述">
-        <a-textarea v-model:value="uploadForm.description" placeholder="请简要描述该脚本配置的功能、适用场景等信息" size="large" :rows="4"
-          :maxlength="200" show-count class="modern-textarea" />
+        <a-textarea
+          v-model:value="uploadForm.description"
+          placeholder="请简要描述该脚本配置的功能、适用场景等信息"
+          size="large"
+          :rows="4"
+          :maxlength="200"
+          show-count
+          class="modern-textarea"
+        />
       </a-form-item>
 
       <a-alert message="分享说明" type="info">
         <template #description>
           <p>
-            所有<span style="font-weight: bold"> 敏感信息
-            </span>均会在上传前自动移除，上传内容仅包含脚本配置的非敏感信息。上传且通过审核后，其他用户可以下载并使用您的脚本配置。请确保配置信息准确且描述清晰。
+            所有<span style="font-weight: bold"> 敏感信息 </span
+            >均会在上传前自动移除，上传内容仅包含脚本配置的非敏感信息。上传且通过审核后，其他用户可以下载并使用您的脚本配置。请确保配置信息准确且描述清晰。
           </p>
         </template>
       </a-alert>
@@ -1509,10 +1724,7 @@ const selectRootPath = async () => {
         if (generalConfig.Script.LogPath && generalConfig.Script.LogPath !== '.') {
           scriptPathUpdates.LogPath = generalConfig.Script.LogPath
         }
-        if (
-          generalConfig.Script.TrackProcessExe &&
-          generalConfig.Script.TrackProcessExe !== '.'
-        ) {
+        if (generalConfig.Script.TrackProcessExe && generalConfig.Script.TrackProcessExe !== '.') {
           scriptPathUpdates.TrackProcessExe = generalConfig.Script.TrackProcessExe
         }
 
@@ -2195,7 +2407,9 @@ html.dark .modern-number-input :deep(.ant-input-number-focused) {
 
 .format-preview-value {
   color: var(--ant-color-text);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
 }
 
 .format-preview-tip {

--- a/frontend/src/views/EditView/Script/M9AScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/M9AScriptEdit.vue
@@ -46,8 +46,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.name" placeholder="请输入脚本名称" size="large" class="modern-input"
-                  @blur="handleChange('Info', 'Name', formData.name)" />
+                <a-input
+                  v-model:value="formData.name"
+                  placeholder="请输入脚本名称"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Info', 'Name', formData.name)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="16">
@@ -61,8 +66,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.path" placeholder="请选择M9A所在的文件夹" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.path"
+                    placeholder="请选择M9A所在的文件夹"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectM9APath">
                     <template #icon>
                       <FolderOpenOutlined />
@@ -90,9 +100,18 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="m9aConfig.Emulator.Id" size="large" placeholder="请选择模拟器"
-                  :loading="emulatorLoading" @change="handleEmulatorSelectChange">
-                  <a-select-option v-for="item in emulatorOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-model:value="m9aConfig.Emulator.Id"
+                  size="large"
+                  placeholder="请选择模拟器"
+                  :loading="emulatorLoading"
+                  @change="handleEmulatorSelectChange"
+                >
+                  <a-select-option
+                    v-for="item in emulatorOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -102,20 +121,44 @@
               <a-form-item>
                 <template #label>
                   <a-tooltip
-                    :title="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading ? '不支持自动扫描实例的模拟器，请手动输入实例信息' : '选择模拟器的具体实例'">
+                    :title="
+                      emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading
+                        ? '不支持自动扫描实例的模拟器，请手动输入实例信息'
+                        : '选择模拟器的具体实例'
+                    "
+                  >
                     <span class="form-label">
                       模拟器实例
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-if="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading && m9aConfig.Emulator.Id"
-                  v-model:value="m9aConfig.Emulator.Index" size="large" placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
-                  class="modern-input" @blur="handleChange('Emulator', 'Index', m9aConfig.Emulator.Index)" />
-                <a-select v-else v-model:value="m9aConfig.Emulator.Index" size="large" placeholder="请先选择模拟器"
-                  :loading="emulatorDeviceLoading" :disabled="!m9aConfig.Emulator.Id"
-                  @change="handleChange('Emulator', 'Index', $event)">
-                  <a-select-option v-for="item in emulatorDeviceOptions" :key="item.value" :value="item.value">
+                <a-input
+                  v-if="
+                    emulatorDeviceOptions.length === 0 &&
+                    !emulatorDeviceLoading &&
+                    m9aConfig.Emulator.Id
+                  "
+                  v-model:value="m9aConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
+                  class="modern-input"
+                  @blur="handleChange('Emulator', 'Index', m9aConfig.Emulator.Index)"
+                />
+                <a-select
+                  v-else
+                  v-model:value="m9aConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请先选择模拟器"
+                  :loading="emulatorDeviceLoading"
+                  :disabled="!m9aConfig.Emulator.Id"
+                  @change="handleChange('Emulator', 'Index', $event)"
+                >
+                  <a-select-option
+                    v-for="item in emulatorDeviceOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -132,16 +175,24 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限">
+                  <a-tooltip
+                    title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限"
+                  >
                     <span class="form-label">
                       用户单日代理次数上限
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="m9aConfig.Run.ProxyTimesLimit" :min="0" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'ProxyTimesLimit', m9aConfig.Run.ProxyTimesLimit)" />
+                <a-input-number
+                  v-model:value="m9aConfig.Run.ProxyTimesLimit"
+                  :min="0"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'ProxyTimesLimit', m9aConfig.Run.ProxyTimesLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -154,9 +205,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="m9aConfig.Run.RunTimeLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimeLimit', m9aConfig.Run.RunTimeLimit)" />
+                <a-input-number
+                  v-model:value="m9aConfig.Run.RunTimeLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimeLimit', m9aConfig.Run.RunTimeLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -169,15 +226,23 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="m9aConfig.Run.RunTimesLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimesLimit', m9aConfig.Run.RunTimesLimit)" />
+                <a-input-number
+                  v-model:value="m9aConfig.Run.RunTimesLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimesLimit', m9aConfig.Run.RunTimesLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="开启后，同一用户每日心相当天成功完成过时，本日后续运行将跳过该任务">
+                  <a-tooltip
+                    title="开启后，同一用户每日心相当天成功完成过时，本日后续运行将跳过该任务"
+                  >
                     <span class="form-label">
                       每日心相每日只执行一次
                       <QuestionCircleOutlined class="help-icon" />
@@ -193,7 +258,9 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="开启后，同一用户自动深眠或自动醒梦本月成功完成过时，本月后续运行将分别跳过对应任务">
+                  <a-tooltip
+                    title="开启后，同一用户自动深眠或自动醒梦本月成功完成过时，本月后续运行将分别跳过对应任务"
+                  >
                     <span class="form-label">
                       深眠浅梦每月只执行一次
                       <QuestionCircleOutlined class="help-icon" />
@@ -211,15 +278,20 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="开启后，当此脚本在调度队列中运行时，所有用户任务完成后将自动更新M9A资源版本，须提前手动打开M9A应用配置更新源">
+                  <a-tooltip
+                    title="开启后，当此脚本在调度队列中运行时，所有用户任务完成后将自动更新M9A资源版本，须提前手动打开M9A应用配置更新源"
+                  >
                     <span class="form-label">
                       队列结束后自动更新
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="m9aConfig.Run.IfAutoUpdateAfterQueue" size="large"
-                  @change="handleChange('Run', 'IfAutoUpdateAfterQueue', $event)">
+                <a-select
+                  v-model:value="m9aConfig.Run.IfAutoUpdateAfterQueue"
+                  size="large"
+                  @change="handleChange('Run', 'IfAutoUpdateAfterQueue', $event)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -227,7 +299,6 @@
             </a-col>
           </a-row>
         </div>
-
       </a-form>
     </a-card>
 
@@ -237,8 +308,11 @@
         <img src="@/assets/M9A.png" alt="M9A" class="guide-logo" />
         <div class="guide-message">
           <span class="guide-text">提醒您：阁下若是遇到了难题，不妨查看</span>
-          <a href="https://doc.auto-mas.top/docs/script-guide/m9a.html"
-             target="_blank" class="guide-link">
+          <a
+            href="https://doc.auto-mas.top/docs/script-guide/m9a.html"
+            target="_blank"
+            class="guide-link"
+          >
             M9A 官方配置指南
           </a>
           <span class="guide-text">，其中清晰写明了所有配置步骤。</span>
@@ -444,8 +518,8 @@ const handleEmulatorSelectChange = async (emulatorId: string) => {
     const updateData = {
       Emulator: {
         Id: emulatorId,
-        Index: ''
-      }
+        Index: '',
+      },
     }
     const success = await updateScript(scriptId, updateData)
     if (success) {

--- a/frontend/src/views/EditView/Script/MAAScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/MAAScriptEdit.vue
@@ -56,8 +56,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.name" placeholder="请输入脚本名称" size="large" class="modern-input"
-                  @blur="handleChange('Info', 'Name', formData.name)" />
+                <a-input
+                  v-model:value="formData.name"
+                  placeholder="请输入脚本名称"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Info', 'Name', formData.name)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="16">
@@ -71,8 +76,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.path" placeholder="请选择MAA.exe所在的文件夹" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.path"
+                    placeholder="请选择MAA.exe所在的文件夹"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectMAAPath">
                     <template #icon>
                       <FolderOpenOutlined />
@@ -101,9 +111,18 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="maaConfig.Emulator.Id" size="large" placeholder="请选择模拟器"
-                  :loading="emulatorLoading" @change="handleEmulatorSelectChange">
-                  <a-select-option v-for="item in emulatorOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-model:value="maaConfig.Emulator.Id"
+                  size="large"
+                  placeholder="请选择模拟器"
+                  :loading="emulatorLoading"
+                  @change="handleEmulatorSelectChange"
+                >
+                  <a-select-option
+                    v-for="item in emulatorOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -113,7 +132,12 @@
               <a-form-item>
                 <template #label>
                   <a-tooltip
-                    :title="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading ? '不支持自动扫描实例的模拟器，请手动输入实例信息' : '选择模拟器的具体实例'">
+                    :title="
+                      emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading
+                        ? '不支持自动扫描实例的模拟器，请手动输入实例信息'
+                        : '选择模拟器的具体实例'
+                    "
+                  >
                     <span class="form-label">
                       模拟器实例
                       <QuestionCircleOutlined class="help-icon" />
@@ -121,14 +145,33 @@
                   </a-tooltip>
                 </template>
                 <!-- 当API返回空列表时显示输入框 -->
-                <a-input v-if="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading && maaConfig.Emulator.Id"
-                  v-model:value="maaConfig.Emulator.Index" size="large" placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
-                  class="modern-input" @blur="handleChange('Emulator', 'Index', maaConfig.Emulator.Index)" />
+                <a-input
+                  v-if="
+                    emulatorDeviceOptions.length === 0 &&
+                    !emulatorDeviceLoading &&
+                    maaConfig.Emulator.Id
+                  "
+                  v-model:value="maaConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
+                  class="modern-input"
+                  @blur="handleChange('Emulator', 'Index', maaConfig.Emulator.Index)"
+                />
                 <!-- 正常情况下显示下拉框 -->
-                <a-select v-else v-model:value="maaConfig.Emulator.Index" size="large" placeholder="请先选择模拟器"
-                  :loading="emulatorDeviceLoading" :disabled="!maaConfig.Emulator.Id"
-                  @change="handleChange('Emulator', 'Index', $event)">
-                  <a-select-option v-for="item in emulatorDeviceOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-else
+                  v-model:value="maaConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请先选择模拟器"
+                  :loading="emulatorDeviceLoading"
+                  :disabled="!maaConfig.Emulator.Id"
+                  @change="handleChange('Emulator', 'Index', $event)"
+                >
+                  <a-select-option
+                    v-for="item in emulatorDeviceOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -153,8 +196,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="maaConfig.Run.TaskTransitionMethod" size="large"
-                  @change="handleChange('Run', 'TaskTransitionMethod', $event)">
+                <a-select
+                  v-model:value="maaConfig.Run.TaskTransitionMethod"
+                  size="large"
+                  @change="handleChange('Run', 'TaskTransitionMethod', $event)"
+                >
                   <a-select-option value="ExitEmulator">重启模拟器</a-select-option>
                   <a-select-option value="ExitGame">重启明日方舟</a-select-option>
                   <a-select-option value="NoAction">直接切换账号</a-select-option>
@@ -164,16 +210,24 @@
             <a-col :span="12">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限">
+                  <a-tooltip
+                    title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限"
+                  >
                     <span class="form-label">
                       用户单日代理次数上限
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="maaConfig.Run.ProxyTimesLimit" :min="0" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'ProxyTimesLimit', maaConfig.Run.ProxyTimesLimit)" />
+                <a-input-number
+                  v-model:value="maaConfig.Run.ProxyTimesLimit"
+                  :min="0"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'ProxyTimesLimit', maaConfig.Run.ProxyTimesLimit)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
@@ -188,9 +242,21 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="maaConfig.Run.AnnihilationTimeLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'AnnihilationTimeLimit', maaConfig.Run.AnnihilationTimeLimit)" />
+                <a-input-number
+                  v-model:value="maaConfig.Run.AnnihilationTimeLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="
+                    handleChange(
+                      'Run',
+                      'AnnihilationTimeLimit',
+                      maaConfig.Run.AnnihilationTimeLimit
+                    )
+                  "
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -203,9 +269,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="maaConfig.Run.RoutineTimeLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RoutineTimeLimit', maaConfig.Run.RoutineTimeLimit)" />
+                <a-input-number
+                  v-model:value="maaConfig.Run.RoutineTimeLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RoutineTimeLimit', maaConfig.Run.RoutineTimeLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -218,14 +290,19 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="maaConfig.Run.RunTimesLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimesLimit', maaConfig.Run.RunTimesLimit)" />
+                <a-input-number
+                  v-model:value="maaConfig.Run.RunTimesLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimesLimit', maaConfig.Run.RunTimesLimit)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
         </div>
-
       </a-form>
     </a-card>
   </div>
@@ -446,8 +523,8 @@ const handleEmulatorSelectChange = async (emulatorId: string) => {
     const updateData = {
       Emulator: {
         Id: emulatorId,
-        Index: ''
-      }
+        Index: '',
+      },
     }
     const success = await updateScript(scriptId, updateData)
     if (success) {

--- a/frontend/src/views/EditView/Script/OkNteScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkNteScriptEdit.vue
@@ -93,7 +93,9 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="游戏管理总开关：关闭后 MAS 不启动也不关闭游戏；开启后可分别配置任务前启动与任务后关闭">
+                  <a-tooltip
+                    title="游戏管理总开关：关闭后 MAS 不启动也不关闭游戏；开启后可分别配置任务前启动与任务后关闭"
+                  >
                     <span class="form-label">
                       启用游戏配置
                       <QuestionCircleOutlined class="help-icon" />
@@ -136,7 +138,9 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="任务成功结束后是否由 MAS 关闭游戏；失败重试前若需重拉游戏也会尝试关闭">
+                  <a-tooltip
+                    title="任务成功结束后是否由 MAS 关闭游戏；失败重试前若需重拉游戏也会尝试关闭"
+                  >
                     <span class="form-label">
                       任务后关闭游戏
                       <QuestionCircleOutlined class="help-icon" />
@@ -163,7 +167,10 @@
                 <template #label>
                   <span class="form-label">
                     游戏根目录
-                    <span class="label-hint">选择包含 <strong>Neverness To Everness</strong> 的任意目录，自动定位 HTGame.exe</span>
+                    <span class="label-hint"
+                      >选择包含 <strong>Neverness To Everness</strong> 的任意目录，自动定位
+                      HTGame.exe</span
+                    >
                   </span>
                 </template>
                 <a-input-group compact class="path-input-group">
@@ -309,8 +316,18 @@
 import { onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { message, Modal } from 'ant-design-vue'
-import { ArrowLeftOutlined, FolderOpenOutlined, QuestionCircleOutlined } from '@ant-design/icons-vue'
-import { type OkNteConfig } from '@/api'
+import {
+  ArrowLeftOutlined,
+  FolderOpenOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons-vue'
+import {
+  type OkNteConfig,
+  type OkNteConfig_Game,
+  type OkNteConfig_Info,
+  type OkNteConfig_Run,
+  type OkNteConfig_Script,
+} from '@/api'
 import { useScriptApi } from '@/composables/useScriptApi'
 
 const logger = window.electronAPI.getLogger('OK-NTE脚本编辑')
@@ -333,13 +350,24 @@ const formData = reactive({
   },
 })
 
-const oknteConfig = reactive<OkNteConfig>({
+type FormSection<T> = { [K in keyof T]-?: NonNullable<T[K]> }
+
+type OkNteFormConfig = {
+  Info: FormSection<OkNteConfig_Info>
+  Script: FormSection<OkNteConfig_Script>
+  Game: FormSection<OkNteConfig_Game>
+  Run: FormSection<OkNteConfig_Run>
+}
+
+const oknteConfig = reactive<OkNteFormConfig>({
   Info: { Name: '', RootPath: '.' },
   Script: {
     ScriptPath: '.',
     Arguments: '',
     IfTrackProcess: true,
+    TrackProcessName: '',
     TrackProcessExe: '',
+    TrackProcessCmdline: '',
     ConfigPath: '.',
     ConfigPathMode: 'Folder',
     UpdateConfigMode: 'Always',
@@ -356,6 +384,9 @@ const oknteConfig = reactive<OkNteConfig>({
     LaunchBeforeTask: false,
     Type: 'Client',
     Path: '.',
+    URL: '',
+    ProcessName: '',
+    Arguments: '',
     WaitTime: 60,
     IfForceClose: true,
     CloseOnFinish: true,
@@ -416,7 +447,13 @@ const applyRootPathDefaults = async (rootPath: string) => {
     message.warning('请先选择脚本根目录')
     return
   }
-  const { rootPath: norm, scriptPath, configPath, logPath, trackProcessExe } = buildAutoPaths(rootPath)
+  const {
+    rootPath: norm,
+    scriptPath,
+    configPath,
+    logPath,
+    trackProcessExe,
+  } = buildAutoPaths(rootPath)
   oknteConfig.Info.RootPath = norm
   oknteConfig.Script.ScriptPath = scriptPath
   oknteConfig.Script.ConfigPath = configPath
@@ -466,10 +503,11 @@ const loadScript = async () => {
       return
     }
     formData.name = detail.name
-    Object.assign(oknteConfig.Info, detail.config.Info || {})
-    Object.assign(oknteConfig.Script, detail.config.Script || {})
-    Object.assign(oknteConfig.Game, detail.config.Game || {})
-    Object.assign(oknteConfig.Run, detail.config.Run || {})
+    const config = detail.config as OkNteConfig
+    Object.assign(oknteConfig.Info, config.Info || {})
+    Object.assign(oknteConfig.Script, config.Script || {})
+    Object.assign(oknteConfig.Game, config.Game || {})
+    Object.assign(oknteConfig.Run, config.Run || {})
   } catch {
     message.error('加载脚本失败')
   } finally {
@@ -479,12 +517,15 @@ const loadScript = async () => {
 }
 
 const selectRootPath = async () => {
-  const picked = await window.electronAPI.selectFolder({ title: '选择脚本根目录' })
+  const picked = await window.electronAPI.selectFolder()
   if (!picked) return
   const normalized = picked.replace(/\\/g, '/')
   const exePath = normalized + '/ok-nte.exe'
   if (!(await window.electronAPI.fileExists(exePath))) {
-    showPathRejectModal('所选目录无效', '所选目录下未找到 ok-nte.exe，请选择包含 ok-nte.exe 的 OK-NTE 脚本根目录。')
+    showPathRejectModal(
+      '所选目录无效',
+      '所选目录下未找到 ok-nte.exe，请选择包含 ok-nte.exe 的 OK-NTE 脚本根目录。'
+    )
     return
   }
   formData.path = normalized
@@ -493,7 +534,7 @@ const selectRootPath = async () => {
 
 const selectGameRootPath = async () => {
   if (!oknteConfig.Game.Enabled) return
-  const picked = await window.electronAPI.selectFolder({ title: '选择游戏根目录（Neverness To Everness）' })
+  const picked = await window.electronAPI.selectFolder()
   if (!picked) return
 
   const normalized = picked.replace(/\\/g, '/')

--- a/frontend/src/views/EditView/Script/SRCScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/SRCScriptEdit.vue
@@ -47,8 +47,13 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.name" placeholder="请输入脚本名称" size="large" class="modern-input"
-                  @blur="handleChange('Info', 'Name', formData.name)" />
+                <a-input
+                  v-model:value="formData.name"
+                  placeholder="请输入脚本名称"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleChange('Info', 'Name', formData.name)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="16">
@@ -62,8 +67,13 @@
                   </a-tooltip>
                 </template>
                 <a-input-group compact class="path-input-group">
-                  <a-input v-model:value="formData.path" placeholder="请选择SRC.exe所在的文件夹" size="large" class="path-input"
-                    readonly />
+                  <a-input
+                    v-model:value="formData.path"
+                    placeholder="请选择SRC.exe所在的文件夹"
+                    size="large"
+                    class="path-input"
+                    readonly
+                  />
                   <a-button size="large" class="path-button" @click="selectSRCPath">
                     <template #icon>
                       <FolderOpenOutlined />
@@ -92,9 +102,18 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="srcConfig.Emulator.Id" size="large" placeholder="请选择模拟器"
-                  :loading="emulatorLoading" @change="handleEmulatorSelectChange">
-                  <a-select-option v-for="item in emulatorOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-model:value="srcConfig.Emulator.Id"
+                  size="large"
+                  placeholder="请选择模拟器"
+                  :loading="emulatorLoading"
+                  @change="handleEmulatorSelectChange"
+                >
+                  <a-select-option
+                    v-for="item in emulatorOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -104,7 +123,12 @@
               <a-form-item>
                 <template #label>
                   <a-tooltip
-                    :title="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading ? '不支持自动扫描实例的模拟器，请手动输入实例信息' : '选择模拟器的具体实例'">
+                    :title="
+                      emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading
+                        ? '不支持自动扫描实例的模拟器，请手动输入实例信息'
+                        : '选择模拟器的具体实例'
+                    "
+                  >
                     <span class="form-label">
                       模拟器实例
                       <QuestionCircleOutlined class="help-icon" />
@@ -112,14 +136,33 @@
                   </a-tooltip>
                 </template>
                 <!-- 当API返回空列表时显示输入框 -->
-                <a-input v-if="emulatorDeviceOptions.length === 0 && !emulatorDeviceLoading && srcConfig.Emulator.Id"
-                  v-model:value="srcConfig.Emulator.Index" size="large" placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
-                  class="modern-input" @blur="handleChange('Emulator', 'Index', srcConfig.Emulator.Index)" />
+                <a-input
+                  v-if="
+                    emulatorDeviceOptions.length === 0 &&
+                    !emulatorDeviceLoading &&
+                    srcConfig.Emulator.Id
+                  "
+                  v-model:value="srcConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请输入实例信息，格式：启动附加命令 | ADB地址"
+                  class="modern-input"
+                  @blur="handleChange('Emulator', 'Index', srcConfig.Emulator.Index)"
+                />
                 <!-- 正常情况下显示下拉框 -->
-                <a-select v-else v-model:value="srcConfig.Emulator.Index" size="large" placeholder="请先选择模拟器"
-                  :loading="emulatorDeviceLoading" :disabled="!srcConfig.Emulator.Id"
-                  @change="handleChange('Emulator', 'Index', $event)">
-                  <a-select-option v-for="item in emulatorDeviceOptions" :key="item.value" :value="item.value">
+                <a-select
+                  v-else
+                  v-model:value="srcConfig.Emulator.Index"
+                  size="large"
+                  placeholder="请先选择模拟器"
+                  :loading="emulatorDeviceLoading"
+                  :disabled="!srcConfig.Emulator.Id"
+                  @change="handleChange('Emulator', 'Index', $event)"
+                >
+                  <a-select-option
+                    v-for="item in emulatorDeviceOptions"
+                    :key="item.value"
+                    :value="item.value"
+                  >
                     {{ item.label }}
                   </a-select-option>
                 </a-select>
@@ -144,8 +187,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="srcConfig.Run.TaskTransitionMethod" size="large"
-                  @change="handleChange('Run', 'TaskTransitionMethod', $event)">
+                <a-select
+                  v-model:value="srcConfig.Run.TaskTransitionMethod"
+                  size="large"
+                  @change="handleChange('Run', 'TaskTransitionMethod', $event)"
+                >
                   <a-select-option value="ExitEmulator">重启模拟器</a-select-option>
                   <a-select-option value="ExitGame">重启游戏</a-select-option>
                 </a-select>
@@ -154,16 +200,24 @@
             <a-col :span="8">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限">
+                  <a-tooltip
+                    title="当用户本日代理成功次数达到该阀值时跳过代理，阈值为「0」时视为无代理次数上限"
+                  >
                     <span class="form-label">
                       用户单日代理次数上限
                       <QuestionCircleOutlined class="help-icon" />
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="srcConfig.Run.ProxyTimesLimit" :min="0" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'ProxyTimesLimit', srcConfig.Run.ProxyTimesLimit)" />
+                <a-input-number
+                  v-model:value="srcConfig.Run.ProxyTimesLimit"
+                  :min="0"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'ProxyTimesLimit', srcConfig.Run.ProxyTimesLimit)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="8">
@@ -176,9 +230,15 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="srcConfig.Run.RunTimesLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimesLimit', srcConfig.Run.RunTimesLimit)" />
+                <a-input-number
+                  v-model:value="srcConfig.Run.RunTimesLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimesLimit', srcConfig.Run.RunTimesLimit)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
@@ -193,14 +253,19 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="srcConfig.Run.RunTimeLimit" :min="1" :max="9999" size="large"
-                  class="modern-number-input" style="width: 100%"
-                  @blur="handleChange('Run', 'RunTimeLimit', srcConfig.Run.RunTimeLimit)" />
+                <a-input-number
+                  v-model:value="srcConfig.Run.RunTimeLimit"
+                  :min="1"
+                  :max="9999"
+                  size="large"
+                  class="modern-number-input"
+                  style="width: 100%"
+                  @blur="handleChange('Run', 'RunTimeLimit', srcConfig.Run.RunTimeLimit)"
+                />
               </a-form-item>
             </a-col>
           </a-row>
         </div>
-
       </a-form>
     </a-card>
   </div>
@@ -416,8 +481,8 @@ const handleEmulatorSelectChange = async (emulatorId: string) => {
     const updateData = {
       Emulator: {
         Id: emulatorId,
-        Index: ''
-      }
+        Index: '',
+      },
     }
     const success = await updateScript(scriptId, updateData)
     if (success) {

--- a/frontend/src/views/EditView/User/GeneralUserEdit.vue
+++ b/frontend/src/views/EditView/User/GeneralUserEdit.vue
@@ -17,15 +17,26 @@
     </div>
 
     <a-space size="middle">
-      <a-button v-if="!showGeneralConfigMask" type="primary" ghost size="large" :loading="generalConfigLoading"
-        @click="handleGeneralConfig">
+      <a-button
+        v-if="!showGeneralConfigMask"
+        type="primary"
+        ghost
+        size="large"
+        :loading="generalConfigLoading"
+        @click="handleGeneralConfig"
+      >
         <template #icon>
           <SettingOutlined />
         </template>
         通用配置
       </a-button>
-      <a-button v-if="showGeneralConfigMask" type="default" size="large" disabled
-        style="color: #52c41a; border-color: #52c41a">
+      <a-button
+        v-if="showGeneralConfigMask"
+        type="default"
+        size="large"
+        disabled
+        style="color: #52c41a; border-color: #52c41a"
+      >
         <template #icon>
           <SettingOutlined />
         </template>
@@ -54,7 +65,12 @@
           配置完成后，请点击"保存配置"按钮来结束配置会话。
         </p>
         <div class="mask-actions">
-          <a-button v-if="generalWebsocketId" type="primary" size="large" @click="handleSaveGeneralConfig">
+          <a-button
+            v-if="generalWebsocketId"
+            type="primary"
+            size="large"
+            @click="handleSaveGeneralConfig"
+          >
             保存配置
           </a-button>
         </div>
@@ -81,8 +97,14 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input v-model:value="formData.userName" placeholder="请输入用户名" :disabled="loading" size="large"
-                  class="modern-input" @blur="handleFieldSave('userName', formData.userName)" />
+                <a-input
+                  v-model:value="formData.userName"
+                  placeholder="请输入用户名"
+                  :disabled="loading"
+                  size="large"
+                  class="modern-input"
+                  @blur="handleFieldSave('userName', formData.userName)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="6">
@@ -95,8 +117,11 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-select v-model:value="formData.Info.Status" size="large"
-                  @change="handleFieldSave('Info.Status', formData.Info.Status)">
+                <a-select
+                  v-model:value="formData.Info.Status"
+                  size="large"
+                  @change="handleFieldSave('Info.Status', formData.Info.Status)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -112,9 +137,16 @@
                     </span>
                   </a-tooltip>
                 </template>
-                <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="-1"
-                  :disabled="loading" size="large" style="width: 100%"
-                  @blur="handleFieldSave('Info.RemainedDay', formData.Info.RemainedDay)" />
+                <a-input-number
+                  v-model:value="formData.Info.RemainedDay"
+                  :min="-1"
+                  :max="9999"
+                  placeholder="-1"
+                  :disabled="loading"
+                  size="large"
+                  style="width: 100%"
+                  @blur="handleFieldSave('Info.RemainedDay', formData.Info.RemainedDay)"
+                />
               </a-form-item>
             </a-col>
             <a-col :span="24">
@@ -136,13 +168,23 @@
                 </span>
               </a-tooltip>
             </template>
-            <a-textarea v-model:value="formData.Info.Notes" placeholder="请输入备注信息" :rows="4" :disabled="loading"
-              class="modern-input" @blur="handleFieldSave('Info.Notes', formData.Info.Notes)" />
+            <a-textarea
+              v-model:value="formData.Info.Notes"
+              placeholder="请输入备注信息"
+              :rows="4"
+              :disabled="loading"
+              class="modern-input"
+              @blur="handleFieldSave('Info.Notes', formData.Info.Notes)"
+            />
           </a-form-item>
         </div>
 
         <!-- 额外脚本 -->
-        <ExtraScriptSection v-model:form-data="formData" :loading="loading" @save="handleFieldSave" />
+        <ExtraScriptSection
+          v-model:form-data="formData"
+          :loading="loading"
+          @save="handleFieldSave"
+        />
 
         <!-- 通知配置 -->
         <div class="form-section">
@@ -154,8 +196,11 @@
               <span style="font-weight: 500">启用通知</span>
             </a-col>
             <a-col :span="18">
-              <a-switch v-model:checked="formData.Notify.Enabled" :disabled="loading"
-                @change="handleFieldSave('Notify.Enabled', formData.Notify.Enabled)" />
+              <a-switch
+                v-model:checked="formData.Notify.Enabled"
+                :disabled="loading"
+                @change="handleFieldSave('Notify.Enabled', formData.Notify.Enabled)"
+              />
               <span class="switch-description">启用后将发送任务通知</span>
             </a-col>
           </a-row>
@@ -166,9 +211,11 @@
               <span style="font-weight: 500">通知内容</span>
             </a-col>
             <a-col :span="18">
-              <a-checkbox v-model:checked="formData.Notify.IfSendStatistic"
+              <a-checkbox
+                v-model:checked="formData.Notify.IfSendStatistic"
                 :disabled="loading || !formData.Notify.Enabled"
-                @change="handleFieldSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)">统计信息
+                @change="handleFieldSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)"
+                >统计信息
               </a-checkbox>
             </a-col>
           </a-row>
@@ -176,34 +223,55 @@
           <!-- 邮件通知 -->
           <a-row :gutter="24" style="margin-top: 16px">
             <a-col :span="6">
-              <a-checkbox v-model:checked="formData.Notify.IfSendMail" :disabled="loading || !formData.Notify.Enabled"
-                @change="handleFieldSave('Notify.IfSendMail', formData.Notify.IfSendMail)">邮件通知
+              <a-checkbox
+                v-model:checked="formData.Notify.IfSendMail"
+                :disabled="loading || !formData.Notify.Enabled"
+                @change="handleFieldSave('Notify.IfSendMail', formData.Notify.IfSendMail)"
+                >邮件通知
               </a-checkbox>
             </a-col>
             <a-col :span="18">
-              <a-input v-model:value="formData.Notify.ToAddress" placeholder="请输入收件人邮箱地址"
-                :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail" size="large"
-                style="width: 100%" @blur="handleFieldSave('Notify.ToAddress', formData.Notify.ToAddress)" />
+              <a-input
+                v-model:value="formData.Notify.ToAddress"
+                placeholder="请输入收件人邮箱地址"
+                :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail"
+                size="large"
+                style="width: 100%"
+                @blur="handleFieldSave('Notify.ToAddress', formData.Notify.ToAddress)"
+              />
             </a-col>
           </a-row>
 
           <!-- Server酱通知 -->
           <a-row :gutter="24" style="margin-top: 16px">
             <a-col :span="6">
-              <a-checkbox v-model:checked="formData.Notify.IfServerChan" :disabled="loading || !formData.Notify.Enabled"
-                @change="handleFieldSave('Notify.IfServerChan', formData.Notify.IfServerChan)">Server酱
+              <a-checkbox
+                v-model:checked="formData.Notify.IfServerChan"
+                :disabled="loading || !formData.Notify.Enabled"
+                @change="handleFieldSave('Notify.IfServerChan', formData.Notify.IfServerChan)"
+                >Server酱
               </a-checkbox>
             </a-col>
             <a-col :span="18">
-              <a-input v-model:value="formData.Notify.ServerChanKey" placeholder="请输入SENDKEY"
-                :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan" size="large"
-                style="width: 100%" @blur="handleFieldSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)" />
+              <a-input
+                v-model:value="formData.Notify.ServerChanKey"
+                placeholder="请输入SENDKEY"
+                :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan"
+                size="large"
+                style="width: 100%"
+                @blur="handleFieldSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)"
+              />
             </a-col>
           </a-row>
 
           <!-- 自定义 Webhook 通知 -->
           <div style="margin-top: 16px">
-            <WebhookManager mode="user" :script-id="scriptId" :user-id="userId" @change="handleWebhookChange" />
+            <WebhookManager
+              mode="user"
+              :script-id="scriptId"
+              :user-id="userId"
+              @change="handleWebhookChange"
+            />
           </div>
         </div>
       </a-form>
@@ -512,7 +580,6 @@ const loadUserData = async () => {
 }
 
 const handleGeneralConfig = async () => {
-
   try {
     generalConfigLoading.value = true
 
@@ -570,7 +637,11 @@ const handleGeneralConfig = async () => {
         }
 
         // 处理任务结束消息（Signal类型且包含Accomplish字段）
-        if (wsMessage.type === 'Signal' && wsMessage.data && wsMessage.data.Accomplish !== undefined) {
+        if (
+          wsMessage.type === 'Signal' &&
+          wsMessage.data &&
+          wsMessage.data.Accomplish !== undefined
+        ) {
           logger.info(`用户 ${formData.userName} 通用配置任务已结束`)
           // 根据结果显示不同消息
           const result = wsMessage.data.Accomplish
@@ -601,7 +672,9 @@ const handleGeneralConfig = async () => {
         async () => {
           if (generalSubscriptionId.value && generalWebsocketId.value) {
             // 超时后自动保存配置
-            message.warning(`用户 ${formData.userName} 的配置会话已超时（30分钟），正在自动保存配置...`)
+            message.warning(
+              `用户 ${formData.userName} 的配置会话已超时（30分钟），正在自动保存配置...`
+            )
             logger.warn('配置会话已超时，自动执行保存操作')
 
             try {

--- a/frontend/src/views/EditView/User/OkNteUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkNteUserEdit.vue
@@ -446,7 +446,17 @@ const oknteTaskOptions = [
   { label: '19 - CinemaDateTask（影院约会）', value: 19 },
 ]
 
-const getDefaultUserData = () => ({
+type FormSection<T> = { [K in keyof T]-?: NonNullable<T[K]> }
+
+type OkNteUserFormData = {
+  userName: string
+  Info: FormSection<NonNullable<OkNteUserConfig['Info']>>
+  Task: FormSection<NonNullable<OkNteUserConfig['Task']>>
+  Notify: FormSection<NonNullable<OkNteUserConfig['Notify']>>
+  Data: FormSection<NonNullable<OkNteUserConfig['Data']>>
+}
+
+const getDefaultUserData = (): Omit<OkNteUserFormData, 'userName'> => ({
   Info: {
     Name: '',
     Status: true,
@@ -455,7 +465,12 @@ const getDefaultUserData = () => ({
     Mode: '简洁',
     Resource: '官服',
     RemainedDay: -1,
+    IfScriptBeforeTask: false,
+    ScriptBeforeTask: '',
+    IfScriptAfterTask: false,
+    ScriptAfterTask: '',
     Notes: '',
+    Tag: '',
   },
   Task: {
     TaskIndex: 2,
@@ -468,17 +483,18 @@ const getDefaultUserData = () => ({
     ToAddress: '',
     IfServerChan: false,
     ServerChanKey: '',
-    CustomWebhooks: [],
   },
   Data: {
     LastProxyDate: '',
     ProxyTimes: 0,
+    LastProxyStatus: '',
+    LastTaskIndex: 0,
   },
 })
 
-const formData = reactive({
+const formData = reactive<OkNteUserFormData>({
   userName: '',
-  ...(getDefaultUserData() as unknown as OkNteUserConfig),
+  ...getDefaultUserData(),
 })
 
 const currentStartupArguments = computed(() => `-t ${formData.Task.TaskIndex || 2} -e`)
@@ -673,7 +689,7 @@ const loadUser = async () => {
     }
     const resp = await getUsers(scriptId, userId)
     const userIndex = resp?.index?.find(i => i.uid === userId)
-    const data = resp?.data?.[userId]
+    const data = resp?.data?.[userId] as OkNteUserConfig | undefined
     if (!userIndex || !data) {
       throw new Error('用户不存在或加载失败')
     }

--- a/frontend/src/views/EditView/User/OkwwUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkwwUserEdit.vue
@@ -383,7 +383,11 @@
 
       <a-card class="config-card" style="margin-top: 24px">
         <a-form :model="formData" layout="vertical" class="config-form">
-          <ExtraScriptSection v-model:form-data="formData" :loading="pageLoading" @save="saveField" />
+          <ExtraScriptSection
+            v-model:form-data="formData"
+            :loading="pageLoading"
+            @save="saveField"
+          />
         </a-form>
       </a-card>
 

--- a/frontend/src/views/Emulator.vue
+++ b/frontend/src/views/Emulator.vue
@@ -374,7 +374,6 @@ const handleDelete = async (uuid: string) => {
       emulatorId: uuid,
     })
     if (response.code === 200) {
-
       // 如果删除的是当前激活的 Tab，需要跳转到其他 Tab
       if (activeKey.value === uuid) {
         const currentIndex = emulatorIndex.value.findIndex(e => e.uid === uuid)
@@ -826,7 +825,13 @@ const handleBossKeyInputChange = (uuid: string) => {
         <div v-if="emulatorIndex.length === 0" class="empty-state-large">
           <a-empty />
           <a-space direction="horizontal" :size="16">
-            <a-button type="primary" size="large" :icon="h(SearchOutlined)" :loading="searching" @click="handleSearch">
+            <a-button
+              type="primary"
+              size="large"
+              :icon="h(SearchOutlined)"
+              :loading="searching"
+              @click="handleSearch"
+            >
               自动搜索模拟器
             </a-button>
             <a-button size="large" :icon="h(PlusOutlined)" @click="handleAddWithSwitch">
@@ -836,8 +841,14 @@ const handleBossKeyInputChange = (uuid: string) => {
         </div>
 
         <!-- Tab 模式：有模拟器时显示 Tabs -->
-        <a-tabs v-else v-model:active-key="activeKey" type="editable-card" hide-add class="emulator-tabs"
-          @change="onTabChange">
+        <a-tabs
+          v-else
+          v-model:active-key="activeKey"
+          type="editable-card"
+          hide-add
+          class="emulator-tabs"
+          @change="onTabChange"
+        >
           <!-- 每个模拟器一个 Tab -->
           <a-tab-pane v-for="element in emulatorIndex" :key="element.uid" :closable="false">
             <template #tab>
@@ -854,8 +865,12 @@ const handleBossKeyInputChange = (uuid: string) => {
                   <h3>模拟器配置</h3>
                   <div class="section-actions">
                     <a-spin v-if="savingMap.get(element.uid)" size="small" />
-                    <a-popconfirm title="确定要删除此模拟器配置吗？" ok-text="确定" cancel-text="取消"
-                      @confirm="handleDelete(element.uid)">
+                    <a-popconfirm
+                      title="确定要删除此模拟器配置吗？"
+                      ok-text="确定"
+                      cancel-text="取消"
+                      @confirm="handleDelete(element.uid)"
+                    >
                       <a-button type="link" danger size="small" :icon="h(DeleteOutlined)">
                         删除
                       </a-button>
@@ -867,11 +882,16 @@ const handleBossKeyInputChange = (uuid: string) => {
                 <div class="config-form">
                   <a-descriptions :column="2" bordered size="small">
                     <a-descriptions-item label="模拟器名称">
-                      <a-input v-model:value="getEditingData(element.uid).name" placeholder="输入模拟器名称" size="small"
-                        :bordered="false" @input="syncNameToDisplay(element.uid, getEditingData(element.uid).name)"
+                      <a-input
+                        v-model:value="getEditingData(element.uid).name"
+                        placeholder="输入模拟器名称"
+                        size="small"
+                        :bordered="false"
+                        @input="syncNameToDisplay(element.uid, getEditingData(element.uid).name)"
                         @blur="
                           handleSaveChange(element.uid, 'name', getEditingData(element.uid).name)
-                          " />
+                        "
+                      />
                     </a-descriptions-item>
                     <a-descriptions-item>
                       <template #label>
@@ -880,16 +900,29 @@ const handleBossKeyInputChange = (uuid: string) => {
                           <QuestionCircleOutlined style="margin-left: 4px" />
                         </a-tooltip>
                       </template>
-                      <a-select v-model:value="getEditingData(element.uid).type" placeholder="选择模拟器类型"
-                        :options="emulatorTypeOptions" size="small" :bordered="false" style="width: 100%"
-                        @change="handleSaveChange(element.uid, 'type', $event)" />
+                      <a-select
+                        v-model:value="getEditingData(element.uid).type"
+                        placeholder="选择模拟器类型"
+                        :options="emulatorTypeOptions"
+                        size="small"
+                        :bordered="false"
+                        style="width: 100%"
+                        @change="handleSaveChange(element.uid, 'type', $event)"
+                      />
                     </a-descriptions-item>
                     <a-descriptions-item label="模拟器路径" :span="2">
-                      <a-input v-model:value="getEditingData(element.uid).path" placeholder="请点击文件夹图标选择模拟器路径"
-                        size="small" :bordered="false" readonly>
+                      <a-input
+                        v-model:value="getEditingData(element.uid).path"
+                        placeholder="请点击文件夹图标选择模拟器路径"
+                        size="small"
+                        :bordered="false"
+                        readonly
+                      >
                         <template #suffix>
-                          <FolderOpenOutlined style="cursor: pointer; color: #1890ff"
-                            @click="selectEmulatorPath(element.uid)" />
+                          <FolderOpenOutlined
+                            style="cursor: pointer; color: #1890ff"
+                            @click="selectEmulatorPath(element.uid)"
+                          />
                         </template>
                       </a-input>
                     </a-descriptions-item>
@@ -900,9 +933,24 @@ const handleBossKeyInputChange = (uuid: string) => {
                           <QuestionCircleOutlined style="margin-left: 4px" />
                         </a-tooltip>
                       </template>
-                      <a-input-number v-model:value="getEditingData(element.uid).max_wait_time" placeholder="输入最大等待时间"
-                        size="small" :bordered="false" style="width: 100%" :min="10" :max="9999" :step="5" suffix="秒"
-                        @blur="handleSaveChange(element.uid, 'max_wait_time', getEditingData(element.uid).max_wait_time)" />
+                      <a-input-number
+                        v-model:value="getEditingData(element.uid).max_wait_time"
+                        placeholder="输入最大等待时间"
+                        size="small"
+                        :bordered="false"
+                        style="width: 100%"
+                        :min="10"
+                        :max="9999"
+                        :step="5"
+                        suffix="秒"
+                        @blur="
+                          handleSaveChange(
+                            element.uid,
+                            'max_wait_time',
+                            getEditingData(element.uid).max_wait_time
+                          )
+                        "
+                      />
                     </a-descriptions-item>
                     <a-descriptions-item>
                       <template #label>
@@ -911,19 +959,37 @@ const handleBossKeyInputChange = (uuid: string) => {
                           <QuestionCircleOutlined style="margin-left: 4px" />
                         </a-tooltip>
                       </template>
-                      <a-input v-if="getEditingData(element.uid).type !== 'mumu'"
-                        v-model:value="bossKeyInputMap[element.uid]" :placeholder="recordingBossKeyMap.get(element.uid)
-                          ? '请按下快捷键组合...'
-                          : '输入格式如 Ctrl+Q，按回车添加'
-                          " size="small" :bordered="false" :disabled="recordingBossKeyMap.get(element.uid)"
-                        @press-enter="handleSetBossKey(element.uid)" @blur="handleSetBossKey(element.uid)"
-                        @input="handleBossKeyInputChange(element.uid)">
+                      <a-input
+                        v-if="getEditingData(element.uid).type !== 'mumu'"
+                        v-model:value="bossKeyInputMap[element.uid]"
+                        :placeholder="
+                          recordingBossKeyMap.get(element.uid)
+                            ? '请按下快捷键组合...'
+                            : '输入格式如 Ctrl+Q，按回车添加'
+                        "
+                        size="small"
+                        :bordered="false"
+                        :disabled="recordingBossKeyMap.get(element.uid)"
+                        @press-enter="handleSetBossKey(element.uid)"
+                        @blur="handleSetBossKey(element.uid)"
+                        @input="handleBossKeyInputChange(element.uid)"
+                      >
                         <template #suffix>
-                          <a-button v-if="!recordingBossKeyMap.get(element.uid)" type="default" size="small"
-                            @click="startRecordBossKey(element.uid)">
+                          <a-button
+                            v-if="!recordingBossKeyMap.get(element.uid)"
+                            type="default"
+                            size="small"
+                            @click="startRecordBossKey(element.uid)"
+                          >
                             录制
                           </a-button>
-                          <a-button v-else type="primary" danger size="small" @click="stopRecordBossKey(element.uid)">
+                          <a-button
+                            v-else
+                            type="primary"
+                            danger
+                            size="small"
+                            @click="stopRecordBossKey(element.uid)"
+                          >
                             取消录制
                           </a-button>
                         </template>
@@ -957,14 +1023,21 @@ const handleBossKeyInputChange = (uuid: string) => {
                 </div>
 
                 <a-spin :spinning="loadingDevices.has(element.uid)">
-                  <div v-if="
-                    !devicesData[element.uid] ||
-                    Object.keys(devicesData[element.uid]).length === 0
-                  " class="empty-devices">
+                  <div
+                    v-if="
+                      !devicesData[element.uid] ||
+                      Object.keys(devicesData[element.uid]).length === 0
+                    "
+                    class="empty-devices"
+                  >
                     <a-empty description="暂无设备信息">
                       <template #extra>
-                        <a-button type="primary" size="small" :icon="h(PlayCircleOutlined)"
-                          @click="startEmulator(element.uid, '0')">
+                        <a-button
+                          type="primary"
+                          size="small"
+                          :icon="h(PlayCircleOutlined)"
+                          @click="startEmulator(element.uid, '0')"
+                        >
                           启动模拟器
                         </a-button>
                       </template>
@@ -972,12 +1045,15 @@ const handleBossKeyInputChange = (uuid: string) => {
                   </div>
 
                   <div v-else class="devices-grid">
-                    <a-table :data-source="Object.entries(devicesData[element.uid]).map(([index, device]) => ({
-                      key: index,
-                      index,
-                      ...device,
-                    }))
-                      " :columns="[
+                    <a-table
+                      :data-source="
+                        Object.entries(devicesData[element.uid]).map(([index, device]) => ({
+                          key: index,
+                          index,
+                          ...device,
+                        }))
+                      "
+                      :columns="[
                         {
                           title: '设备',
                           dataIndex: 'index',
@@ -999,7 +1075,11 @@ const handleBossKeyInputChange = (uuid: string) => {
                           ellipsis: true,
                         },
                         { title: '操作', key: 'action', width: 160 },
-                      ]" :pagination="false" size="small" :scroll="{ x: 'max-content', y: 'calc(100vh - 560px)' }">
+                      ]"
+                      :pagination="false"
+                      size="small"
+                      :scroll="{ x: 'max-content', y: 'calc(100vh - 560px)' }"
+                    >
                       <template #bodyCell="{ column, record }">
                         <template v-if="column.key === 'status'">
                           <a-tag :color="getDeviceStatusInfo(record.status).color" size="small">
@@ -1008,19 +1088,30 @@ const handleBossKeyInputChange = (uuid: string) => {
                         </template>
                         <template v-else-if="column.key === 'action'">
                           <a-space :size="4">
-                            <a-button :icon="h(EyeOutlined)" :disabled="record.status !== 0"
+                            <a-button
+                              :icon="h(EyeOutlined)"
+                              :disabled="record.status !== 0"
                               :loading="showingDevices.has(`${element.uid}-${record.index}`)"
-                              @click="showEmulator(element.uid, String(record.index))">
+                              @click="showEmulator(element.uid, String(record.index))"
+                            >
                               显示
                             </a-button>
-                            <a-button v-if="canStartDevice(record.status)" type="primary" :icon="h(PlayCircleOutlined)"
+                            <a-button
+                              v-if="canStartDevice(record.status)"
+                              type="primary"
+                              :icon="h(PlayCircleOutlined)"
                               :loading="startingDevices.has(`${element.uid}-${record.index}`)"
-                              @click="startEmulator(element.uid, String(record.index))">
+                              @click="startEmulator(element.uid, String(record.index))"
+                            >
                               启动
                             </a-button>
-                            <a-button v-else-if="canStopDevice(record.status)" danger :icon="h(StopOutlined)"
+                            <a-button
+                              v-else-if="canStopDevice(record.status)"
+                              danger
+                              :icon="h(StopOutlined)"
                               :loading="stoppingDevices.has(`${element.uid}-${record.index}`)"
-                              @click="stopEmulator(element.uid, String(record.index))">
+                              @click="stopEmulator(element.uid, String(record.index))"
+                            >
                               关闭
                             </a-button>
                             <a-button v-else disabled>
@@ -1040,10 +1131,21 @@ const handleBossKeyInputChange = (uuid: string) => {
           <template #rightExtra>
             <div class="tab-extra-actions">
               <a-space :size="8">
-                <a-button type="default" size="middle" :icon="h(SearchOutlined)" :loading="searching" @click="handleSearch()">
+                <a-button
+                  type="default"
+                  size="middle"
+                  :icon="h(SearchOutlined)"
+                  :loading="searching"
+                  @click="handleSearch()"
+                >
                   自动搜索模拟器
                 </a-button>
-                <a-button type="primary" size="middle" :icon="h(PlusOutlined)" @click="handleAddWithSwitch">
+                <a-button
+                  type="primary"
+                  size="middle"
+                  :icon="h(PlusOutlined)"
+                  @click="handleAddWithSwitch"
+                >
                   手动添加多开器
                 </a-button>
               </a-space>

--- a/frontend/src/views/Initialization/components/EnvironmentStep.vue
+++ b/frontend/src/views/Initialization/components/EnvironmentStep.vue
@@ -148,9 +148,7 @@ const mirrorMirrors = computed(() => props.mirrors.filter(m => m.type === 'mirro
 const sortedOfficialMirrors = computed(() =>
   sortMirrorsBySpeedAndRecommendation(officialMirrors.value)
 )
-const sortedMirrorMirrors = computed(() =>
-  sortMirrorsBySpeedAndRecommendation(mirrorMirrors.value)
-)
+const sortedMirrorMirrors = computed(() => sortMirrorsBySpeedAndRecommendation(mirrorMirrors.value))
 
 function handleMirrorSelect(key: string) {
   emit('update:selectedMirror', key)

--- a/frontend/src/views/Initialization/components/RepositoryStep.vue
+++ b/frontend/src/views/Initialization/components/RepositoryStep.vue
@@ -12,11 +12,7 @@
         <a-alert
           :type="repoExists ? 'info' : 'warning'"
           :message="repoExists ? '本地仓库已存在' : '本地仓库不存在'"
-          :description="
-            repoExists
-              ? '将更新现有仓库到最新版本'
-              : '将从远程克隆仓库到本地'
-          "
+          :description="repoExists ? '将更新现有仓库到最新版本' : '将从远程克隆仓库到本地'"
           show-icon
         />
       </div>

--- a/frontend/src/views/Initialization/components/StepPanel.vue
+++ b/frontend/src/views/Initialization/components/StepPanel.vue
@@ -14,34 +14,51 @@
       <!-- 详细信息展示区域 -->
       <div class="detail-info-container">
         <!-- 环境检查信息（Python/Pip/Git） -->
-        <div v-if="checkInfo && (checkInfo.exeExists !== undefined || checkInfo.canRun !== undefined)"
-          class="info-section">
+        <div
+          v-if="checkInfo && (checkInfo.exeExists !== undefined || checkInfo.canRun !== undefined)"
+          class="info-section"
+        >
           <div class="info-title">环境检查</div>
           <div class="info-items">
-            <a-tag v-if="checkInfo.exeExists !== undefined" :color="checkInfo.exeExists ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.exeExists !== undefined"
+              :color="checkInfo.exeExists ? 'green' : 'orange'"
+            >
               可执行文件: {{ checkInfo.exeExists ? '存在' : '不存在' }}
             </a-tag>
-            <a-tag v-if="checkInfo.canRun !== undefined" :color="checkInfo.canRun ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.canRun !== undefined"
+              :color="checkInfo.canRun ? 'green' : 'orange'"
+            >
               运行状态: {{ checkInfo.canRun ? '正常' : '异常' }}
             </a-tag>
-            <a-tag v-if="checkInfo.version" color="blue">
-              版本: {{ checkInfo.version }}
-            </a-tag>
+            <a-tag v-if="checkInfo.version" color="blue"> 版本: {{ checkInfo.version }} </a-tag>
           </div>
         </div>
 
         <!-- 仓库检查信息 -->
-        <div v-if="checkInfo && (checkInfo.exists !== undefined || checkInfo.isGitRepo !== undefined)"
-          class="info-section">
+        <div
+          v-if="checkInfo && (checkInfo.exists !== undefined || checkInfo.isGitRepo !== undefined)"
+          class="info-section"
+        >
           <div class="info-title">仓库检查</div>
           <div class="info-items">
-            <a-tag v-if="checkInfo.exists !== undefined" :color="checkInfo.exists ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.exists !== undefined"
+              :color="checkInfo.exists ? 'green' : 'orange'"
+            >
               本地仓库: {{ checkInfo.exists ? '存在' : '不存在' }}
             </a-tag>
-            <a-tag v-if="checkInfo.isGitRepo !== undefined" :color="checkInfo.isGitRepo ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.isGitRepo !== undefined"
+              :color="checkInfo.isGitRepo ? 'green' : 'orange'"
+            >
               Git仓库: {{ checkInfo.isGitRepo ? '是' : '否' }}
             </a-tag>
-            <a-tag v-if="checkInfo.isHealthy !== undefined" :color="checkInfo.isHealthy ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.isHealthy !== undefined"
+              :color="checkInfo.isHealthy ? 'green' : 'orange'"
+            >
               健康状态: {{ checkInfo.isHealthy ? '健康' : '异常' }}
             </a-tag>
             <a-tag v-if="checkInfo.currentBranch" color="blue">
@@ -51,15 +68,25 @@
         </div>
 
         <!-- 依赖检查信息 -->
-        <div v-if="checkInfo && (checkInfo.requirementsExists !== undefined || checkInfo.needsInstall !== undefined)"
-          class="info-section">
+        <div
+          v-if="
+            checkInfo &&
+            (checkInfo.requirementsExists !== undefined || checkInfo.needsInstall !== undefined)
+          "
+          class="info-section"
+        >
           <div class="info-title">依赖检查</div>
           <div class="info-items">
-            <a-tag v-if="checkInfo.requirementsExists !== undefined"
-              :color="checkInfo.requirementsExists ? 'green' : 'orange'">
+            <a-tag
+              v-if="checkInfo.requirementsExists !== undefined"
+              :color="checkInfo.requirementsExists ? 'green' : 'orange'"
+            >
               requirements.txt: {{ checkInfo.requirementsExists ? '存在' : '不存在' }}
             </a-tag>
-            <a-tag v-if="checkInfo.needsInstall !== undefined" :color="checkInfo.needsInstall ? 'orange' : 'green'">
+            <a-tag
+              v-if="checkInfo.needsInstall !== undefined"
+              :color="checkInfo.needsInstall ? 'orange' : 'green'"
+            >
               需要安装: {{ checkInfo.needsInstall ? '是' : '否' }}
             </a-tag>
           </div>
@@ -69,9 +96,7 @@
         <div v-if="currentMirror || mirrorProgress" class="info-section">
           <div class="info-title">镜像源信息</div>
           <div class="info-items">
-            <a-tag v-if="currentMirror" color="blue">
-              当前镜像源: {{ currentMirror }}
-            </a-tag>
+            <a-tag v-if="currentMirror" color="blue"> 当前镜像源: {{ currentMirror }} </a-tag>
             <a-tag v-if="mirrorProgress" color="purple">
               尝试进度: {{ mirrorProgress.current }}/{{ mirrorProgress.total }}
             </a-tag>
@@ -82,12 +107,8 @@
         <div v-if="downloadSpeed || downloadSize" class="info-section">
           <div class="info-title">下载信息</div>
           <div class="info-items">
-            <a-tag v-if="downloadSpeed" color="green">
-              下载速度: {{ downloadSpeed }}
-            </a-tag>
-            <a-tag v-if="downloadSize" color="cyan">
-              已下载: {{ downloadSize }}
-            </a-tag>
+            <a-tag v-if="downloadSpeed" color="green"> 下载速度: {{ downloadSpeed }} </a-tag>
+            <a-tag v-if="downloadSize" color="cyan"> 已下载: {{ downloadSize }} </a-tag>
           </div>
         </div>
 
@@ -131,7 +152,13 @@
 
     <!-- 失败状态 - 显示镜像源选择 -->
     <div v-else-if="status === 'failed' && showMirrorSelection" class="failed-state">
-      <a-alert type="error" :message="`${title}失败`" :description="message" show-icon style="margin-bottom: 20px" />
+      <a-alert
+        type="error"
+        :message="`${title}失败`"
+        :description="message"
+        show-icon
+        style="margin-bottom: 20px"
+      />
 
       <!-- 镜像源选择 -->
       <div class="mirror-selection">
@@ -144,8 +171,13 @@
             <a-tag color="green">推荐使用</a-tag>
           </div>
           <div class="mirror-grid">
-            <div v-for="mirror in mirrorMirrors" :key="mirror.key" class="mirror-card"
-              :class="{ active: selectedMirror === mirror.key }" @click="$emit('update:selected-mirror', mirror.key)">
+            <div
+              v-for="mirror in mirrorMirrors"
+              :key="mirror.key"
+              class="mirror-card"
+              :class="{ active: selectedMirror === mirror.key }"
+              @click="$emit('update:selected-mirror', mirror.key)"
+            >
               <div class="mirror-header">
                 <div class="mirror-title">
                   <h4>{{ mirror.name }}</h4>
@@ -164,8 +196,13 @@
             <a-tag color="orange">中国大陆连通性不佳</a-tag>
           </div>
           <div class="mirror-grid">
-            <div v-for="mirror in officialMirrors" :key="mirror.key" class="mirror-card"
-              :class="{ active: selectedMirror === mirror.key }" @click="$emit('update:selected-mirror', mirror.key)">
+            <div
+              v-for="mirror in officialMirrors"
+              :key="mirror.key"
+              class="mirror-card"
+              :class="{ active: selectedMirror === mirror.key }"
+              @click="$emit('update:selected-mirror', mirror.key)"
+            >
               <div class="mirror-header">
                 <div class="mirror-title">
                   <h4>{{ mirror.name }}</h4>
@@ -185,9 +222,7 @@
               使用选中的镜像源重试
             </a-button>
           </a-space>
-          <div class="countdown-text" v-if="countdown > 0">
-            {{ countdown }} 秒后自动重试
-          </div>
+          <div v-if="countdown > 0" class="countdown-text">{{ countdown }} 秒后自动重试</div>
         </div>
       </div>
     </div>
@@ -274,7 +309,7 @@ const props = withDefaults(defineProps<Props>(), {
   deployProgress: undefined,
   operationDesc: '',
   checkInfo: undefined,
-  mirrorProgress: undefined
+  mirrorProgress: undefined,
 })
 
 defineEmits<{
@@ -284,7 +319,9 @@ defineEmits<{
 }>()
 
 const mirrorMirrors = computed(() => props.mirrors.filter((m: MirrorConfig) => m.type === 'mirror'))
-const officialMirrors = computed(() => props.mirrors.filter((m: MirrorConfig) => m.type === 'official'))
+const officialMirrors = computed(() =>
+  props.mirrors.filter((m: MirrorConfig) => m.type === 'official')
+)
 </script>
 
 <style scoped>

--- a/frontend/src/views/Initialization/index.vue
+++ b/frontend/src/views/Initialization/index.vue
@@ -12,8 +12,15 @@
 
     <div class="step-content">
       <!-- 当前步骤内容 -->
-      <component :is="currentStepComponent" v-bind="currentStepProps" @update:selected-mirror="handleMirrorSelect"
-        @retry="handleRetry" @skip="handleSkip" @complete="handleBackendComplete" @error="handleBackendError" />
+      <component
+        :is="currentStepComponent"
+        v-bind="currentStepProps"
+        @update:selected-mirror="handleMirrorSelect"
+        @retry="handleRetry"
+        @skip="handleSkip"
+        @complete="handleBackendComplete"
+        @error="handleBackendError"
+      />
     </div>
 
     <!-- 步骤操作按钮区域 - 后端启动完成后会自动进入应用，不需要手动按钮 -->
@@ -21,9 +28,19 @@
   </div>
 
   <!-- 跳过初始化弹窗 -->
-  <a-modal v-model:open="forceEnterVisible" title="警告" ok-text="我知道我在做什么" cancel-text="取消"
-    @ok="handleForceEnterConfirm">
-    <a-alert message="注意" description="你正在尝试跳过初始化流程，可能导致程序无法正常运行。请确保你已经手动完成了所有配置。" type="warning" show-icon />
+  <a-modal
+    v-model:open="forceEnterVisible"
+    title="警告"
+    ok-text="我知道我在做什么"
+    cancel-text="取消"
+    @ok="handleForceEnterConfirm"
+  >
+    <a-alert
+      message="注意"
+      description="你正在尝试跳过初始化流程，可能导致程序无法正常运行。请确保你已经手动完成了所有配置。"
+      type="warning"
+      show-icon
+    />
   </a-modal>
 </template>
 
@@ -95,12 +112,108 @@ interface StepState {
 }
 
 const stepStates = ref<Record<string, StepState>>({
-  python: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
-  pip: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
-  git: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
-  repository: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
-  dependency: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
-  backend: { status: 'waiting', message: '', progress: 0, showMirrorSelection: false, mirrors: [], selectedMirror: '', countdown: 0, currentMirror: '', downloadSpeed: '', downloadSize: '', installMessage: '', installProgress: 0, deployMessage: '', deployProgress: 0, operationDesc: '' },
+  python: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
+  pip: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
+  git: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
+  repository: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
+  dependency: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
+  backend: {
+    status: 'waiting',
+    message: '',
+    progress: 0,
+    showMirrorSelection: false,
+    mirrors: [],
+    selectedMirror: '',
+    countdown: 0,
+    currentMirror: '',
+    downloadSpeed: '',
+    downloadSize: '',
+    installMessage: '',
+    installProgress: 0,
+    deployMessage: '',
+    deployProgress: 0,
+    operationDesc: '',
+  },
 })
 
 // 倒计时定时器
@@ -127,7 +240,10 @@ const currentStepProps = computed(() => {
     message: state.message,
     progress: state.progress,
     showProgress: true,
-    progressStatus: (state.status === 'failed' ? 'exception' : 'normal') as 'normal' | 'exception' | 'success',
+    progressStatus: (state.status === 'failed' ? 'exception' : 'normal') as
+      | 'normal'
+      | 'exception'
+      | 'success',
     successTitle: `${step.title}完成`,
     showMirrorSelection: state.showMirrorSelection, // 所有步骤失败时都显示镜像源选择
     showSkipButton: step.canSkip && state.status === 'failed', // 只有可跳过的步骤且失败时才显示跳过按钮
@@ -143,7 +259,7 @@ const currentStepProps = computed(() => {
     deployProgress: state.deployProgress,
     operationDesc: state.operationDesc,
     checkInfo: state.checkInfo,
-    mirrorProgress: state.mirrorProgress
+    mirrorProgress: state.mirrorProgress,
   }
 })
 
@@ -286,7 +402,10 @@ async function executeStep(stepKey: string): Promise<boolean> {
         result = await (window.electronAPI as any).installGit(state.selectedMirror)
         break
       case 'repository':
-        result = await (window.electronAPI as any).pullRepository(targetBranch.value, state.selectedMirror)
+        result = await (window.electronAPI as any).pullRepository(
+          targetBranch.value,
+          state.selectedMirror
+        )
         break
       case 'dependency':
         result = await (window.electronAPI as any).installDependencies(state.selectedMirror)
@@ -572,11 +691,11 @@ async function loadMirrorConfigs() {
 
     // 并行获取所有镜像源配置
     const [pythonMirrors, getPipMirrors, gitMirrors, repoMirrors, pipMirrors] = await Promise.all([
-      api.getMirrors('python'),      // Python 安装包
-      api.getMirrors('get_pip'),     // get-pip.py 脚本
-      api.getMirrors('git'),         // Git 安装包
-      api.getMirrors('repo'),        // Git 仓库
-      api.getMirrors('pip_mirror'),  // PyPI 镜像源
+      api.getMirrors('python'), // Python 安装包
+      api.getMirrors('get_pip'), // get-pip.py 脚本
+      api.getMirrors('git'), // Git 安装包
+      api.getMirrors('repo'), // Git 仓库
+      api.getMirrors('pip_mirror'), // PyPI 镜像源
     ])
 
     // 转换后端镜像源格式为前端格式
@@ -679,7 +798,9 @@ onMounted(async () => {
       }
     } else {
       // 版本号不同或无记录：执行完整初始化流程
-      logger.info(`自动更新已关闭，初始化版本号不一致（当前${version} vs 保存${savedVersion}），执行完整初始化流程`)
+      logger.info(
+        `自动更新已关闭，初始化版本号不一致（当前${version} vs 保存${savedVersion}），执行完整初始化流程`
+      )
     }
   } else if (!forceBackendUpdate) {
     // 自动更新开启且非强制更新：无条件执行完整初始化流程

--- a/frontend/src/views/Logs.vue
+++ b/frontend/src/views/Logs.vue
@@ -27,254 +27,264 @@ const editorTheme = computed(() => (isDark.value ? 'vs-dark' : 'vs'))
 
 // Monaco Editor 配置
 const editorOptions = {
-    readOnly: true,
-    fontSize: 13,
-    lineNumbers: 'on',
-    minimap: { enabled: false },
-    scrollBeyondLastLine: false,
-    automaticLayout: true,
-    wordWrap: 'on',
-    wrappingIndent: 'same',
-    scrollbar: {
-        vertical: 'auto',
-        horizontal: 'auto',
-        useShadows: false,
-    },
+  readOnly: true,
+  fontSize: 13,
+  lineNumbers: 'on',
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  automaticLayout: true,
+  wordWrap: 'on',
+  wrappingIndent: 'same',
+  scrollbar: {
+    vertical: 'auto',
+    horizontal: 'auto',
+    useShadows: false,
+  },
 } as const
 
 // 处理编辑器挂载
 const handleEditorMount = (editor: any) => {
-    editorInstance = editor
-    // 初始滚动到底部
-    if (logMode.value === 'follow' && logs.value) {
-        nextTick(() => scrollToBottom())
-    }
+  editorInstance = editor
+  // 初始滚动到底部
+  if (logMode.value === 'follow' && logs.value) {
+    nextTick(() => scrollToBottom())
+  }
 }
 
 // 滚动到底部
 const scrollToBottom = () => {
-    if (editorInstance) {
-        const lineCount = editorInstance.getModel()?.getLineCount()
-        if (lineCount) {
-            editorInstance.revealLine(lineCount)
-            editorInstance.setScrollTop(editorInstance.getScrollHeight())
-        }
+  if (editorInstance) {
+    const lineCount = editorInstance.getModel()?.getLineCount()
+    if (lineCount) {
+      editorInstance.revealLine(lineCount)
+      editorInstance.setScrollTop(editorInstance.getScrollHeight())
     }
+  }
 }
 
 // 切换日志模式
 const toggleLogMode = () => {
-    if (logMode.value === 'follow') {
-        // 从保持最新切换到自由浏览
-        logMode.value = 'browse'
-    } else {
-        // 从自由浏览切换到保持最新
-        logMode.value = 'follow'
-        setTimeout(scrollToBottom, 10)
-    }
+  if (logMode.value === 'follow') {
+    // 从保持最新切换到自由浏览
+    logMode.value = 'browse'
+  } else {
+    // 从自由浏览切换到保持最新
+    logMode.value = 'follow'
+    setTimeout(scrollToBottom, 10)
+  }
 }
 
 // 加载日志
 const loadLogs = async (silent = false) => {
+  if (!silent) {
+    loading.value = true
+  }
+  try {
+    const fileName = selectedLogFile.value === 'app' ? 'app.log' : 'frontend.log'
+    const logContent = await (window as any).electronAPI?.getLogs?.(0, fileName)
+    if (logContent) {
+      logs.value = logContent
+      // 只在保持最新模式下自动滚动
+      if (logMode.value === 'follow') {
+        nextTick(() => scrollToBottom())
+      }
+    } else {
+      logs.value = ''
+    }
+  } catch (error) {
     if (!silent) {
-        loading.value = true
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`加载日志失败: ${errorMsg}`)
+      message.error('加载日志失败')
     }
-    try {
-        const fileName = selectedLogFile.value === 'app' ? 'app.log' : 'frontend.log'
-        const logContent = await (window as any).electronAPI?.getLogs?.(0, fileName)
-        if (logContent) {
-            logs.value = logContent
-            // 只在保持最新模式下自动滚动
-            if (logMode.value === 'follow') {
-                nextTick(() => scrollToBottom())
-            }
-        } else {
-            logs.value = ''
-        }
-    } catch (error) {
-        if (!silent) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.error(`加载日志失败: ${errorMsg}`)
-            message.error('加载日志失败')
-        }
-    } finally {
-        if (!silent) {
-            loading.value = false
-        }
+  } finally {
+    if (!silent) {
+      loading.value = false
     }
+  }
 }
 
 // 开始实时刷新
 const startRealTimeRefresh = () => {
-    if (refreshInterval) {
-        clearInterval(refreshInterval)
-    }
-    refreshInterval = setInterval(() => {
-        loadLogs(true) // 静默刷新
-    }, 2000) // 每2秒刷新一次
+  if (refreshInterval) {
+    clearInterval(refreshInterval)
+  }
+  refreshInterval = setInterval(() => {
+    loadLogs(true) // 静默刷新
+  }, 2000) // 每2秒刷新一次
 }
 
 // 停止实时刷新
 const stopRealTimeRefresh = () => {
-    if (refreshInterval) {
-        clearInterval(refreshInterval)
-        refreshInterval = null
-    }
+  if (refreshInterval) {
+    clearInterval(refreshInterval)
+    refreshInterval = null
+  }
 }
 
 // 切换实时刷新
 const toggleRealTime = () => {
-    realTimeEnabled.value = !realTimeEnabled.value
-    if (realTimeEnabled.value) {
-        startRealTimeRefresh()
-        message.success('已启用自动更新')
-    } else {
-        stopRealTimeRefresh()
-        message.info('已停止自动更新')
-    }
+  realTimeEnabled.value = !realTimeEnabled.value
+  if (realTimeEnabled.value) {
+    startRealTimeRefresh()
+    message.success('已启用自动更新')
+  } else {
+    stopRealTimeRefresh()
+    message.info('已停止自动更新')
+  }
 }
 
 // 切换日志文件
 const onLogFileChange = () => {
-    loadLogs()
+  loadLogs()
 }
 
 // 监听日志内容变化
 watch(logs, () => {
-    if (logMode.value === 'follow') {
-        nextTick(() => scrollToBottom())
-    }
+  if (logMode.value === 'follow') {
+    nextTick(() => scrollToBottom())
+  }
 })
 
 onMounted(() => {
-    loadLogs()
-    if (realTimeEnabled.value) {
-        startRealTimeRefresh()
-    }
+  loadLogs()
+  if (realTimeEnabled.value) {
+    startRealTimeRefresh()
+  }
 })
 
 onUnmounted(() => {
-    stopRealTimeRefresh()
+  stopRealTimeRefresh()
 })
 </script>
 
 <template>
-    <div class="logs-container">
-        <div class="logs-header">
-            <h1 class="page-title">日志查看</h1>
-            <div class="header-actions">
-                <a-space :size="12">
-                    <a-radio-group v-model:value="selectedLogFile" button-style="solid" @change="onLogFileChange">
-                        <a-radio-button value="app">后端日志</a-radio-button>
-                        <a-radio-button value="frontend">前端日志</a-radio-button>
-                    </a-radio-group>
+  <div class="logs-container">
+    <div class="logs-header">
+      <h1 class="page-title">日志查看</h1>
+      <div class="header-actions">
+        <a-space :size="12">
+          <a-radio-group
+            v-model:value="selectedLogFile"
+            button-style="solid"
+            @change="onLogFileChange"
+          >
+            <a-radio-button value="app">后端日志</a-radio-button>
+            <a-radio-button value="frontend">前端日志</a-radio-button>
+          </a-radio-group>
 
-                    <a-button :type="logMode === 'follow' ? 'primary' : 'default'" @click="toggleLogMode">
-                        {{ logMode === 'follow' ? '保持最新' : '自由浏览' }}
-                    </a-button>
+          <a-button :type="logMode === 'follow' ? 'primary' : 'default'" @click="toggleLogMode">
+            {{ logMode === 'follow' ? '保持最新' : '自由浏览' }}
+          </a-button>
 
-                    <a-button :type="realTimeEnabled ? 'primary' : 'default'" @click="toggleRealTime">
-                        <template #icon>
-                            <SyncOutlined :spin="realTimeEnabled" />
-                        </template>
-                        {{ realTimeEnabled ? '自动更新' : '停止更新' }}
-                    </a-button>
+          <a-button :type="realTimeEnabled ? 'primary' : 'default'" @click="toggleRealTime">
+            <template #icon>
+              <SyncOutlined :spin="realTimeEnabled" />
+            </template>
+            {{ realTimeEnabled ? '自动更新' : '停止更新' }}
+          </a-button>
 
-                    <a-button @click="exportMaaEndIssueReport" :loading="exporting" type="primary">
-                        <template #icon>
-                            <DownloadOutlined />
-                        </template>
-                        导出 MaaEnd 问题包
-                    </a-button>
-                </a-space>
-            </div>
-        </div>
-
-        <div class="logs-content">
-            <a-spin :spinning="loading" tip="加载日志中...">
-                <div class="editor-container" :class="{ 'log-locked': logMode === 'follow' }">
-                    <vue-monaco-editor v-model:value="logs" language="log" :theme="editorTheme" :options="editorOptions"
-                        class="log-editor" @mount="handleEditorMount" />
-                </div>
-            </a-spin>
-        </div>
+          <a-button :loading="exporting" type="primary" @click="exportMaaEndIssueReport">
+            <template #icon>
+              <DownloadOutlined />
+            </template>
+            导出 MaaEnd 问题包
+          </a-button>
+        </a-space>
+      </div>
     </div>
+
+    <div class="logs-content">
+      <a-spin :spinning="loading" tip="加载日志中...">
+        <div class="editor-container" :class="{ 'log-locked': logMode === 'follow' }">
+          <vue-monaco-editor
+            v-model:value="logs"
+            language="log"
+            :theme="editorTheme"
+            :options="editorOptions"
+            class="log-editor"
+            @mount="handleEditorMount"
+          />
+        </div>
+      </a-spin>
+    </div>
+  </div>
 </template>
 
 <style scoped>
 .logs-container {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
-    box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  box-sizing: border-box;
 }
 
 .logs-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-    flex-shrink: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-shrink: 0;
 }
 
 .page-title {
-    margin: 0;
-    font-size: 32px;
-    font-weight: 700;
-    background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .header-actions {
-    display: flex;
-    gap: 12px;
+  display: flex;
+  gap: 12px;
 }
 
 .logs-content {
-    flex: 1;
-    background: var(--ant-color-bg-container);
-    border-radius: 12px;
-    padding: 20px;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
+  flex: 1;
+  background: var(--ant-color-bg-container);
+  border-radius: 12px;
+  padding: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .editor-container {
-    flex: 1;
-    border: 1px solid var(--ant-color-border);
-    border-radius: 8px;
-    overflow: hidden;
-    transition: all 0.3s ease;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* 保持最新模式：添加视觉提示 */
 .log-locked {
-    border-color: var(--ant-color-primary);
-    box-shadow: 0 0 0 2px var(--ant-color-primary-bg);
+  border-color: var(--ant-color-primary);
+  box-shadow: 0 0 0 2px var(--ant-color-primary-bg);
 }
 
 .log-editor {
-    flex: 1;
-    min-height: 0;
+  flex: 1;
+  min-height: 0;
 }
 
 :deep(.monaco-editor) {
-    border-radius: 8px;
+  border-radius: 8px;
 }
 
 :deep(.ant-spin-nested-loading),
 :deep(.ant-spin-container) {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
@@ -14,8 +14,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input v-model:value="formData.userName" placeholder="请输入用户名" :disabled="loading" size="large"
-            class="modern-input" @blur="emitSave('userName', formData.userName)" />
+          <a-input
+            v-model:value="formData.userName"
+            placeholder="请输入用户名"
+            :disabled="loading"
+            size="large"
+            class="modern-input"
+            @blur="emitSave('userName', formData.userName)"
+          />
         </a-form-item>
       </a-col>
       <a-col :span="12">
@@ -28,8 +34,11 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Status" size="large"
-            @change="emitSave('Info.Status', formData.Info.Status)">
+          <a-select
+            v-model:value="formData.Info.Status"
+            size="large"
+            @change="emitSave('Info.Status', formData.Info.Status)"
+          >
             <a-select-option :value="true">是</a-select-option>
             <a-select-option :value="false">否</a-select-option>
           </a-select>
@@ -63,8 +72,8 @@
           <template #label>
             <a-tooltip>
               <template #title>
-                <div style="max-width: 260px; white-space: normal;">
-                  填写目标账号时会在账号列表中逐页下滑查找并切换，找不到则任务失败<br><br>
+                <div style="max-width: 260px; white-space: normal">
+                  填写目标账号时会在账号列表中逐页下滑查找并切换，找不到则任务失败<br /><br />
                   目前该功能仅支持官服，且仅支持 1280×720 实际未缩放分辨率
                 </div>
               </template>
@@ -97,9 +106,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="0"
-            :disabled="loading" size="large" style="width: 100%"
-            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
+          <a-input-number
+            v-model:value="formData.Info.RemainedDay"
+            :min="-1"
+            :max="9999"
+            placeholder="0"
+            :disabled="loading"
+            size="large"
+            style="width: 100%"
+            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -113,8 +129,14 @@
           </span>
         </a-tooltip>
       </template>
-      <a-textarea v-model:value="formData.Info.Notes" placeholder="请输入备注信息" :rows="4" :disabled="loading"
-        class="modern-input" @blur="emitSave('Info.Notes', formData.Info.Notes)" />
+      <a-textarea
+        v-model:value="formData.Info.Notes"
+        placeholder="请输入备注信息"
+        :rows="4"
+        :disabled="loading"
+        class="modern-input"
+        @blur="emitSave('Info.Notes', formData.Info.Notes)"
+      />
     </a-form-item>
   </div>
 </template>

--- a/frontend/src/views/M9AUserEdit/NotifyConfigSection.vue
+++ b/frontend/src/views/M9AUserEdit/NotifyConfigSection.vue
@@ -8,8 +8,11 @@
         <span style="font-weight: 500">启用通知</span>
       </a-col>
       <a-col :span="18">
-        <a-switch v-model:checked="formData.Notify.Enabled" :disabled="loading"
-          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)" />
+        <a-switch
+          v-model:checked="formData.Notify.Enabled"
+          :disabled="loading"
+          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)"
+        />
         <span class="switch-description">启用后将发送此用户的任务通知到选中的渠道</span>
       </a-col>
     </a-row>
@@ -18,40 +21,64 @@
         <span style="font-weight: 500">通知内容</span>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 32px">
-        <a-checkbox v-model:checked="formData.Notify.IfSendStatistic" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)">统计信息
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendStatistic"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)"
+          >统计信息
         </a-checkbox>
       </a-col>
     </a-row>
 
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfSendMail" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)">邮件通知
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendMail"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)"
+          >邮件通知
         </a-checkbox>
       </a-col>
       <a-col :span="18">
-        <a-input v-model:value="formData.Notify.ToAddress" placeholder="请输入收件人邮箱地址"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail" size="large"
-          style="width: 100%" @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)" />
+        <a-input
+          v-model:value="formData.Notify.ToAddress"
+          placeholder="请输入收件人邮箱地址"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail"
+          size="large"
+          style="width: 100%"
+          @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)"
+        />
       </a-col>
     </a-row>
 
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfServerChan" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)">Server酱
+        <a-checkbox
+          v-model:checked="formData.Notify.IfServerChan"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)"
+          >Server酱
         </a-checkbox>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 8px">
-        <a-input v-model:value="formData.Notify.ServerChanKey" placeholder="请输入SENDKEY"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan" size="large" style="flex: 2"
-          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)" />
+        <a-input
+          v-model:value="formData.Notify.ServerChanKey"
+          placeholder="请输入SENDKEY"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan"
+          size="large"
+          style="flex: 2"
+          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)"
+        />
       </a-col>
     </a-row>
 
     <div style="margin-top: 16px">
-      <WebhookManager mode="user" :script-id="props.scriptId" :user-id="props.userId" @change="handleWebhookChange" />
+      <WebhookManager
+        mode="user"
+        :script-id="props.scriptId"
+        :user-id="props.userId"
+        @change="handleWebhookChange"
+      />
     </div>
   </div>
 </template>

--- a/frontend/src/views/M9AUserEdit/TaskOptionRenderer.vue
+++ b/frontend/src/views/M9AUserEdit/TaskOptionRenderer.vue
@@ -2,7 +2,7 @@
   <div class="task-option-renderer">
     <div v-for="(option, index) in currentOptions" :key="index" class="option-item">
       <div class="option-label">{{ getOptionLabel(option.name) }}</div>
-      
+
       <template v-if="optionDefinitions && optionDefinitions[option.name]">
         <a-radio-group
           v-if="optionDefinitions[option.name].type === 'switch'"
@@ -17,7 +17,7 @@
             {{ getCaseLabel(caseItem) }}
           </a-radio>
         </a-radio-group>
-        
+
         <a-select
           v-else-if="['select', 'scan_select'].includes(optionDefinitions[option.name].type)"
           v-model:value="option.index"
@@ -32,7 +32,7 @@
             {{ getCaseLabel(caseItem) }}
           </a-select-option>
         </a-select>
-        
+
         <div
           v-else-if="optionDefinitions[option.name].type === 'input' && option.input_values"
           class="input-fields"
@@ -47,22 +47,19 @@
               v-model:value="option.input_values[input.name]"
               :min="0"
               style="width: 100%"
-              @change="handleInputChange(index)"
+              @change="handleInputChange"
             />
             <a-input
               v-else
               v-model:value="option.input_values[input.name]"
               :placeholder="input.description || input.name"
               style="width: 100%"
-              @change="handleInputChange(index)"
+              @change="handleInputChange"
             />
           </a-form-item>
         </div>
-        
-        <div
-          v-else-if="optionDefinitions[option.name].type === 'checkbox'"
-          class="checkbox-cases"
-        >
+
+        <div v-else-if="optionDefinitions[option.name].type === 'checkbox'" class="checkbox-cases">
           <a-checkbox-group
             v-model:value="option.selected_cases"
             @change="handleCheckboxChange(index)"
@@ -77,7 +74,7 @@
           </a-checkbox-group>
         </div>
       </template>
-      
+
       <div v-if="option.sub_options && option.sub_options.length > 0" class="sub-options">
         <TaskOptionRenderer
           :task-options="option.sub_options"
@@ -105,7 +102,7 @@ const emit = defineEmits<{
 const currentOptions = ref<M9ATaskOption[]>([])
 
 const getDisplayLabel = (label: string | undefined, fallback: string | undefined) => {
-  return label && !label.startsWith('$') ? label : fallback ?? ''
+  return label && !label.startsWith('$') ? label : (fallback ?? '')
 }
 
 const getOptionLabel = (optionName: string) => {
@@ -121,15 +118,17 @@ const getDisplayCases = (optionDef: any) => {
   if (!optionDef || !optionDef.cases) {
     return []
   }
-  
+
   const cases = [...optionDef.cases]
-  
-  const isYesNoSwitch = cases.some(c => c.name === 'Yes' || c.name === 'No' || c.name === '是' || c.name === '否')
-  
+
+  const isYesNoSwitch = cases.some(
+    c => c.name === 'Yes' || c.name === 'No' || c.name === '是' || c.name === '否'
+  )
+
   if (!isYesNoSwitch) {
     return cases
   }
-  
+
   return cases.sort((a, b) => {
     const aIsYes = a.name === 'Yes' || a.name === '是'
     const bIsYes = b.name === 'Yes' || b.name === '是'
@@ -148,10 +147,10 @@ const getCaseIndex = (optionDef: any, caseItem: any) => {
 
 const buildSubOptions = (optionNames: string[]): M9ATaskOption[] => {
   const subOpts: M9ATaskOption[] = []
-  
+
   for (const optName of optionNames) {
     const optItem: M9ATaskOption = { name: optName, index: 0 }
-    
+
     const optDef = props.optionDefinitions[optName]
     if (optDef && optDef.cases && optDef.cases.length > 0) {
       const subSubOpts = getSubOptions(optDef, 0)
@@ -159,10 +158,10 @@ const buildSubOptions = (optionNames: string[]): M9ATaskOption[] => {
         optItem.sub_options = subSubOpts
       }
     }
-    
+
     subOpts.push(optItem)
   }
-  
+
   return subOpts
 }
 
@@ -186,7 +185,7 @@ const getCheckboxSubOptions = (optionDef: any, selectedCases: string[] = []): M9
 
   const optionNames = optionDef.cases
     .filter((caseItem: any) => selectedCases.includes(caseItem.name))
-    .flatMap((caseItem: any) => Array.isArray(caseItem.option) ? caseItem.option : [])
+    .flatMap((caseItem: any) => (Array.isArray(caseItem.option) ? caseItem.option : []))
 
   return buildSubOptions(Array.from(new Set(optionNames)))
 }
@@ -207,26 +206,26 @@ const getDefaultCaseNames = (optionDef: any) => {
 
 const initializeOptions = () => {
   currentOptions.value = props.taskOptions.map(opt => {
-    const newOpt: M9ATaskOption = { 
-      name: opt.name, 
+    const newOpt: M9ATaskOption = {
+      name: opt.name,
       index: opt.index ?? 0,
       sub_options: opt.sub_options ? [...opt.sub_options] : undefined,
       input_values: opt.input_values ? { ...opt.input_values } : undefined,
-      selected_cases: opt.selected_cases ? [...opt.selected_cases] : undefined
+      selected_cases: opt.selected_cases ? [...opt.selected_cases] : undefined,
     }
-    
+
     if (props.optionDefinitions && props.optionDefinitions[opt.name]) {
       const optDef = props.optionDefinitions[opt.name]
 
       if (optDef.type === 'checkbox' && newOpt.selected_cases === undefined) {
         newOpt.selected_cases = getDefaultCaseNames(optDef)
       }
-      
+
       if (optDef.type === 'input' && optDef.inputs) {
         if (!newOpt.input_values) {
           newOpt.input_values = {}
         }
-        
+
         for (const input of optDef.inputs) {
           if (newOpt.input_values[input.name] === undefined && input.default !== undefined) {
             if (input.pipeline_type === 'int') {
@@ -237,18 +236,19 @@ const initializeOptions = () => {
           }
         }
       }
-      
-      const subOpts = optDef.type === 'checkbox'
-        ? getCheckboxSubOptions(optDef, newOpt.selected_cases ?? [])
-        : getSubOptions(optDef, opt.index ?? 0)
-      
+
+      const subOpts =
+        optDef.type === 'checkbox'
+          ? getCheckboxSubOptions(optDef, newOpt.selected_cases ?? [])
+          : getSubOptions(optDef, opt.index ?? 0)
+
       if (subOpts.length > 0) {
         if (!newOpt.sub_options || newOpt.sub_options.length === 0) {
           newOpt.sub_options = subOpts
         } else {
-          const currentSubOptNames = newOpt.sub_options.map((o) => o.name)
-          const newSubOptNames = subOpts.map((o) => o.name)
-          
+          const currentSubOptNames = newOpt.sub_options.map(o => o.name)
+          const newSubOptNames = subOpts.map(o => o.name)
+
           if (JSON.stringify(currentSubOptNames) !== JSON.stringify(newSubOptNames)) {
             newOpt.sub_options = subOpts
           }
@@ -257,7 +257,7 @@ const initializeOptions = () => {
         newOpt.sub_options = []
       }
     }
-    
+
     return newOpt
   })
 }
@@ -266,14 +266,14 @@ const handleOptionChange = (index: number) => {
   if (props.optionDefinitions && props.optionDefinitions[currentOptions.value[index].name]) {
     const optDef = props.optionDefinitions[currentOptions.value[index].name]
     const subOpts = getSubOptions(optDef, currentOptions.value[index].index)
-    
+
     if (subOpts.length > 0) {
       currentOptions.value[index].sub_options = subOpts
     } else {
       currentOptions.value[index].sub_options = []
     }
   }
-  
+
   emit('update', currentOptions.value)
 }
 

--- a/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
+++ b/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
@@ -3,7 +3,7 @@
     <div class="section-header">
       <h3>任务队列配置</h3>
     </div>
-    
+
     <a-row :gutter="24" class="task-queue-layout">
       <a-col :span="12" class="left-column">
         <div class="column-header">
@@ -22,7 +22,7 @@
             </template>
           </a-dropdown>
         </div>
-        
+
         <div class="task-list">
           <!-- 预设模板区域（队列为空时显示） -->
           <div v-if="localTaskQueue.length === 0" class="preset-section">
@@ -44,18 +44,25 @@
                 </div>
 
                 <div class="preset-tasks-preview">
-                  <div class="task-chip" v-for="(item, idx) in matchedTasks" :key="idx">
+                  <div v-for="(item, idx) in matchedTasks" :key="idx" class="task-chip">
                     <span class="task-dot" :class="{ 'task-dot-miss': !item.matched }"></span>
-                    <span class="task-name" :class="{ 'task-name-miss': !item.matched }">{{ item.name }}</span>
+                    <span class="task-name" :class="{ 'task-name-miss': !item.matched }">{{
+                      item.name
+                    }}</span>
                     <CheckCircleFilled v-if="item.matched" class="task-check" />
                     <CloseCircleFilled v-else class="task-check task-check-miss" />
                   </div>
                 </div>
 
                 <div class="preset-actions">
-                  <a-button type="primary" size="large" block :loading="addingFromPreset"
+                  <a-button
+                    type="primary"
+                    size="large"
+                    block
+                    :loading="addingFromPreset"
                     :disabled="matchedCount === 0"
-                    @click="addFromPreset">
+                    @click="addFromPreset"
+                  >
                     <template #icon><ThunderboltOutlined /></template>
                     一键添加 {{ matchedCount }} 个任务
                   </a-button>
@@ -110,32 +117,37 @@
           </draggable>
         </div>
       </a-col>
-      
+
       <a-col :span="12" class="right-column">
         <div class="column-header">
           <span>任务配置</span>
         </div>
-        
-        <div class="task-config" v-if="selectedTaskIndex !== null && taskQueue[selectedTaskIndex]">
+
+        <div v-if="selectedTaskIndex !== null && taskQueue[selectedTaskIndex]" class="task-config">
           <div class="selected-task-name">
             {{ getQueuedTaskLabel(taskQueue[selectedTaskIndex]) }}
           </div>
-          
+
           <TaskOptionRenderer
             :task-options="taskQueue[selectedTaskIndex].options"
             :option-definitions="getOptionDefinitions(selectedTaskIndex)"
             @update="handleOptionUpdate"
           />
-          
-          <a-popconfirm title="确定要删除这个任务吗？" ok-text="确定" cancel-text="取消" @confirm="deleteSelectedTask">
-            <a-button danger block style="margin-top: 24px; height: 40px; font-size: 14px;">
+
+          <a-popconfirm
+            title="确定要删除这个任务吗？"
+            ok-text="确定"
+            cancel-text="取消"
+            @confirm="deleteSelectedTask"
+          >
+            <a-button danger block style="margin-top: 24px; height: 40px; font-size: 14px">
               <template #icon><DeleteOutlined /></template>
               删除此任务
             </a-button>
           </a-popconfirm>
         </div>
-        
-        <div class="no-selection" v-else>
+
+        <div v-else class="no-selection">
           <Empty description="请从左侧选择一个任务进行配置" />
         </div>
       </a-col>
@@ -145,7 +157,15 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
-import { PlusOutlined, UpOutlined, DownOutlined, DeleteOutlined, ThunderboltOutlined, CheckCircleFilled, CloseCircleFilled } from '@ant-design/icons-vue'
+import {
+  PlusOutlined,
+  UpOutlined,
+  DownOutlined,
+  DeleteOutlined,
+  ThunderboltOutlined,
+  CheckCircleFilled,
+  CloseCircleFilled,
+} from '@ant-design/icons-vue'
 import { message } from 'ant-design-vue'
 import draggable from 'vuedraggable'
 import { Service } from '@/api'
@@ -219,7 +239,9 @@ const getDefaultCaseIndex = (optDef: any) => {
   if (!optDef || !Array.isArray(optDef.cases) || typeof optDef.default_case !== 'string') {
     return 0
   }
-  const defaultIndex = optDef.cases.findIndex((caseItem: any) => caseItem.name === optDef.default_case)
+  const defaultIndex = optDef.cases.findIndex(
+    (caseItem: any) => caseItem.name === optDef.default_case
+  )
   return defaultIndex >= 0 ? defaultIndex : 0
 }
 
@@ -241,23 +263,23 @@ const buildDefaultOptions = (taskDef: any): M9ATaskOption[] => {
   const options: M9ATaskOption[] = []
   const optionNames = taskDef.option || []
   const optionDefs = taskDef._option_definitions || {}
-  
+
   for (const optName of optionNames) {
     const optItem: M9ATaskOption = { name: optName, index: 0 }
-    
+
     const optDef = optionDefs[optName]
     if (optDef) {
       if (optDef.type === 'checkbox') {
         optItem.selected_cases = getDefaultCaseNames(optDef)
         const subOptionNames = Array.isArray(optDef.cases)
           ? optDef.cases
-            .filter((caseItem: any) => optItem.selected_cases?.includes(caseItem.name))
-            .flatMap((caseItem: any) => Array.isArray(caseItem.option) ? caseItem.option : [])
+              .filter((caseItem: any) => optItem.selected_cases?.includes(caseItem.name))
+              .flatMap((caseItem: any) => (Array.isArray(caseItem.option) ? caseItem.option : []))
           : []
         if (subOptionNames.length > 0) {
           const subOpts = buildDefaultOptions({
             option: Array.from(new Set(subOptionNames)),
-            _option_definitions: optionDefs
+            _option_definitions: optionDefs,
           })
           if (subOpts.length > 0) {
             optItem.sub_options = subOpts
@@ -282,7 +304,7 @@ const buildDefaultOptions = (taskDef: any): M9ATaskOption[] => {
         if (currentCase.option) {
           const subOpts = buildDefaultOptions({
             option: currentCase.option,
-            _option_definitions: optionDefs
+            _option_definitions: optionDefs,
           })
           if (subOpts.length > 0) {
             optItem.sub_options = subOpts
@@ -290,23 +312,25 @@ const buildDefaultOptions = (taskDef: any): M9ATaskOption[] => {
         }
       }
     }
-    
+
     options.push(optItem)
   }
-  
+
   return options
 }
 
 const loadAvailableTasks = async () => {
   try {
     logger.info(`loadAvailableTasks called, scriptId: ${props.scriptId}`)
-    const response = await Service.getM9AAvailableTasksApiScriptsM9ATasksAvailablePost(props.scriptId)
+    const response = await Service.getM9AAvailableTasksApiScriptsM9ATasksAvailablePost(
+      props.scriptId
+    )
     logger.info(`API response: ${JSON.stringify(response)}`)
-    
+
     if (response && response.code === 200 && response.data) {
       availableTasks.value = []
       taskDefinitions.value = {}
-      
+
       const RESERVED_ENTRIES = ['StartUp', 'Close1999', 'SwitchAccount']
 
       response.data.forEach((task: any) => {
@@ -318,7 +342,7 @@ const loadAvailableTasks = async () => {
           taskDefinitions.value[task.name] = task
         }
       })
-      
+
       logger.info(`availableTasks set to: ${JSON.stringify(availableTasks.value)}`)
     }
   } catch (error) {
@@ -334,7 +358,7 @@ const handleAddTask = ({ key }: { key: string }) => {
   if (taskDef) {
     const newTask: M9ATaskQueueItem = {
       name: key,
-      options: buildDefaultOptions(taskDef)
+      options: buildDefaultOptions(taskDef),
     }
     const newQueue = [...localTaskQueue.value, newTask]
     emit('update:taskQueue', newQueue)
@@ -426,7 +450,7 @@ const handleOptionUpdate = (newOptions: M9ATaskOption[]) => {
     const newQueue = [...localTaskQueue.value]
     newQueue[selectedTaskIndex.value] = {
       ...newQueue[selectedTaskIndex.value],
-      options: newOptions
+      options: newOptions,
     }
     emit('update:taskQueue', newQueue)
   }
@@ -442,7 +466,7 @@ const onDragEnd = () => {
 
 watch(
   () => props.taskQueue,
-  (newQueue) => {
+  newQueue => {
     if (!isDragging.value) {
       localTaskQueue.value = [...newQueue]
     }

--- a/frontend/src/views/MAAUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/MAAUserEdit/BasicInfoSection.vue
@@ -14,8 +14,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input v-model:value="formData.userName" placeholder="请输入用户名" :disabled="loading" size="large"
-            class="modern-input" @blur="emitSave('userName', formData.userName)" />
+          <a-input
+            v-model:value="formData.userName"
+            placeholder="请输入用户名"
+            :disabled="loading"
+            size="large"
+            class="modern-input"
+            @blur="emitSave('userName', formData.userName)"
+          />
         </a-form-item>
       </a-col>
       <a-col :span="12">
@@ -28,8 +34,13 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input v-model:value="formData.userId" placeholder="请输入账号ID" :disabled="loading" size="large"
-            @blur="emitSave('userId', formData.userId)" />
+          <a-input
+            v-model:value="formData.userId"
+            placeholder="请输入账号ID"
+            :disabled="loading"
+            size="large"
+            @blur="emitSave('userId', formData.userId)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -45,8 +56,11 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Status" size="large"
-            @change="emitSave('Info.Status', formData.Info.Status)">
+          <a-select
+            v-model:value="formData.Info.Status"
+            size="large"
+            @change="emitSave('Info.Status', formData.Info.Status)"
+          >
             <a-select-option :value="true">是</a-select-option>
             <a-select-option :value="false">否</a-select-option>
           </a-select>
@@ -62,8 +76,13 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input-password v-model:value="formData.Info.Password" placeholder="密码仅用于储存以防遗忘，此外无任何作用" :disabled="loading"
-            size="large" @blur="emitSave('Info.Password', formData.Info.Password)" />
+          <a-input-password
+            v-model:value="formData.Info.Password"
+            placeholder="密码仅用于储存以防遗忘，此外无任何作用"
+            :disabled="loading"
+            size="large"
+            @blur="emitSave('Info.Password', formData.Info.Password)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -79,8 +98,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Server" placeholder="请选择服务器" :disabled="loading"
-            :options="serverOptions" size="large" @change="emitSave('Info.Server', formData.Info.Server)" />
+          <a-select
+            v-model:value="formData.Info.Server"
+            placeholder="请选择服务器"
+            :disabled="loading"
+            :options="serverOptions"
+            size="large"
+            @change="emitSave('Info.Server', formData.Info.Server)"
+          />
         </a-form-item>
       </a-col>
 
@@ -94,9 +119,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="0"
-            :disabled="loading" size="large" style="width: 100%"
-            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
+          <a-input-number
+            v-model:value="formData.Info.RemainedDay"
+            :min="-1"
+            :max="9999"
+            placeholder="0"
+            :disabled="loading"
+            size="large"
+            style="width: 100%"
+            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -112,10 +144,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Mode" :options="[
-            { label: '简洁', value: '简洁' },
-            { label: '详细', value: '详细' },
-          ]" :disabled="loading" size="large" @change="emitSave('Info.Mode', formData.Info.Mode)" />
+          <a-select
+            v-model:value="formData.Info.Mode"
+            :options="[
+              { label: '简洁', value: '简洁' },
+              { label: '详细', value: '详细' },
+            ]"
+            :disabled="loading"
+            size="large"
+            @change="emitSave('Info.Mode', formData.Info.Mode)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -129,8 +167,14 @@
           </span>
         </a-tooltip>
       </template>
-      <a-textarea v-model:value="formData.Info.Notes" placeholder="请输入备注信息" :rows="4" :disabled="loading"
-        class="modern-input" @blur="emitSave('Info.Notes', formData.Info.Notes)" />
+      <a-textarea
+        v-model:value="formData.Info.Notes"
+        placeholder="请输入备注信息"
+        :rows="4"
+        :disabled="loading"
+        class="modern-input"
+        @blur="emitSave('Info.Notes', formData.Info.Notes)"
+      />
     </a-form-item>
   </div>
 </template>

--- a/frontend/src/views/MAAUserEdit/NotifyConfigSection.vue
+++ b/frontend/src/views/MAAUserEdit/NotifyConfigSection.vue
@@ -8,8 +8,11 @@
         <span style="font-weight: 500">启用通知</span>
       </a-col>
       <a-col :span="18">
-        <a-switch v-model:checked="formData.Notify.Enabled" :disabled="loading"
-          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)" />
+        <a-switch
+          v-model:checked="formData.Notify.Enabled"
+          :disabled="loading"
+          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)"
+        />
         <span class="switch-description">启用后将发送此用户的任务通知到选中的渠道</span>
       </a-col>
     </a-row>
@@ -19,11 +22,17 @@
         <span style="font-weight: 500">通知内容</span>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 32px">
-        <a-checkbox v-model:checked="formData.Notify.IfSendStatistic" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)">统计信息
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendStatistic"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)"
+          >统计信息
         </a-checkbox>
-        <a-checkbox v-model:checked="formData.Notify.IfSendSixStar" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendSixStar', formData.Notify.IfSendSixStar)">公开招募高资喜报
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendSixStar"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendSixStar', formData.Notify.IfSendSixStar)"
+          >公开招募高资喜报
         </a-checkbox>
       </a-col>
     </a-row>
@@ -31,34 +40,55 @@
     <!-- 邮件通知 -->
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfSendMail" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)">邮件通知
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendMail"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)"
+          >邮件通知
         </a-checkbox>
       </a-col>
       <a-col :span="18">
-        <a-input v-model:value="formData.Notify.ToAddress" placeholder="请输入收件人邮箱地址"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail" size="large"
-          style="width: 100%" @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)" />
+        <a-input
+          v-model:value="formData.Notify.ToAddress"
+          placeholder="请输入收件人邮箱地址"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail"
+          size="large"
+          style="width: 100%"
+          @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)"
+        />
       </a-col>
     </a-row>
 
     <!-- Server酱通知 -->
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfServerChan" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)">Server酱
+        <a-checkbox
+          v-model:checked="formData.Notify.IfServerChan"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)"
+          >Server酱
         </a-checkbox>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 8px">
-        <a-input v-model:value="formData.Notify.ServerChanKey" placeholder="请输入SENDKEY"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan" size="large" style="flex: 2"
-          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)" />
+        <a-input
+          v-model:value="formData.Notify.ServerChanKey"
+          placeholder="请输入SENDKEY"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan"
+          size="large"
+          style="flex: 2"
+          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)"
+        />
       </a-col>
     </a-row>
 
     <!-- 自定义 Webhook 通知 -->
     <div style="margin-top: 16px">
-      <WebhookManager mode="user" :script-id="props.scriptId" :user-id="props.userId" @change="handleWebhookChange" />
+      <WebhookManager
+        mode="user"
+        :script-id="props.scriptId"
+        :user-id="props.userId"
+        @change="handleWebhookChange"
+      />
     </div>
   </div>
 </template>

--- a/frontend/src/views/MAAUserEdit/StageConfigSection.vue
+++ b/frontend/src/views/MAAUserEdit/StageConfigSection.vue
@@ -9,8 +9,12 @@
               hint="「固定」直接在此配置关卡；「计划表」按计划自动切换"
             />
           </template>
-          <a-select v-model:value="formData.Info.StageMode" :options="stageModeOptions" :disabled="loading"
-            @change="emitSave('Info.StageMode', formData.Info.StageMode)" />
+          <a-select
+            v-model:value="formData.Info.StageMode"
+            :options="stageModeOptions"
+            :disabled="loading"
+            @change="emitSave('Info.StageMode', formData.Info.StageMode)"
+          />
         </a-form-item>
       </a-col>
       <a-col v-if="isPlanMode" :xs="24" :md="12" class="plans-link-col">
@@ -40,8 +44,16 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示输入框 -->
-          <a-input-number v-else :value="displayMedicineNumb" :min="0" :max="9999" placeholder="0" :disabled="loading"
-            style="width: 100%" @update:value="$emit('update-medicine-numb', $event)" />
+          <a-input-number
+            v-else
+            :value="displayMedicineNumb"
+            :min="0"
+            :max="9999"
+            placeholder="0"
+            :disabled="loading"
+            style="width: 100%"
+            @update:value="$emit('update-medicine-numb', $event)"
+          />
         </a-form-item>
       </a-col>
       <a-col :xs="24" :md="12" :xl="6">
@@ -71,16 +83,22 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <a-select v-else :value="displaySeriesNumb" :options="[
-            { label: 'AUTO', value: '0' },
-            { label: '1', value: '1' },
-            { label: '2', value: '2' },
-            { label: '3', value: '3' },
-            { label: '4', value: '4' },
-            { label: '5', value: '5' },
-            { label: '6', value: '6' },
-            { label: '不切换', value: '-1' },
-          ]" :disabled="loading" @update:value="$emit('update-series-numb', $event)" />
+          <a-select
+            v-else
+            :value="displaySeriesNumb"
+            :options="[
+              { label: 'AUTO', value: '0' },
+              { label: '1', value: '1' },
+              { label: '2', value: '2' },
+              { label: '3', value: '3' },
+              { label: '4', value: '4' },
+              { label: '5', value: '5' },
+              { label: '6', value: '6' },
+              { label: '不切换', value: '-1' },
+            ]"
+            :disabled="loading"
+            @update:value="$emit('update-series-numb', $event)"
+          />
         </a-form-item>
       </a-col>
 
@@ -102,9 +120,15 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <StageSelector v-else :value="displayStage" :options="stageOptions" :loading="loading"
-            placeholder="选择或输入自定义关卡" @update:value="$emit('update-stage', $event)"
-            @add-custom-stage="handleAddCustomStage" />
+          <StageSelector
+            v-else
+            :value="displayStage"
+            :options="stageOptions"
+            :loading="loading"
+            placeholder="选择或输入自定义关卡"
+            @update:value="$emit('update-stage', $event)"
+            @add-custom-stage="handleAddCustomStage"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -130,9 +154,15 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <StageSelector v-else :value="displayStage1" :options="stageOptions" :loading="loading"
-            placeholder="选择或输入自定义关卡" @update:value="$emit('update-stage1', $event)"
-            @add-custom-stage="handleAddCustomStage1" />
+          <StageSelector
+            v-else
+            :value="displayStage1"
+            :options="stageOptions"
+            :loading="loading"
+            placeholder="选择或输入自定义关卡"
+            @update:value="$emit('update-stage1', $event)"
+            @add-custom-stage="handleAddCustomStage1"
+          />
         </a-form-item>
       </a-col>
       <a-col :xs="24" :md="12" :xl="6">
@@ -156,9 +186,15 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <StageSelector v-else :value="displayStage2" :options="stageOptions" :loading="loading"
-            placeholder="选择或输入自定义关卡" @update:value="$emit('update-stage2', $event)"
-            @add-custom-stage="handleAddCustomStage2" />
+          <StageSelector
+            v-else
+            :value="displayStage2"
+            :options="stageOptions"
+            :loading="loading"
+            placeholder="选择或输入自定义关卡"
+            @update:value="$emit('update-stage2', $event)"
+            @add-custom-stage="handleAddCustomStage2"
+          />
         </a-form-item>
       </a-col>
       <a-col :xs="24" :md="12" :xl="6">
@@ -182,9 +218,15 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <StageSelector v-else :value="displayStage3" :options="stageOptions" :loading="loading"
-            placeholder="选择或输入自定义关卡" @update:value="$emit('update-stage3', $event)"
-            @add-custom-stage="handleAddCustomStage3" />
+          <StageSelector
+            v-else
+            :value="displayStage3"
+            :options="stageOptions"
+            :loading="loading"
+            placeholder="选择或输入自定义关卡"
+            @update:value="$emit('update-stage3', $event)"
+            @add-custom-stage="handleAddCustomStage3"
+          />
         </a-form-item>
       </a-col>
       <a-col :xs="24" :md="12" :xl="6">
@@ -206,9 +248,15 @@
             </a-tooltip>
           </div>
           <!-- 固定模式：显示选择框 -->
-          <StageSelector v-else :value="displayStageRemain" :options="stageRemainOptions" :loading="loading"
-            placeholder="选择或输入自定义关卡" @update:value="$emit('update-stage-remain', $event)"
-            @add-custom-stage="handleAddCustomStageRemain" />
+          <StageSelector
+            v-else
+            :value="displayStageRemain"
+            :options="stageRemainOptions"
+            :loading="loading"
+            placeholder="选择或输入自定义关卡"
+            @update:value="$emit('update-stage-remain', $event)"
+            @add-custom-stage="handleAddCustomStageRemain"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -257,7 +305,7 @@ const emit = defineEmits<{
   'handle-add-custom-stage2': [stageName: string]
   'handle-add-custom-stage3': [stageName: string]
   'handle-add-custom-stage-remain': [stageName: string]
-  'save': [key: string, value: any]
+  save: [key: string, value: any]
 }>()
 
 const emitSave = (key: string, value: any) => {

--- a/frontend/src/views/MAAUserEdit/StageSelector.vue
+++ b/frontend/src/views/MAAUserEdit/StageSelector.vue
@@ -1,12 +1,22 @@
 <template>
-  <a-select :value="value" :disabled="loading" :placeholder="placeholder"
-    @update:value="$emit('update:value', $event)">
+  <a-select
+    :value="value"
+    :disabled="loading"
+    :placeholder="placeholder"
+    @update:value="$emit('update:value', $event)"
+  >
     <template #dropdownRender="{ menuNode: menu }">
       <v-nodes :vnodes="menu" />
       <a-divider style="margin: 4px 0" />
       <a-space style="padding: 4px 8px" size="small">
-        <a-input ref="inputRef" v-model:value="customStageName" placeholder="输入自定义关卡，如: 11-8" style="flex: 1"
-          size="small" @keyup.enter="addCustomStage" />
+        <a-input
+          ref="inputRef"
+          v-model:value="customStageName"
+          placeholder="输入自定义关卡，如: 11-8"
+          style="flex: 1"
+          size="small"
+          @keyup.enter="addCustomStage"
+        />
         <a-button type="text" size="small" @click="addCustomStage">
           <template #icon>
             <PlusOutlined />
@@ -24,7 +34,12 @@
       </template>
       <template v-else>
         {{ option.label }}
-        <a-tag v-if="isCustomStage(option.value)" color="blue" size="small" style="margin-left: 8px">
+        <a-tag
+          v-if="isCustomStage(option.value)"
+          color="blue"
+          size="small"
+          style="margin-left: 8px"
+        >
           自定义
         </a-tag>
       </template>

--- a/frontend/src/views/OCRdev.vue
+++ b/frontend/src/views/OCRdev.vue
@@ -8,7 +8,7 @@
     </div>
 
     <!-- 功能选项卡 -->
-    <a-tabs v-model:activeKey="activeTab" type="card">
+    <a-tabs v-model:active-key="activeTab" type="card">
       <!-- 截图测试 -->
       <a-tab-pane key="screenshot" tab="窗口截图">
         <a-card title="截图参数配置" class="config-card">
@@ -16,7 +16,10 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="窗口标题" required>
-                  <a-input v-model:value="screenshotForm.window_title" placeholder="请输入窗口标题关键字（如：记事本、Chrome）" />
+                  <a-input
+                    v-model:value="screenshotForm.window_title"
+                    placeholder="请输入窗口标题关键字（如：记事本、Chrome）"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
@@ -24,14 +27,22 @@
             <a-row :gutter="16">
               <a-col :span="12">
                 <a-form-item label="宽高比 - 宽度">
-                  <a-input-number v-model:value="screenshotForm.aspect_ratio_width" :min="1" :max="32"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="screenshotForm.aspect_ratio_width"
+                    :min="1"
+                    :max="32"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
               <a-col :span="12">
                 <a-form-item label="宽高比 - 高度">
-                  <a-input-number v-model:value="screenshotForm.aspect_ratio_height" :min="1" :max="32"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="screenshotForm.aspect_ratio_height"
+                    :min="1"
+                    :max="32"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
@@ -39,8 +50,11 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="预处理模式">
-                  <a-switch v-model:checked="screenshotForm.should_preprocess" checked-children="启用"
-                    un-checked-children="禁用" />
+                  <a-switch
+                    v-model:checked="screenshotForm.should_preprocess"
+                    checked-children="启用"
+                    un-checked-children="禁用"
+                  />
                   <span style="margin-left: 12px; color: var(--ant-color-text-secondary)">
                     启用时将排除窗口边框和标题栏
                   </span>
@@ -89,7 +103,11 @@
           <!-- 图片展示 -->
           <div v-if="screenshotResult.image_base64" class="image-container">
             <h3>截图预览：</h3>
-            <img :src="`data:image/png;base64,${screenshotResult.image_base64}`" alt="截图" class="screenshot-image" />
+            <img
+              :src="`data:image/png;base64,${screenshotResult.image_base64}`"
+              alt="截图"
+              class="screenshot-image"
+            />
           </div>
           <a-empty v-else description="未获取到截图数据" />
         </a-card>
@@ -102,8 +120,10 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="ADB 可执行文件路径" required>
-                  <a-input v-model:value="adbScreenshotForm.adb_path"
-                    placeholder="请输入 ADB 可执行文件的完整路径（如：D:\Android\platform-tools\adb.exe）" />
+                  <a-input
+                    v-model:value="adbScreenshotForm.adb_path"
+                    placeholder="请输入 ADB 可执行文件的完整路径（如：D:\Android\platform-tools\adb.exe）"
+                  />
                   <span style="color: var(--ant-color-text-secondary); font-size: 12px">
                     Windows 示例: D:\Android\platform-tools\adb.exe
                   </span>
@@ -114,10 +134,13 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="设备序列号" required>
-                  <a-input v-model:value="adbScreenshotForm.serial"
-                    placeholder="请输入设备序列号（如：127.0.0.1:5555 或 emulator-5554）" />
+                  <a-input
+                    v-model:value="adbScreenshotForm.serial"
+                    placeholder="请输入设备序列号（如：127.0.0.1:5555 或 emulator-5554）"
+                  />
                   <span style="color: var(--ant-color-text-secondary); font-size: 12px">
-                    网络设备示例: 127.0.0.1:5555 | USB设备示例: emulator-5554 | 可通过 adb devices 命令查看
+                    网络设备示例: 127.0.0.1:5555 | USB设备示例: emulator-5554 | 可通过 adb devices
+                    命令查看
                   </span>
                 </a-form-item>
               </a-col>
@@ -126,8 +149,11 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="截图方法">
-                  <a-switch v-model:checked="adbScreenshotForm.use_screencap" checked-children="PNG"
-                    un-checked-children="RAW" />
+                  <a-switch
+                    v-model:checked="adbScreenshotForm.use_screencap"
+                    checked-children="PNG"
+                    un-checked-children="RAW"
+                  />
                   <span style="margin-left: 12px; color: var(--ant-color-text-secondary)">
                     PNG 方法速度更快（推荐），RAW 方法兼容性更好
                   </span>
@@ -137,7 +163,11 @@
 
             <a-form-item>
               <a-space>
-                <a-button type="primary" :loading="adbScreenshotLoading" @click="handleADBScreenshot">
+                <a-button
+                  type="primary"
+                  :loading="adbScreenshotLoading"
+                  @click="handleADBScreenshot"
+                >
                   <template #icon>
                     <CameraOutlined />
                   </template>
@@ -176,8 +206,11 @@
           <!-- 图片展示 -->
           <div v-if="adbScreenshotResult.image_base64" class="image-container">
             <h3>截图预览：</h3>
-            <img :src="`data:image/png;base64,${adbScreenshotResult.image_base64}`" alt="ADB 截图"
-              class="screenshot-image" />
+            <img
+              :src="`data:image/png;base64,${adbScreenshotResult.image_base64}`"
+              alt="ADB 截图"
+              class="screenshot-image"
+            />
           </div>
           <a-empty v-else description="未获取到截图数据" />
         </a-card>
@@ -202,18 +235,35 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="窗口标题" required>
-                  <a-input v-model:value="checkForm.window_title" placeholder="请输入窗口标题关键字" />
+                  <a-input
+                    v-model:value="checkForm.window_title"
+                    placeholder="请输入窗口标题关键字"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
 
             <a-row :gutter="16">
               <a-col :span="24">
-                <a-form-item :label="checkForm.mode === 'single' ? '图片路径' : '图片路径列表'" required>
-                  <a-textarea v-model:value="checkForm.image_paths_text"
-                    :placeholder="checkForm.mode === 'single' ? '请输入图片完整路径' : '请输入图片路径，每行一个'" :rows="4" />
+                <a-form-item
+                  :label="checkForm.mode === 'single' ? '图片路径' : '图片路径列表'"
+                  required
+                >
+                  <a-textarea
+                    v-model:value="checkForm.image_paths_text"
+                    :placeholder="
+                      checkForm.mode === 'single'
+                        ? '请输入图片完整路径'
+                        : '请输入图片路径，每行一个'
+                    "
+                    :rows="4"
+                  />
                   <span style="color: var(--ant-color-text-secondary); font-size: 12px">
-                    {{ checkForm.mode === 'single' ? '例如: D:\\images\\button.png' : '多个路径时每行一个路径' }}
+                    {{
+                      checkForm.mode === 'single'
+                        ? '例如: D:\\images\\button.png'
+                        : '多个路径时每行一个路径'
+                    }}
                   </span>
                 </a-form-item>
               </a-col>
@@ -222,19 +272,34 @@
             <a-row :gutter="16">
               <a-col :span="8">
                 <a-form-item label="重试次数">
-                  <a-input-number v-model:value="checkForm.retry_times" :min="1" :max="20" style="width: 100%" />
+                  <a-input-number
+                    v-model:value="checkForm.retry_times"
+                    :min="1"
+                    :max="20"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
               <a-col :span="8">
                 <a-form-item label="间隔时间(秒)">
-                  <a-input-number v-model:value="checkForm.interval" :min="0" :max="10" :step="0.5"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="checkForm.interval"
+                    :min="0"
+                    :max="10"
+                    :step="0.5"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
               <a-col :span="8">
                 <a-form-item label="匹配阈值">
-                  <a-input-number v-model:value="checkForm.threshold" :min="0" :max="1" :step="0.05"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="checkForm.threshold"
+                    :min="0"
+                    :max="1"
+                    :step="0.05"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
@@ -299,7 +364,10 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item label="窗口标题" required>
-                  <a-input v-model:value="clickForm.window_title" placeholder="请输入窗口标题关键字" />
+                  <a-input
+                    v-model:value="clickForm.window_title"
+                    placeholder="请输入窗口标题关键字"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
@@ -307,7 +375,10 @@
             <a-row :gutter="16">
               <a-col :span="24">
                 <a-form-item v-if="clickForm.mode === 'image'" label="图片路径" required>
-                  <a-input v-model:value="clickForm.image_path" placeholder="请输入要点击的图片完整路径" />
+                  <a-input
+                    v-model:value="clickForm.image_path"
+                    placeholder="请输入要点击的图片完整路径"
+                  />
                   <span style="color: var(--ant-color-text-secondary); font-size: 12px">
                     例如: D:\images\button.png
                   </span>
@@ -324,19 +395,34 @@
             <a-row :gutter="16">
               <a-col :span="8">
                 <a-form-item label="重试次数">
-                  <a-input-number v-model:value="clickForm.retry_times" :min="1" :max="20" style="width: 100%" />
+                  <a-input-number
+                    v-model:value="clickForm.retry_times"
+                    :min="1"
+                    :max="20"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
               <a-col :span="8">
                 <a-form-item label="间隔时间(秒)">
-                  <a-input-number v-model:value="clickForm.interval" :min="0" :max="10" :step="0.5"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="clickForm.interval"
+                    :min="0"
+                    :max="10"
+                    :step="0.5"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
-              <a-col :span="8" v-if="clickForm.mode === 'image'">
+              <a-col v-if="clickForm.mode === 'image'" :span="8">
                 <a-form-item label="匹配阈值">
-                  <a-input-number v-model:value="clickForm.threshold" :min="0" :max="1" :step="0.05"
-                    style="width: 100%" />
+                  <a-input-number
+                    v-model:value="clickForm.threshold"
+                    :min="0"
+                    :max="1"
+                    :step="0.05"
+                    style="width: 100%"
+                  />
                 </a-form-item>
               </a-col>
             </a-row>
@@ -393,7 +479,7 @@ import {
   CameraOutlined,
   ClearOutlined,
   SearchOutlined,
-  ThunderboltOutlined
+  ThunderboltOutlined,
 } from '@ant-design/icons-vue'
 import { OcrService } from '@/api/services/OcrService'
 import type { OCRScreenshotIn } from '@/api/models/OCRScreenshotIn'

--- a/frontend/src/views/SRCUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/SRCUserEdit/BasicInfoSection.vue
@@ -14,8 +14,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input v-model:value="formData.userName" placeholder="请输入用户名" :disabled="loading" size="large"
-            class="modern-input" @blur="emitSave('userName', formData.userName)" />
+          <a-input
+            v-model:value="formData.userName"
+            placeholder="请输入用户名"
+            :disabled="loading"
+            size="large"
+            class="modern-input"
+            @blur="emitSave('userName', formData.userName)"
+          />
         </a-form-item>
       </a-col>
       <a-col :span="12">
@@ -28,8 +34,11 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Status" size="large"
-            @change="emitSave('Info.Status', formData.Info.Status)">
+          <a-select
+            v-model:value="formData.Info.Status"
+            size="large"
+            @change="emitSave('Info.Status', formData.Info.Status)"
+          >
             <a-select-option :value="true">是</a-select-option>
             <a-select-option :value="false">否</a-select-option>
           </a-select>
@@ -43,10 +52,13 @@
           <template #label>
             <a-tooltip>
               <template #title>
-                <div style="max-width: 520px; line-height: 1.6; white-space: normal;">
+                <div style="max-width: 520px; line-height: 1.6; white-space: normal">
                   用于切换账号，无需切换则留空。<br />
-                  官服输入 11 位手机号，若输入手机号中包含「*」则切换账号时将仅通过识别已登录账号列表登录。<br />
-                  B 服输入用户名片段，允许同时输入 B 站账号/邮箱号/手机号，中间使用「|」分隔，通过账号密码登录时将优先使用 B 站账号/邮箱号/手机号。
+                  官服输入 11
+                  位手机号，若输入手机号中包含「*」则切换账号时将仅通过识别已登录账号列表登录。<br />
+                  B 服输入用户名片段，允许同时输入 B
+                  站账号/邮箱号/手机号，中间使用「|」分隔，通过账号密码登录时将优先使用 B
+                  站账号/邮箱号/手机号。
                 </div>
               </template>
               <span class="form-label">
@@ -55,22 +67,34 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input v-model:value="formData.Info.Id" placeholder="请输入账号" :disabled="loading" size="large"
-            @blur="emitSave('Info.Id', formData.Info.Id)" />
+          <a-input
+            v-model:value="formData.Info.Id"
+            placeholder="请输入账号"
+            :disabled="loading"
+            size="large"
+            @blur="emitSave('Info.Id', formData.Info.Id)"
+          />
         </a-form-item>
       </a-col>
       <a-col :span="12">
         <a-form-item :name="['Info', 'Password']">
           <template #label>
-            <a-tooltip title="用户密码，填写时将启用备选的通过输入账号密码方式登录，留空时仅通过识别已登录账号列表登录">
+            <a-tooltip
+              title="用户密码，填写时将启用备选的通过输入账号密码方式登录，留空时仅通过识别已登录账号列表登录"
+            >
               <span class="form-label">
                 密码
                 <QuestionCircleOutlined class="help-icon" />
               </span>
             </a-tooltip>
           </template>
-          <a-input-password v-model:value="formData.Info.Password" placeholder="请输入密码" :disabled="loading" size="large"
-            @blur="emitSave('Info.Password', formData.Info.Password)" />
+          <a-input-password
+            v-model:value="formData.Info.Password"
+            placeholder="请输入密码"
+            :disabled="loading"
+            size="large"
+            @blur="emitSave('Info.Password', formData.Info.Password)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -86,8 +110,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Server" placeholder="请选择服务器" :disabled="loading"
-            :options="serverOptions" size="large" @change="emitSave('Info.Server', formData.Info.Server)" />
+          <a-select
+            v-model:value="formData.Info.Server"
+            placeholder="请选择服务器"
+            :disabled="loading"
+            :options="serverOptions"
+            size="large"
+            @change="emitSave('Info.Server', formData.Info.Server)"
+          />
         </a-form-item>
       </a-col>
       <a-col :span="12">
@@ -100,9 +130,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="-1"
-            :disabled="loading" size="large" style="width: 100%"
-            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
+          <a-input-number
+            v-model:value="formData.Info.RemainedDay"
+            :min="-1"
+            :max="9999"
+            placeholder="-1"
+            :disabled="loading"
+            size="large"
+            style="width: 100%"
+            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -118,10 +155,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Info.Mode" :options="[
-            { label: '简洁', value: '简洁' },
-            { label: '详细', value: '详细' },
-          ]" :disabled="loading" size="large" @change="emitSave('Info.Mode', formData.Info.Mode)" />
+          <a-select
+            v-model:value="formData.Info.Mode"
+            :options="[
+              { label: '简洁', value: '简洁' },
+              { label: '详细', value: '详细' },
+            ]"
+            :disabled="loading"
+            size="large"
+            @change="emitSave('Info.Mode', formData.Info.Mode)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -135,8 +178,14 @@
           </span>
         </a-tooltip>
       </template>
-      <a-textarea v-model:value="formData.Info.Notes" placeholder="请输入备注信息" :rows="4" :disabled="loading"
-        class="modern-input" @blur="emitSave('Info.Notes', formData.Info.Notes)" />
+      <a-textarea
+        v-model:value="formData.Info.Notes"
+        placeholder="请输入备注信息"
+        :rows="4"
+        :disabled="loading"
+        class="modern-input"
+        @blur="emitSave('Info.Notes', formData.Info.Notes)"
+      />
     </a-form-item>
   </div>
 </template>

--- a/frontend/src/views/SRCUserEdit/NotifyConfigSection.vue
+++ b/frontend/src/views/SRCUserEdit/NotifyConfigSection.vue
@@ -8,8 +8,11 @@
         <span style="font-weight: 500">启用通知</span>
       </a-col>
       <a-col :span="18">
-        <a-switch v-model:checked="formData.Notify.Enabled" :disabled="loading"
-          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)" />
+        <a-switch
+          v-model:checked="formData.Notify.Enabled"
+          :disabled="loading"
+          @change="emitSave('Notify.Enabled', formData.Notify.Enabled)"
+        />
         <span class="switch-description">启用后将发送此用户的任务通知到选中的渠道</span>
       </a-col>
     </a-row>
@@ -19,8 +22,11 @@
         <span style="font-weight: 500">通知内容</span>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 32px">
-        <a-checkbox v-model:checked="formData.Notify.IfSendStatistic" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)">统计信息
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendStatistic"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendStatistic', formData.Notify.IfSendStatistic)"
+          >统计信息
         </a-checkbox>
       </a-col>
     </a-row>
@@ -28,34 +34,55 @@
     <!-- 邮件通知 -->
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfSendMail" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)">邮件通知
+        <a-checkbox
+          v-model:checked="formData.Notify.IfSendMail"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfSendMail', formData.Notify.IfSendMail)"
+          >邮件通知
         </a-checkbox>
       </a-col>
       <a-col :span="18">
-        <a-input v-model:value="formData.Notify.ToAddress" placeholder="请输入收件人邮箱地址"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail" size="large"
-          style="width: 100%" @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)" />
+        <a-input
+          v-model:value="formData.Notify.ToAddress"
+          placeholder="请输入收件人邮箱地址"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfSendMail"
+          size="large"
+          style="width: 100%"
+          @blur="emitSave('Notify.ToAddress', formData.Notify.ToAddress)"
+        />
       </a-col>
     </a-row>
 
     <!-- Server酱通知 -->
     <a-row :gutter="24" style="margin-top: 16px">
       <a-col :span="6">
-        <a-checkbox v-model:checked="formData.Notify.IfServerChan" :disabled="loading || !formData.Notify.Enabled"
-          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)">Server酱
+        <a-checkbox
+          v-model:checked="formData.Notify.IfServerChan"
+          :disabled="loading || !formData.Notify.Enabled"
+          @change="emitSave('Notify.IfServerChan', formData.Notify.IfServerChan)"
+          >Server酱
         </a-checkbox>
       </a-col>
       <a-col :span="18" style="display: flex; gap: 8px">
-        <a-input v-model:value="formData.Notify.ServerChanKey" placeholder="请输入SENDKEY"
-          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan" size="large" style="flex: 2"
-          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)" />
+        <a-input
+          v-model:value="formData.Notify.ServerChanKey"
+          placeholder="请输入SENDKEY"
+          :disabled="loading || !formData.Notify.Enabled || !formData.Notify.IfServerChan"
+          size="large"
+          style="flex: 2"
+          @blur="emitSave('Notify.ServerChanKey', formData.Notify.ServerChanKey)"
+        />
       </a-col>
     </a-row>
 
     <!-- 自定义 Webhook 通知 -->
     <div style="margin-top: 16px">
-      <WebhookManager mode="user" :script-id="props.scriptId" :user-id="props.userId" @change="handleWebhookChange" />
+      <WebhookManager
+        mode="user"
+        :script-id="props.scriptId"
+        :user-id="props.userId"
+        @change="handleWebhookChange"
+      />
     </div>
   </div>
 </template>

--- a/frontend/src/views/SRCUserEdit/SRCUserEditHeader.vue
+++ b/frontend/src/views/SRCUserEdit/SRCUserEditHeader.vue
@@ -17,15 +17,26 @@
     </div>
 
     <a-space size="middle">
-      <a-button v-if="userMode !== '简洁' && !showSrcConfigMask" type="primary" ghost size="large"
-        :loading="srcConfigLoading" @click="$emit('handleSRCConfig')">
+      <a-button
+        v-if="userMode !== '简洁' && !showSrcConfigMask"
+        type="primary"
+        ghost
+        size="large"
+        :loading="srcConfigLoading"
+        @click="$emit('handleSRCConfig')"
+      >
         <template #icon>
           <SettingOutlined />
         </template>
         SRC配置
       </a-button>
-      <a-button v-if="userMode !== '简洁' && showSrcConfigMask" type="default" size="large" disabled
-        style="color: #52c41a; border-color: #52c41a">
+      <a-button
+        v-if="userMode !== '简洁' && showSrcConfigMask"
+        type="default"
+        size="large"
+        disabled
+        style="color: #52c41a; border-color: #52c41a"
+      >
         <template #icon>
           <SettingOutlined />
         </template>

--- a/frontend/src/views/SRCUserEdit/StageConfigSection.vue
+++ b/frontend/src/views/SRCUserEdit/StageConfigSection.vue
@@ -16,8 +16,12 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.Channel" size="large" placeholder="请选择刷取类型"
-            @change="emitSave('Stage.Channel', formData.Stage.Channel)">
+          <a-select
+            v-model:value="formData.Stage.Channel"
+            size="large"
+            placeholder="请选择刷取类型"
+            @change="emitSave('Stage.Channel', formData.Stage.Channel)"
+          >
             <a-select-option value="Relic">遗器</a-select-option>
             <a-select-option value="Materials">材料</a-select-option>
             <a-select-option value="Ornament">饰品</a-select-option>
@@ -55,25 +59,63 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.Relic" size="large" placeholder="请选择遗器关卡" show-search
-            :filter-option="filterOption" @change="emitSave('Stage.Relic', formData.Stage.Relic)">
+          <a-select
+            v-model:value="formData.Stage.Relic"
+            size="large"
+            placeholder="请选择遗器关卡"
+            show-search
+            :filter-option="filterOption"
+            @change="emitSave('Stage.Relic', formData.Stage.Relic)"
+          >
             <a-select-option value="-">沿用原始配置</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Insight">遗器：领航员 & 名冶（观火之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Possession">遗器：魔法少女 & 卜者（魔占之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Hidden_Salvation">遗器：救世主 & 隐士（隐救之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Thundersurge">遗器：烈阳 & 船长（雳涌之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Aria">遗器：英豪 & 诗人（弦歌之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Uncertainty">遗器：司铎 & 学者（迷识之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Cavalier">遗器：铁骑 & 勇烈（勇骑之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Dreamdive">遗器：死水 & 钟表匠（梦潜之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Darkness">遗器：大公 & DoT套（幽冥之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Elixir_Seekers">遗器：莳者 & 信使（药使之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Conflagration">遗器：火套 & 虚数套（野焰之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Holy_Hymn">遗器：防御套 & 雷套（圣颂之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Providence">遗器：铁卫 & 量子套（睿治之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Drifting">遗器：治疗套 & 快枪手（漂泊之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Jabbing_Punch">遗器：物理套 & 怪盗（迅拳之径）</a-select-option>
-            <a-select-option value="Cavern_of_Corrosion_Path_of_Gelid_Wind">遗器：冰套 & 风套（霜风之径）</a-select-option>
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Insight"
+              >遗器：领航员 & 名冶（观火之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Possession"
+              >遗器：魔法少女 & 卜者（魔占之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Hidden_Salvation"
+              >遗器：救世主 & 隐士（隐救之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Thundersurge"
+              >遗器：烈阳 & 船长（雳涌之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Aria"
+              >遗器：英豪 & 诗人（弦歌之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Uncertainty"
+              >遗器：司铎 & 学者（迷识之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Cavalier"
+              >遗器：铁骑 & 勇烈（勇骑之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Dreamdive"
+              >遗器：死水 & 钟表匠（梦潜之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Darkness"
+              >遗器：大公 & DoT套（幽冥之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Elixir_Seekers"
+              >遗器：莳者 & 信使（药使之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Conflagration"
+              >遗器：火套 & 虚数套（野焰之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Holy_Hymn"
+              >遗器：防御套 & 雷套（圣颂之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Providence"
+              >遗器：铁卫 & 量子套（睿治之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Drifting"
+              >遗器：治疗套 & 快枪手（漂泊之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Jabbing_Punch"
+              >遗器：物理套 & 怪盗（迅拳之径）</a-select-option
+            >
+            <a-select-option value="Cavern_of_Corrosion_Path_of_Gelid_Wind"
+              >遗器：冰套 & 风套（霜风之径）</a-select-option
+            >
           </a-select>
         </a-form-item>
       </a-col>
@@ -87,23 +129,57 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.Ornament" size="large" placeholder="请选择饰品关卡" show-search
-            :filter-option="filterOption" @change="emitSave('Stage.Ornament', formData.Stage.Ornament)">
+          <a-select
+            v-model:value="formData.Stage.Ornament"
+            size="large"
+            placeholder="请选择饰品关卡"
+            show-search
+            :filter-option="filterOption"
+            @change="emitSave('Stage.Ornament', formData.Stage.Ornament)"
+          >
             <a-select-option value="-">沿用原始配置</a-select-option>
-            <a-select-option value="Divergent_Universe_Bugs_Incoming">饰品：坠星 & 寰宇（虫虫来袭）</a-select-option>
-            <a-select-option value="Divergent_Universe_Gilded_Recollection">饰品：朋克洛德 & 千星荟萃（鎏金追忆）</a-select-option>
-            <a-select-option value="Divergent_Universe_Within_the_West_Wind">饰品：翁法罗斯 & 天国（西风丛中）</a-select-option>
-            <a-select-option value="Divergent_Universe_Moonlit_Blood">饰品：妖精 & 沉醉（月下朱殷）</a-select-option>
-            <a-select-option value="Divergent_Universe_Unceasing_Strife">饰品：拾骨地 & 巨树（纷争不休）</a-select-option>
-            <a-select-option value="Divergent_Universe_Famished_Worker">饰品：海域 & 奇想（蠹役饥肠）</a-select-option>
-            <a-select-option value="Divergent_Universe_Eternal_Comedy">饰品：奔狼 & 火宫（永恒笑剧）</a-select-option>
-            <a-select-option value="Divergent_Universe_To_Sweet_Dreams">饰品：茨冈尼亚 & 出云（伴你入眠）</a-select-option>
-            <a-select-option value="Divergent_Universe_Pouring_Blades">饰品：苍穹 & 匹诺康尼（天剑如雨）</a-select-option>
-            <a-select-option value="Divergent_Universe_Fruit_of_Evil">饰品：繁星 & 龙骨（孽果盘生）</a-select-option>
-            <a-select-option value="Divergent_Universe_Permafrost">饰品：贝洛伯格 & 萨尔索图（百年冻土）</a-select-option>
-            <a-select-option value="Divergent_Universe_Gentle_Words">饰品：商业公司 & 差分机（温柔话语）</a-select-option>
-            <a-select-option value="Divergent_Universe_Smelted_Heart">饰品：盗贼 & 翁瓦克（浴火钢心）</a-select-option>
-            <a-select-option value="Divergent_Universe_Untoppled_Walls">饰品：太空 & 仙舟（坚城不倒）</a-select-option>
+            <a-select-option value="Divergent_Universe_Bugs_Incoming"
+              >饰品：坠星 & 寰宇（虫虫来袭）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Gilded_Recollection"
+              >饰品：朋克洛德 & 千星荟萃（鎏金追忆）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Within_the_West_Wind"
+              >饰品：翁法罗斯 & 天国（西风丛中）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Moonlit_Blood"
+              >饰品：妖精 & 沉醉（月下朱殷）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Unceasing_Strife"
+              >饰品：拾骨地 & 巨树（纷争不休）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Famished_Worker"
+              >饰品：海域 & 奇想（蠹役饥肠）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Eternal_Comedy"
+              >饰品：奔狼 & 火宫（永恒笑剧）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_To_Sweet_Dreams"
+              >饰品：茨冈尼亚 & 出云（伴你入眠）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Pouring_Blades"
+              >饰品：苍穹 & 匹诺康尼（天剑如雨）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Fruit_of_Evil"
+              >饰品：繁星 & 龙骨（孽果盘生）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Permafrost"
+              >饰品：贝洛伯格 & 萨尔索图（百年冻土）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Gentle_Words"
+              >饰品：商业公司 & 差分机（温柔话语）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Smelted_Heart"
+              >饰品：盗贼 & 翁瓦克（浴火钢心）</a-select-option
+            >
+            <a-select-option value="Divergent_Universe_Untoppled_Walls"
+              >饰品：太空 & 仙舟（坚城不倒）</a-select-option
+            >
           </a-select>
         </a-form-item>
       </a-col>
@@ -139,8 +215,14 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.Materials" size="large" placeholder="请选择材料关卡" show-search
-            :filter-option="filterOption" @change="emitSave('Stage.Materials', formData.Stage.Materials)">
+          <a-select
+            v-model:value="formData.Stage.Materials"
+            size="large"
+            placeholder="请选择材料关卡"
+            show-search
+            :filter-option="filterOption"
+            @change="emitSave('Stage.Materials', formData.Stage.Materials)"
+          >
             <a-select-option value="-">沿用原始配置</a-select-option>
             <template v-for="option in filteredMaterialOptions" :key="option.value">
               <a-select-option :value="option.value">{{ option.label }}</a-select-option>
@@ -162,18 +244,42 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.EchoOfWar" size="large" placeholder="请选择历战余响" show-search
-            :filter-option="filterOption" @change="emitSave('Stage.EchoOfWar', formData.Stage.EchoOfWar)">
+          <a-select
+            v-model:value="formData.Stage.EchoOfWar"
+            size="large"
+            placeholder="请选择历战余响"
+            show-search
+            :filter-option="filterOption"
+            @change="emitSave('Stage.EchoOfWar', formData.Stage.EchoOfWar)"
+          >
             <a-select-option value="-">禁用</a-select-option>
-            <a-select-option value="Echo_of_War_The_Comedy_of_Doom">坏灭的喜剧（二相乐园）</a-select-option>
-            <a-select-option value="Echo_of_War_Rusted_Crypt_of_the_Iron_Carcass">铁骸的锈冢（翁法罗斯）</a-select-option>
-            <a-select-option value="Echo_of_War_Glance_of_Twilight">晨昏的回眸（翁法罗斯）</a-select-option>
-            <a-select-option value="Echo_of_War_Inner_Beast_Battlefield">心兽的战场（仙舟「罗浮」）</a-select-option>
-            <a-select-option value="Echo_of_War_Salutations_of_Ashen_Dreams">尘梦的赞礼（匹诺康尼）</a-select-option>
-            <a-select-option value="Echo_of_War_Borehole_Planet_Past_Nightmares">蛀星的旧魇（空间站「黑塔」）</a-select-option>
-            <a-select-option value="Echo_of_War_Divine_Seed">不死的神实（仙舟「罗浮」）</a-select-option>
-            <a-select-option value="Echo_of_War_End_of_the_Eternal_Freeze">寒潮的落幕（雅利洛-Ⅵ）</a-select-option>
-            <a-select-option value="Echo_of_War_Destruction_Beginning">毁灭的开端（空间站「黑塔」）</a-select-option>
+            <a-select-option value="Echo_of_War_The_Comedy_of_Doom"
+              >坏灭的喜剧（二相乐园）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Rusted_Crypt_of_the_Iron_Carcass"
+              >铁骸的锈冢（翁法罗斯）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Glance_of_Twilight"
+              >晨昏的回眸（翁法罗斯）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Inner_Beast_Battlefield"
+              >心兽的战场（仙舟「罗浮」）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Salutations_of_Ashen_Dreams"
+              >尘梦的赞礼（匹诺康尼）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Borehole_Planet_Past_Nightmares"
+              >蛀星的旧魇（空间站「黑塔」）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Divine_Seed"
+              >不死的神实（仙舟「罗浮」）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_End_of_the_Eternal_Freeze"
+              >寒潮的落幕（雅利洛-Ⅵ）</a-select-option
+            >
+            <a-select-option value="Echo_of_War_Destruction_Beginning"
+              >毁灭的开端（空间站「黑塔」）</a-select-option
+            >
           </a-select>
         </a-form-item>
       </a-col>
@@ -187,9 +293,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.SimulatedUniverseWorld" size="large" placeholder="请选择模拟宇宙" show-search
+          <a-select
+            v-model:value="formData.Stage.SimulatedUniverseWorld"
+            size="large"
+            placeholder="请选择模拟宇宙"
+            show-search
             :filter-option="filterOption"
-            @change="emitSave('Stage.SimulatedUniverseWorld', formData.Stage.SimulatedUniverseWorld)">
+            @change="
+              emitSave('Stage.SimulatedUniverseWorld', formData.Stage.SimulatedUniverseWorld)
+            "
+          >
             <a-select-option value="-">禁用</a-select-option>
             <a-select-option value="Simulated_Universe_World_3">第三世界</a-select-option>
             <a-select-option value="Simulated_Universe_World_4">第四世界</a-select-option>
@@ -213,8 +326,16 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.ExtractReservedTrailblazePower" size="large"
-            @change="emitSave('Stage.ExtractReservedTrailblazePower', formData.Stage.ExtractReservedTrailblazePower)">
+          <a-select
+            v-model:value="formData.Stage.ExtractReservedTrailblazePower"
+            size="large"
+            @change="
+              emitSave(
+                'Stage.ExtractReservedTrailblazePower',
+                formData.Stage.ExtractReservedTrailblazePower
+              )
+            "
+          >
             <a-select-option :value="true">是</a-select-option>
             <a-select-option :value="false">否</a-select-option>
           </a-select>
@@ -230,8 +351,11 @@
               </span>
             </a-tooltip>
           </template>
-          <a-select v-model:value="formData.Stage.UseFuel" size="large"
-            @change="emitSave('Stage.UseFuel', formData.Stage.UseFuel)">
+          <a-select
+            v-model:value="formData.Stage.UseFuel"
+            size="large"
+            @change="emitSave('Stage.UseFuel', formData.Stage.UseFuel)"
+          >
             <a-select-option :value="true">是</a-select-option>
             <a-select-option :value="false">否</a-select-option>
           </a-select>
@@ -247,8 +371,15 @@
               </span>
             </a-tooltip>
           </template>
-          <a-input-number v-model:value="formData.Stage.FuelReserve" :min="0" :max="9999" placeholder="5" size="large"
-            style="width: 100%" @blur="emitSave('Stage.FuelReserve', formData.Stage.FuelReserve)" />
+          <a-input-number
+            v-model:value="formData.Stage.FuelReserve"
+            :min="0"
+            :max="9999"
+            placeholder="5"
+            size="large"
+            style="width: 100%"
+            @blur="emitSave('Stage.FuelReserve', formData.Stage.FuelReserve)"
+          />
         </a-form-item>
       </a-col>
     </a-row>
@@ -278,72 +409,328 @@ const materialCategory = ref('')
 // 材料关卡选项
 const materialOptions = [
   // 拟造花萼（金）
-  { value: 'Calyx_Golden_Memories_Planarcadia', label: '材料：角色经验（回忆之蕾 二相乐园）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Aether_Planarcadia', label: '材料：武器经验（以太之蕾 二相乐园）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Treasures_Planarcadia', label: '材料：信用点（藏珍之蕾 二相乐园）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Memories_Amphoreus', label: '材料：角色经验（回忆之蕾 翁法罗斯）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Aether_Amphoreus', label: '材料：武器经验（以太之蕾 翁法罗斯）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Treasures_Amphoreus', label: '材料：信用点（藏珍之蕾 翁法罗斯）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Memories_Penacony', label: '材料：角色经验（回忆之蕾 匹诺康尼）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Aether_Penacony', label: '材料：武器经验（以太之蕾 匹诺康尼）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Treasures_Penacony', label: '材料：信用点（藏珍之蕾 匹诺康尼）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Memories_The_Xianzhou_Luofu', label: '材料：角色经验（回忆之蕾 仙舟罗浮）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Aether_The_Xianzhou_Luofu', label: '材料：武器经验（以太之蕾 仙舟罗浮）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Treasures_The_Xianzhou_Luofu', label: '材料：信用点（藏珍之蕾 仙舟罗浮）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Memories_Jarilo_VI', label: '材料：角色经验（回忆之蕾 雅利洛-Ⅵ）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Aether_Jarilo_VI', label: '材料：武器经验（以太之蕾 雅利洛-Ⅵ）', category: 'Calyx_Golden' },
-  { value: 'Calyx_Golden_Treasures_Jarilo_VI', label: '材料：信用点（藏珍之蕾 雅利洛-Ⅵ）', category: 'Calyx_Golden' },
+  {
+    value: 'Calyx_Golden_Memories_Planarcadia',
+    label: '材料：角色经验（回忆之蕾 二相乐园）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Aether_Planarcadia',
+    label: '材料：武器经验（以太之蕾 二相乐园）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Treasures_Planarcadia',
+    label: '材料：信用点（藏珍之蕾 二相乐园）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Memories_Amphoreus',
+    label: '材料：角色经验（回忆之蕾 翁法罗斯）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Aether_Amphoreus',
+    label: '材料：武器经验（以太之蕾 翁法罗斯）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Treasures_Amphoreus',
+    label: '材料：信用点（藏珍之蕾 翁法罗斯）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Memories_Penacony',
+    label: '材料：角色经验（回忆之蕾 匹诺康尼）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Aether_Penacony',
+    label: '材料：武器经验（以太之蕾 匹诺康尼）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Treasures_Penacony',
+    label: '材料：信用点（藏珍之蕾 匹诺康尼）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Memories_The_Xianzhou_Luofu',
+    label: '材料：角色经验（回忆之蕾 仙舟罗浮）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Aether_The_Xianzhou_Luofu',
+    label: '材料：武器经验（以太之蕾 仙舟罗浮）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Treasures_The_Xianzhou_Luofu',
+    label: '材料：信用点（藏珍之蕾 仙舟罗浮）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Memories_Jarilo_VI',
+    label: '材料：角色经验（回忆之蕾 雅利洛-Ⅵ）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Aether_Jarilo_VI',
+    label: '材料：武器经验（以太之蕾 雅利洛-Ⅵ）',
+    category: 'Calyx_Golden',
+  },
+  {
+    value: 'Calyx_Golden_Treasures_Jarilo_VI',
+    label: '材料：信用点（藏珍之蕾 雅利洛-Ⅵ）',
+    category: 'Calyx_Golden',
+  },
   // 拟造花萼（赤）
-  { value: 'Calyx_Crimson_Destruction_Herta_StorageZone', label: '行迹材料：毁灭（收容舱段）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Destruction_Luofu_ScalegorgeWaterscape', label: '行迹材料：毁灭（鳞渊境）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Destruction_Planarcadia_InkfordHermitage', label: '行迹材料：毁灭（渡画泉隐）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Preservation_Herta_SupplyZone', label: '行迹材料：存护（支援舱段）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Preservation_Penacony_ClockStudiosThemePark', label: '行迹材料：存护（克劳克影视乐园）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_The_Hunt_Jarilo_OutlyingSnowPlains', label: '行迹材料：巡猎（城郊雪原）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_The_Hunt_Penacony_SoulGladScorchsandAuditionVenue', label: '行迹材料：巡猎（苏乐达热砂海选会场）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_The_Hunt_Amphoreus_MemortisShoreRuinsofTime', label: '行迹材料：巡猎（葬忆彼岸时光归墟）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Abundance_Jarilo_BackwaterPass', label: '行迹材料：丰饶（边缘通路）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Abundance_Luofu_FyxestrollGarden', label: '行迹材料：丰饶（绥园）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Erudition_Jarilo_RivetTown', label: '行迹材料：智识（铆钉镇）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Erudition_Penacony_PenaconyGrandTheater', label: '行迹材料：智识（匹诺康尼大剧院）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Erudition_Planarcadia_SeafeldTVTower', label: '行迹材料：智识（海原电视塔）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Harmony_Jarilo_RobotSettlement', label: '行迹材料：同谐（机械聚落）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Harmony_Penacony_TheReverieDreamscape', label: '行迹材料：同谐（白日梦酒店-梦境）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Nihility_Jarilo_GreatMine', label: '行迹材料：虚无（大矿区）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Nihility_Luofu_AlchemyCommission', label: '行迹材料：虚无（丹鼎司）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Nihility_Amphoreus_RadiantScarwoodGroveofEpiphany', label: '行迹材料：虚无（辉痕圣林神悟树庭）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Remembrance_Amphoreus_StrifeRuinsCastrumKremnos', label: '行迹材料：记忆（纷争荒墟悬锋城）', category: 'Calyx_Crimson' },
-  { value: 'Calyx_Crimson_Elation_Planarcadia_WorldEndTavern', label: '行迹材料：欢愉（世界尽头酒馆）', category: 'Calyx_Crimson' },
+  {
+    value: 'Calyx_Crimson_Destruction_Herta_StorageZone',
+    label: '行迹材料：毁灭（收容舱段）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Destruction_Luofu_ScalegorgeWaterscape',
+    label: '行迹材料：毁灭（鳞渊境）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Destruction_Planarcadia_InkfordHermitage',
+    label: '行迹材料：毁灭（渡画泉隐）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Preservation_Herta_SupplyZone',
+    label: '行迹材料：存护（支援舱段）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Preservation_Penacony_ClockStudiosThemePark',
+    label: '行迹材料：存护（克劳克影视乐园）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_The_Hunt_Jarilo_OutlyingSnowPlains',
+    label: '行迹材料：巡猎（城郊雪原）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_The_Hunt_Penacony_SoulGladScorchsandAuditionVenue',
+    label: '行迹材料：巡猎（苏乐达热砂海选会场）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_The_Hunt_Amphoreus_MemortisShoreRuinsofTime',
+    label: '行迹材料：巡猎（葬忆彼岸时光归墟）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Abundance_Jarilo_BackwaterPass',
+    label: '行迹材料：丰饶（边缘通路）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Abundance_Luofu_FyxestrollGarden',
+    label: '行迹材料：丰饶（绥园）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Erudition_Jarilo_RivetTown',
+    label: '行迹材料：智识（铆钉镇）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Erudition_Penacony_PenaconyGrandTheater',
+    label: '行迹材料：智识（匹诺康尼大剧院）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Erudition_Planarcadia_SeafeldTVTower',
+    label: '行迹材料：智识（海原电视塔）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Harmony_Jarilo_RobotSettlement',
+    label: '行迹材料：同谐（机械聚落）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Harmony_Penacony_TheReverieDreamscape',
+    label: '行迹材料：同谐（白日梦酒店-梦境）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Nihility_Jarilo_GreatMine',
+    label: '行迹材料：虚无（大矿区）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Nihility_Luofu_AlchemyCommission',
+    label: '行迹材料：虚无（丹鼎司）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Nihility_Amphoreus_RadiantScarwoodGroveofEpiphany',
+    label: '行迹材料：虚无（辉痕圣林神悟树庭）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Remembrance_Amphoreus_StrifeRuinsCastrumKremnos',
+    label: '行迹材料：记忆（纷争荒墟悬锋城）',
+    category: 'Calyx_Crimson',
+  },
+  {
+    value: 'Calyx_Crimson_Elation_Planarcadia_WorldEndTavern',
+    label: '行迹材料：欢愉（世界尽头酒馆）',
+    category: 'Calyx_Crimson',
+  },
   // 凝滞虚影
-  { value: 'Stagnant_Shadow_Spike', label: '晋阶材料：物理（娜塔莎 / 克拉拉 / 卢卡 / 素裳）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Perdition', label: '晋阶材料：物理（寒鸦 / 银枝）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Duty', label: '晋阶材料：物理（云璃 / 知更鸟 / 波提欧）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Deepsheaf', label: '晋阶材料：物理（白厄 / 海瑟音 / 丹恒•腾荒 / 爻光 / 绯英）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Blaze', label: '晋阶材料：火（姬子 / 艾丝妲 / 虎克）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Scorch', label: '晋阶材料：火（托帕&账账 / 桂乃芬 / 忘归人）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Roast', label: '晋阶材料：量子（花火 / 翡翠）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Ire', label: '晋阶材料：火（椒丘 / 灵砂 / 加拉赫 / 流萤）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Ashes', label: '晋阶材料：火（大丽花 / 火花 / 千冶•刃 / 姬子•启行）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Rime', label: '晋阶材料：冰（三月七 / 黑塔 / 杰帕德 / 佩拉）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Icicle', label: '晋阶材料：冰（彦卿 / 镜流 / 阮•梅）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Nectar', label: '晋阶材料：冰（米沙 / 大黑塔）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Sirens', label: '晋阶材料：冰（长夜月 / 昔涟）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Fulmination', label: '晋阶材料：雷（阿兰 / 希露瓦 / 停云 / 白露）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Doom', label: '晋阶材料：雷（卡芙卡 / 景元 / 黄泉）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Mechwolf', label: '晋阶材料：雷（貊泽 / 阿格莱雅）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Soundburst', label: '晋阶材料：雷（不死途 / 吉尔伽美什）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Gust', label: '晋阶材料：风（丹恒 / 布洛妮娅 / 桑博）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Celestial', label: '晋阶材料：风（刃 / 藿藿 / 黑天鹅）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Gloam', label: '晋阶材料：风（飞霄 / 那刻夏 / 风堇 / Saber）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Cinders', label: '晋阶材料：风（刻律德菈）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Quanta', label: '晋阶材料：量子（银狼 / 希儿 / 青雀）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Abomination', label: '晋阶材料：量子（玲可 / 符玄 / 雪衣）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Gelidmoon', label: '晋阶材料：量子（缇宝 / 赛飞儿 / 遐蝶 / Archer）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Devour', label: '晋阶材料：量子（远坂凛）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Mirage', label: '晋阶材料：虚数（瓦尔特 / 罗刹 / 驭空）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Puppetry', label: '晋阶材料：虚数（丹恒•饮月 / 砂金 / 真理医生）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Timbre', label: '晋阶材料：虚数（星期日 / 乱破）', category: 'Stagnant_Shadow' },
-  { value: 'Stagnant_Shadow_Sloggyre', label: '晋阶材料：虚数（万敌 / 银狼LV.999）', category: 'Stagnant_Shadow' },
+  {
+    value: 'Stagnant_Shadow_Spike',
+    label: '晋阶材料：物理（娜塔莎 / 克拉拉 / 卢卡 / 素裳）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Perdition',
+    label: '晋阶材料：物理（寒鸦 / 银枝）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Duty',
+    label: '晋阶材料：物理（云璃 / 知更鸟 / 波提欧）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Deepsheaf',
+    label: '晋阶材料：物理（白厄 / 海瑟音 / 丹恒•腾荒 / 爻光 / 绯英）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Blaze',
+    label: '晋阶材料：火（姬子 / 艾丝妲 / 虎克）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Scorch',
+    label: '晋阶材料：火（托帕&账账 / 桂乃芬 / 忘归人）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Roast',
+    label: '晋阶材料：量子（花火 / 翡翠）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Ire',
+    label: '晋阶材料：火（椒丘 / 灵砂 / 加拉赫 / 流萤）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Ashes',
+    label: '晋阶材料：火（大丽花 / 火花 / 千冶•刃 / 姬子•启行）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Rime',
+    label: '晋阶材料：冰（三月七 / 黑塔 / 杰帕德 / 佩拉）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Icicle',
+    label: '晋阶材料：冰（彦卿 / 镜流 / 阮•梅）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Nectar',
+    label: '晋阶材料：冰（米沙 / 大黑塔）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Sirens',
+    label: '晋阶材料：冰（长夜月 / 昔涟）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Fulmination',
+    label: '晋阶材料：雷（阿兰 / 希露瓦 / 停云 / 白露）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Doom',
+    label: '晋阶材料：雷（卡芙卡 / 景元 / 黄泉）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Mechwolf',
+    label: '晋阶材料：雷（貊泽 / 阿格莱雅）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Soundburst',
+    label: '晋阶材料：雷（不死途 / 吉尔伽美什）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Gust',
+    label: '晋阶材料：风（丹恒 / 布洛妮娅 / 桑博）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Celestial',
+    label: '晋阶材料：风（刃 / 藿藿 / 黑天鹅）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Gloam',
+    label: '晋阶材料：风（飞霄 / 那刻夏 / 风堇 / Saber）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Cinders',
+    label: '晋阶材料：风（刻律德菈）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Quanta',
+    label: '晋阶材料：量子（银狼 / 希儿 / 青雀）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Abomination',
+    label: '晋阶材料：量子（玲可 / 符玄 / 雪衣）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Gelidmoon',
+    label: '晋阶材料：量子（缇宝 / 赛飞儿 / 遐蝶 / Archer）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Devour',
+    label: '晋阶材料：量子（远坂凛）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Mirage',
+    label: '晋阶材料：虚数（瓦尔特 / 罗刹 / 驭空）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Puppetry',
+    label: '晋阶材料：虚数（丹恒•饮月 / 砂金 / 真理医生）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Timbre',
+    label: '晋阶材料：虚数（星期日 / 乱破）',
+    category: 'Stagnant_Shadow',
+  },
+  {
+    value: 'Stagnant_Shadow_Sloggyre',
+    label: '晋阶材料：虚数（万敌 / 银狼LV.999）',
+    category: 'Stagnant_Shadow',
+  },
 ]
 
 // 筛选后的材料关卡选项
@@ -400,37 +787,37 @@ const getStageLabel = (value: string, type: string) => {
 
   const stageMap: Record<string, string> = {
     // 遗器
-    'Cavern_of_Corrosion_Path_of_Insight': '遗器：领航员 & 名冶（观火之径）',
-    'Cavern_of_Corrosion_Path_of_Possession': '遗器：魔法少女 & 卜者（魔占之径）',
-    'Cavern_of_Corrosion_Path_of_Hidden_Salvation': '遗器：救世主 & 隐士（隐救之径）',
-    'Cavern_of_Corrosion_Path_of_Thundersurge': '遗器：烈阳 & 船长（雳涌之径）',
-    'Cavern_of_Corrosion_Path_of_Aria': '遗器：英豪 & 诗人（弦歌之径）',
-    'Cavern_of_Corrosion_Path_of_Uncertainty': '遗器：司铎 & 学者（迷识之径）',
-    'Cavern_of_Corrosion_Path_of_Cavalier': '遗器：铁骑 & 勇烈（勇骑之径）',
-    'Cavern_of_Corrosion_Path_of_Dreamdive': '遗器：死水 & 钟表匠（梦潜之径）',
-    'Cavern_of_Corrosion_Path_of_Darkness': '遗器：大公 & DoT套（幽冥之径）',
-    'Cavern_of_Corrosion_Path_of_Elixir_Seekers': '遗器：莳者 & 信使（药使之径）',
-    'Cavern_of_Corrosion_Path_of_Conflagration': '遗器：火套 & 虚数套（野焰之径）',
-    'Cavern_of_Corrosion_Path_of_Holy_Hymn': '遗器：防御套 & 雷套（圣颂之径）',
-    'Cavern_of_Corrosion_Path_of_Providence': '遗器：铁卫 & 量子套（睿治之径）',
-    'Cavern_of_Corrosion_Path_of_Drifting': '遗器：治疗套 & 快枪手（漂泊之径）',
-    'Cavern_of_Corrosion_Path_of_Jabbing_Punch': '遗器：物理套 & 怪盗（迅拳之径）',
-    'Cavern_of_Corrosion_Path_of_Gelid_Wind': '遗器：冰套 & 风套（霜风之径）',
+    Cavern_of_Corrosion_Path_of_Insight: '遗器：领航员 & 名冶（观火之径）',
+    Cavern_of_Corrosion_Path_of_Possession: '遗器：魔法少女 & 卜者（魔占之径）',
+    Cavern_of_Corrosion_Path_of_Hidden_Salvation: '遗器：救世主 & 隐士（隐救之径）',
+    Cavern_of_Corrosion_Path_of_Thundersurge: '遗器：烈阳 & 船长（雳涌之径）',
+    Cavern_of_Corrosion_Path_of_Aria: '遗器：英豪 & 诗人（弦歌之径）',
+    Cavern_of_Corrosion_Path_of_Uncertainty: '遗器：司铎 & 学者（迷识之径）',
+    Cavern_of_Corrosion_Path_of_Cavalier: '遗器：铁骑 & 勇烈（勇骑之径）',
+    Cavern_of_Corrosion_Path_of_Dreamdive: '遗器：死水 & 钟表匠（梦潜之径）',
+    Cavern_of_Corrosion_Path_of_Darkness: '遗器：大公 & DoT套（幽冥之径）',
+    Cavern_of_Corrosion_Path_of_Elixir_Seekers: '遗器：莳者 & 信使（药使之径）',
+    Cavern_of_Corrosion_Path_of_Conflagration: '遗器：火套 & 虚数套（野焰之径）',
+    Cavern_of_Corrosion_Path_of_Holy_Hymn: '遗器：防御套 & 雷套（圣颂之径）',
+    Cavern_of_Corrosion_Path_of_Providence: '遗器：铁卫 & 量子套（睿治之径）',
+    Cavern_of_Corrosion_Path_of_Drifting: '遗器：治疗套 & 快枪手（漂泊之径）',
+    Cavern_of_Corrosion_Path_of_Jabbing_Punch: '遗器：物理套 & 怪盗（迅拳之径）',
+    Cavern_of_Corrosion_Path_of_Gelid_Wind: '遗器：冰套 & 风套（霜风之径）',
     // 饰品
-    'Divergent_Universe_Bugs_Incoming': '饰品：坠星 & 寰宇（虫虫来袭）',
-    'Divergent_Universe_Gilded_Recollection': '饰品：朋克洛德 & 千星荟萃（鎏金追忆）',
-    'Divergent_Universe_Within_the_West_Wind': '饰品：翁法罗斯 & 天国（西风丛中）',
-    'Divergent_Universe_Moonlit_Blood': '饰品：妖精 & 沉醉（月下朱殷）',
-    'Divergent_Universe_Unceasing_Strife': '饰品：拾骨地 & 巨树（纷争不休）',
-    'Divergent_Universe_Famished_Worker': '饰品：海域 & 奇想（蠹役饥肠）',
-    'Divergent_Universe_Eternal_Comedy': '饰品：奔狼 & 火宫（永恒笑剧）',
-    'Divergent_Universe_To_Sweet_Dreams': '饰品：茨冈尼亚 & 出云（伴你入眠）',
-    'Divergent_Universe_Pouring_Blades': '饰品：苍穹 & 匹诺康尼（天剑如雨）',
-    'Divergent_Universe_Fruit_of_Evil': '饰品：繁星 & 龙骨（孽果盘生）',
-    'Divergent_Universe_Permafrost': '饰品：贝洛伯格 & 萨尔索图（百年冻土）',
-    'Divergent_Universe_Gentle_Words': '饰品：商业公司 & 差分机（温柔话语）',
-    'Divergent_Universe_Smelted_Heart': '饰品：盗贼 & 翁瓦克（浴火钢心）',
-    'Divergent_Universe_Untoppled_Walls': '饰品：太空 & 仙舟（坚城不倒）',
+    Divergent_Universe_Bugs_Incoming: '饰品：坠星 & 寰宇（虫虫来袭）',
+    Divergent_Universe_Gilded_Recollection: '饰品：朋克洛德 & 千星荟萃（鎏金追忆）',
+    Divergent_Universe_Within_the_West_Wind: '饰品：翁法罗斯 & 天国（西风丛中）',
+    Divergent_Universe_Moonlit_Blood: '饰品：妖精 & 沉醉（月下朱殷）',
+    Divergent_Universe_Unceasing_Strife: '饰品：拾骨地 & 巨树（纷争不休）',
+    Divergent_Universe_Famished_Worker: '饰品：海域 & 奇想（蠹役饥肠）',
+    Divergent_Universe_Eternal_Comedy: '饰品：奔狼 & 火宫（永恒笑剧）',
+    Divergent_Universe_To_Sweet_Dreams: '饰品：茨冈尼亚 & 出云（伴你入眠）',
+    Divergent_Universe_Pouring_Blades: '饰品：苍穹 & 匹诺康尼（天剑如雨）',
+    Divergent_Universe_Fruit_of_Evil: '饰品：繁星 & 龙骨（孽果盘生）',
+    Divergent_Universe_Permafrost: '饰品：贝洛伯格 & 萨尔索图（百年冻土）',
+    Divergent_Universe_Gentle_Words: '饰品：商业公司 & 差分机（温柔话语）',
+    Divergent_Universe_Smelted_Heart: '饰品：盗贼 & 翁瓦克（浴火钢心）',
+    Divergent_Universe_Untoppled_Walls: '饰品：太空 & 仙舟（坚城不倒）',
   }
 
   // 材料关卡从materialOptions中查找

--- a/frontend/src/views/WSdev.vue
+++ b/frontend/src/views/WSdev.vue
@@ -63,15 +63,28 @@
               v-for="client in sortedClientList"
               :key="client.name"
               class="client-item"
-              :class="{ active: selectedClient === client.name, connected: client.is_connected, system: client.is_system }"
+              :class="{
+                active: selectedClient === client.name,
+                connected: client.is_connected,
+                system: client.is_system,
+              }"
               @click="selectClient(client.name)"
             >
               <div class="client-info">
                 <div class="client-name">
                   <a-badge :status="client.is_connected ? 'success' : 'default'" />
-                  <LockOutlined v-if="client.is_system" style="margin-right: 4px; color: var(--ant-color-warning)" />
+                  <LockOutlined
+                    v-if="client.is_system"
+                    style="margin-right: 4px; color: var(--ant-color-warning)"
+                  />
                   {{ client.name }}
-                  <a-tag v-if="client.is_system" color="orange" size="small" style="margin-left: 4px">系统</a-tag>
+                  <a-tag
+                    v-if="client.is_system"
+                    color="orange"
+                    size="small"
+                    style="margin-left: 4px"
+                    >系统</a-tag
+                  >
                 </div>
                 <div class="client-url">{{ client.url }}</div>
               </div>
@@ -104,11 +117,7 @@
                   <DeleteOutlined />
                 </a-button>
                 <a-tooltip v-else title="系统客户端不可删除">
-                  <a-button
-                    type="link"
-                    size="small"
-                    disabled
-                  >
+                  <a-button type="link" size="small" disabled>
                     <DeleteOutlined />
                   </a-button>
                 </a-tooltip>
@@ -186,12 +195,7 @@
             </template>
 
             <a-form-item>
-              <a-button
-                type="primary"
-                block
-                :loading="sending"
-                @click="sendMessage"
-              >
+              <a-button type="primary" block :loading="sending" @click="sendMessage">
                 <template #icon><SendOutlined /></template>
                 发送消息
               </a-button>
@@ -210,11 +214,7 @@
                 checked-children="自动滚动"
                 un-checked-children="手动滚动"
               />
-              <a-select
-                v-model:value="messageFilter"
-                style="width: 120px"
-                size="small"
-              >
+              <a-select v-model:value="messageFilter" style="width: 120px" size="small">
                 <a-select-option value="all">全部消息</a-select-option>
                 <a-select-option value="sent">仅发送</a-select-option>
                 <a-select-option value="received">仅接收</a-select-option>
@@ -254,21 +254,15 @@
     <a-modal
       v-model:open="createModalVisible"
       title="创建 WebSocket 客户端"
+      :confirm-loading="creating"
       @ok="createClient"
-      :confirmLoading="creating"
     >
       <a-form layout="vertical">
         <a-form-item label="客户端名称" required>
-          <a-input
-            v-model:value="createForm.name"
-            placeholder="输入客户端名称，如 Koishi"
-          />
+          <a-input v-model:value="createForm.name" placeholder="输入客户端名称，如 Koishi" />
         </a-form-item>
         <a-form-item label="服务器 URL" required>
-          <a-input
-            v-model:value="createForm.url"
-            placeholder="ws://localhost:5140/AUTO_MAS"
-          />
+          <a-input v-model:value="createForm.url" placeholder="ws://localhost:5140/AUTO_MAS" />
         </a-form-item>
         <a-row :gutter="12">
           <a-col :span="12">
@@ -405,7 +399,7 @@ let liveWs: WebSocket | null = null
 // ============== 计算属性 ==============
 
 const connectedCount = computed(() => {
-  return clientList.value.filter((c) => c.is_connected).length
+  return clientList.value.filter(c => c.is_connected).length
 })
 
 const totalMessageCount = computed(() => {
@@ -425,7 +419,7 @@ const sortedClientList = computed(() => {
 
 const _isSelectedClientConnected = computed(() => {
   if (!selectedClient.value) return false
-  const client = clientList.value.find((c) => c.name === selectedClient.value)
+  const client = clientList.value.find(c => c.name === selectedClient.value)
   return client?.is_connected ?? false
 })
 
@@ -433,7 +427,7 @@ const filteredMessages = computed(() => {
   if (messageFilter.value === 'all') {
     return messages.value
   }
-  return messages.value.filter((m) => m.direction === messageFilter.value)
+  return messages.value.filter(m => m.direction === messageFilter.value)
 })
 
 // ============== 方法 ==============
@@ -586,7 +580,8 @@ async function disconnectClient(name: string) {
   try {
     const requestBody = { name }
     logApiRequest('/api/ws_debug/client/disconnect', 'POST', requestBody)
-    const response = await WebSocketService.disconnectClientApiWsDebugClientDisconnectPost(requestBody)
+    const response =
+      await WebSocketService.disconnectClientApiWsDebugClientDisconnectPost(requestBody)
     logApiResponse('/api/ws_debug/client/disconnect', response)
 
     if (response.code === 200) {
@@ -649,7 +644,8 @@ async function sendMessage() {
         data,
       }
       logApiRequest('/api/ws_debug/message/send_json', 'POST', jsonRequestBody)
-      response = await WebSocketService.sendJsonMessageApiWsDebugMessageSendJsonPost(jsonRequestBody)
+      response =
+        await WebSocketService.sendJsonMessageApiWsDebugMessageSendJsonPost(jsonRequestBody)
       logApiResponse('/api/ws_debug/message/send_json', response)
     } else if (sendMode.value === 'raw') {
       let messageObj: any
@@ -743,7 +739,7 @@ function connectLiveWs() {
       console.log('实时消息连接已建立')
     }
 
-    liveWs.onmessage = (event) => {
+    liveWs.onmessage = event => {
       try {
         const data = JSON.parse(event.data)
 
@@ -769,7 +765,7 @@ function connectLiveWs() {
       }
     }
 
-    liveWs.onerror = (error) => {
+    liveWs.onerror = error => {
       console.error('实时消息连接错误:', error)
     }
 

--- a/frontend/src/views/gamesign/index.vue
+++ b/frontend/src/views/gamesign/index.vue
@@ -16,26 +16,26 @@ const { subscribe, unsubscribe } = useWebSocket()
 
 // 工具数据（保留完整 ToolsConfig，避免更新时覆盖其它工具的配置）
 const toolsConfig = reactive<ToolsConfig>({
-    GameSign: {
-        Enabled: false,
-        NotifyEnabled: false,
-        RunOnStartup: false,
-        LastSignDate: '2000-01-01',
-        Status: '-',
-        Result: '{}',
-    },
+  GameSign: {
+    Enabled: false,
+    NotifyEnabled: false,
+    RunOnStartup: false,
+    LastSignDate: '2000-01-01',
+    Status: '-',
+    Result: '{}',
+  },
 })
 
 // 本地编辑状态
 const editingConfig = reactive<ToolsConfig>({
-    GameSign: {
-        Enabled: false,
-        NotifyEnabled: false,
-        RunOnStartup: false,
-        LastSignDate: '2000-01-01',
-        Status: '-',
-        Result: '{}',
-    },
+  GameSign: {
+    Enabled: false,
+    NotifyEnabled: false,
+    RunOnStartup: false,
+    LastSignDate: '2000-01-01',
+    Status: '-',
+    Result: '{}',
+  },
 })
 
 // 轮询定时器
@@ -47,298 +47,303 @@ let statusPollFailed = false
 let isMounted = true
 
 const syncGameSignResult = (result: unknown) => {
-    if (!isMounted || typeof result !== 'string') return
-    if (toolsConfig.GameSign) {
-        toolsConfig.GameSign.Result = result
-    }
-    if (editingConfig.GameSign) {
-        editingConfig.GameSign.Result = result
-    }
+  if (!isMounted || typeof result !== 'string') return
+  if (toolsConfig.GameSign) {
+    toolsConfig.GameSign.Result = result
+  }
+  if (editingConfig.GameSign) {
+    editingConfig.GameSign.Result = result
+  }
 }
 
 // 仅更新状态（不影响编辑状态，不触发 loading）
 const updateStatus = async () => {
-    try {
-        const response = await Service.getToolsApiToolsGetPost()
-        if (!isMounted) return
-        if (response.code !== 200 || !response.data) {
-            throw new Error(response.message || '签到状态响应无效')
-        }
-        statusPollFailed = false
-        const data = response.data
-        if (data.GameSign?.Status) {
-            toolsConfig.GameSign!.Status = data.GameSign.Status
-        }
-        syncGameSignResult(data.GameSign?.Result)
-    } catch (error) {
-        if (!statusPollFailed) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.warn(`更新签到状态失败，将继续重试: ${errorMsg}`)
-            statusPollFailed = true
-        }
+  try {
+    const response = await Service.getToolsApiToolsGetPost()
+    if (!isMounted) return
+    if (response.code !== 200 || !response.data) {
+      throw new Error(response.message || '签到状态响应无效')
     }
+    statusPollFailed = false
+    const data = response.data
+    if (data.GameSign?.Status) {
+      toolsConfig.GameSign!.Status = data.GameSign.Status
+    }
+    syncGameSignResult(data.GameSign?.Result)
+  } catch (error) {
+    if (!statusPollFailed) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.warn(`更新签到状态失败，将继续重试: ${errorMsg}`)
+      statusPollFailed = true
+    }
+  }
 }
 
 // 签到完成后立即刷新配置（不等轮询）
 const refreshGameSignConfig = async () => {
-    try {
-        const response = await Service.getToolsApiToolsGetPost()
-        if (!isMounted) return
-        if (response.code !== 200 || !response.data) {
-            throw new Error(response.message || '签到结果响应无效')
-        }
-        const data = response.data
-        if (data.GameSign?.Status) {
-            toolsConfig.GameSign!.Status = data.GameSign.Status
-        }
-        syncGameSignResult(data.GameSign?.Result)
-    } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.warn(`刷新签到结果失败: ${errorMsg}`)
+  try {
+    const response = await Service.getToolsApiToolsGetPost()
+    if (!isMounted) return
+    if (response.code !== 200 || !response.data) {
+      throw new Error(response.message || '签到结果响应无效')
     }
+    const data = response.data
+    if (data.GameSign?.Status) {
+      toolsConfig.GameSign!.Status = data.GameSign.Status
+    }
+    syncGameSignResult(data.GameSign?.Result)
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.warn(`刷新签到结果失败: ${errorMsg}`)
+  }
 }
 
 const startStatusPolling = () => {
-    if (pollTimer) clearInterval(pollTimer)
-    pollTimer = setInterval(() => {
-        updateStatus()
-    }, 1000)
+  if (pollTimer) clearInterval(pollTimer)
+  pollTimer = setInterval(() => {
+    updateStatus()
+  }, 1000)
 }
 
 const stopStatusPolling = () => {
-    if (pollTimer) {
-        clearInterval(pollTimer)
-        pollTimer = null
-    }
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
 }
 
 // 加载配置
 const loadTools = async () => {
-    try {
-        const data = await getTools()
-        if (!data.GameSign) {
-            data.GameSign = {
-                Enabled: false,
-                NotifyEnabled: false,
-                RunOnStartup: false,
-                LastSignDate: '2000-01-01',
-                Status: '-',
-                Result: '{}',
-            }
-        }
-        Object.assign(toolsConfig, data)
-        Object.assign(editingConfig, JSON.parse(JSON.stringify(data)))
-        logger.info('游戏签到配置加载完成')
-    } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`加载游戏签到配置失败: ${errorMsg}`)
+  try {
+    const data = await getTools()
+    if (!data.GameSign) {
+      data.GameSign = {
+        Enabled: false,
+        NotifyEnabled: false,
+        RunOnStartup: false,
+        LastSignDate: '2000-01-01',
+        Status: '-',
+        Result: '{}',
+      }
     }
+    Object.assign(toolsConfig, data)
+    Object.assign(editingConfig, JSON.parse(JSON.stringify(data)))
+    logger.info('游戏签到配置加载完成')
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`加载游戏签到配置失败: ${errorMsg}`)
+  }
 }
 
 // 只提交当前 GameSign 字段，避免并发覆盖签到状态或其它工具配置。
 const handleGameSignFieldChange = async (key: string, value: any) => {
-    if (!editingConfig.GameSign) return
+  if (!editingConfig.GameSign) return
 
-    const previousValue = (editingConfig.GameSign as any)[key]
+  const previousValue = (editingConfig.GameSign as any)[key]
 
-    try {
-        (editingConfig.GameSign as any)[key] = value
-        await updateTools({ GameSign: { [key]: value } })
+  try {
+    ;(editingConfig.GameSign as any)[key] = value
+    await updateTools({ GameSign: { [key]: value } })
 
-        if (toolsConfig.GameSign && key !== 'Status' && key !== 'Result') {
-            (toolsConfig.GameSign as any)[key] = value
-        }
-
-        logger.info(`GameSign.${key} 已保存`)
-    } catch (error) {
-        // 仅在当前值仍是本次提交值时回滚，避免较早请求失败覆盖更新后的操作。
-        if ((editingConfig.GameSign as any)[key] === value) {
-            (editingConfig.GameSign as any)[key] = previousValue
-        }
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`保存 GameSign.${key} 失败: ${errorMsg}`)
-        throw error
+    if (toolsConfig.GameSign && key !== 'Status' && key !== 'Result') {
+      ;(toolsConfig.GameSign as any)[key] = value
     }
+
+    logger.info(`GameSign.${key} 已保存`)
+  } catch (error) {
+    // 仅在当前值仍是本次提交值时回滚，避免较早请求失败覆盖更新后的操作。
+    if ((editingConfig.GameSign as any)[key] === value) {
+      ;(editingConfig.GameSign as any)[key] = previousValue
+    }
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`保存 GameSign.${key} 失败: ${errorMsg}`)
+    throw error
+  }
 }
 
 useEventListener(window, 'focus', () => void updateStatus())
 useEventListener(document, 'visibilitychange', () => {
-    if (document.visibilityState === 'visible') {
-        void updateStatus()
-    }
+  if (document.visibilityState === 'visible') {
+    void updateStatus()
+  }
 })
 
 onMounted(async () => {
-    gameSignSubscriptionId = subscribe({ id: 'GameSign', type: 'Update' }, message => {
-        const data = message.data as { Result?: unknown } | undefined
-        syncGameSignResult(data?.Result)
-    })
-    await loadTools()
-    startStatusPolling()
+  gameSignSubscriptionId = subscribe({ id: 'GameSign', type: 'Update' }, message => {
+    const data = message.data as { Result?: unknown } | undefined
+    syncGameSignResult(data?.Result)
+  })
+  await loadTools()
+  startStatusPolling()
 })
 
 onUnmounted(() => {
-    isMounted = false
-    stopStatusPolling()
-    if (gameSignSubscriptionId) {
-        unsubscribe(gameSignSubscriptionId)
-        gameSignSubscriptionId = null
-    }
+  isMounted = false
+  stopStatusPolling()
+  if (gameSignSubscriptionId) {
+    unsubscribe(gameSignSubscriptionId)
+    gameSignSubscriptionId = null
+  }
 })
 </script>
 
 <template>
-    <div class="gamesign-container">
-        <div class="gamesign-header">
-            <h1 class="page-title">游戏签到</h1>
-        </div>
-        <div class="gamesign-content">
-            <TabGameSign v-if="editingConfig.GameSign" :config="editingConfig.GameSign" :disabled="loading"
-                :on-field-change="handleGameSignFieldChange" :on-refresh-config="refreshGameSignConfig" />
-        </div>
+  <div class="gamesign-container">
+    <div class="gamesign-header">
+      <h1 class="page-title">游戏签到</h1>
     </div>
+    <div class="gamesign-content">
+      <TabGameSign
+        v-if="editingConfig.GameSign"
+        :config="editingConfig.GameSign"
+        :disabled="loading"
+        :on-field-change="handleGameSignFieldChange"
+        :on-refresh-config="refreshGameSignConfig"
+      />
+    </div>
+  </div>
 </template>
 
 <style scoped>
 /* 与工具/设置页统一的页面布局与内容卡片样式 */
 .gamesign-container {
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .gamesign-header {
-    margin-bottom: 16px;
-    padding: 0 4px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  margin-bottom: 16px;
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .page-title {
-    margin: 0;
-    font-size: 32px;
-    font-weight: 700;
-    color: var(--ant-color-text);
-    background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .gamesign-content {
-    background: var(--ant-color-bg-container);
-    border-radius: 12px;
-    width: 100%;
-    flex: 1;
-    min-height: 0;
-    overflow: auto;
+  background: var(--ant-color-bg-container);
+  border-radius: 12px;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 /* 内容区滚动条样式（与工具页统一） */
 .gamesign-content::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+  width: 8px;
+  height: 8px;
 }
 
 .gamesign-content::-webkit-scrollbar-track {
-    background: var(--ant-color-bg-container);
-    border-radius: 4px;
+  background: var(--ant-color-bg-container);
+  border-radius: 4px;
 }
 
 .gamesign-content::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
 }
 
 .gamesign-content::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.25);
 }
 
 :root.dark .gamesign-content::-webkit-scrollbar-track {
-    background: var(--ant-color-bg-elevated);
+  background: var(--ant-color-bg-elevated);
 }
 
 :root.dark .gamesign-content::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.15);
 }
 
 :root.dark .gamesign-content::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.25);
 }
 
 /* ==================== 子组件统一表单样式（与工具页/设置页一致） ==================== */
 :deep(.tab-content) {
-    padding: 24px;
-    width: 100%;
+  padding: 24px;
+  width: 100%;
 }
 
 :deep(.form-section) {
-    margin-bottom: 32px;
+  margin-bottom: 32px;
 }
 
 :deep(.form-section:last-child) {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 :deep(.section-header) {
-    margin-bottom: 20px;
-    padding-bottom: 8px;
-    border-bottom: 2px solid var(--ant-color-border-secondary);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--ant-color-border-secondary);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 :deep(.section-header h3) {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 700;
-    color: var(--ant-color-text);
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 :deep(.section-header h3::before) {
-    content: '';
-    width: 4px;
-    height: 24px;
-    background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-    border-radius: 2px;
+  content: '';
+  width: 4px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  border-radius: 2px;
 }
 
 :deep(.section-description) {
-    margin: 4px 0 0;
-    font-size: 13px;
-    color: var(--ant-color-text-secondary);
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--ant-color-text-secondary);
 }
 
 :deep(.form-item-vertical) {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
 }
 
 :deep(.form-label-wrapper) {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 :deep(.form-label) {
-    font-weight: 600;
-    color: var(--ant-color-text);
-    font-size: 14px;
+  font-weight: 600;
+  color: var(--ant-color-text);
+  font-size: 14px;
 }
 
 :deep(.help-icon) {
-    color: #8c8c8c;
-    font-size: 14px;
+  color: #8c8c8c;
+  font-size: 14px;
 }
 </style>

--- a/frontend/src/views/history/components/HistoryDateSidebar.vue
+++ b/frontend/src/views/history/components/HistoryDateSidebar.vue
@@ -240,8 +240,6 @@ const formatDateGroup = (date: string) => formatHistoryGroupLabel(date)
   font-size: 13px;
   color: var(--ant-color-text-secondary);
 }
-
-
 </style>
 
 <style>

--- a/frontend/src/views/history/components/HistoryRecordList.vue
+++ b/frontend/src/views/history/components/HistoryRecordList.vue
@@ -23,16 +23,26 @@
       </div>
 
       <div v-else class="records-scroll">
-        <div v-for="(record, index) in records" :key="record.jsonFile" class="record-item" :class="{
-          active: selectedIndex === index,
-          success: record.status === 'DONE',
-          error: record.status === 'ERROR',
-        }" @click="$emit('select', index, record)">
+        <div
+          v-for="(record, index) in records"
+          :key="record.jsonFile"
+          class="record-item"
+          :class="{
+            active: selectedIndex === index,
+            success: record.status === 'DONE',
+            error: record.status === 'ERROR',
+          }"
+          @click="$emit('select', index, record)"
+        >
           <div class="record-status-bar" :class="record.status === 'DONE' ? 'success' : 'error'" />
           <div class="record-content">
             <div class="record-main">
               <span class="record-time">{{ formatRecordTime(record.date) }}</span>
-              <a-tag :color="record.status === 'DONE' ? 'success' : 'error'" size="small" class="status-tag">
+              <a-tag
+                :color="record.status === 'DONE' ? 'success' : 'error'"
+                size="small"
+                class="status-tag"
+              >
                 <CheckCircleOutlined v-if="record.status === 'DONE'" />
                 <CloseCircleOutlined v-else />
                 {{

--- a/frontend/src/views/history/components/UserStatisticsCard.vue
+++ b/frontend/src/views/history/components/UserStatisticsCard.vue
@@ -7,11 +7,7 @@
       class="statistics-tabs"
       size="small"
     >
-      <a-tab-pane
-        v-for="option in availableStatistics"
-        :key="option.value"
-        :tab="option.label"
-      />
+      <a-tab-pane v-for="option in availableStatistics" :key="option.value" :tab="option.label" />
     </a-tabs>
 
     <div class="card-content">
@@ -218,7 +214,6 @@ watch(
   },
   { immediate: true }
 )
-
 </script>
 
 <style scoped>

--- a/frontend/src/views/home/components/HomeBackToTop.vue
+++ b/frontend/src/views/home/components/HomeBackToTop.vue
@@ -55,7 +55,9 @@ onBeforeUnmount(() => {
   color: #fff;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  transition: background 0.2s, transform 0.2s;
+  transition:
+    background 0.2s,
+    transform 0.2s;
 }
 
 .back-to-top:hover {
@@ -74,7 +76,9 @@ onBeforeUnmount(() => {
 
 .back-to-top-enter-active,
 .back-to-top-leave-active {
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
 
 .back-to-top-enter-from,

--- a/frontend/src/views/home/components/HomeReverse1999Overview.vue
+++ b/frontend/src/views/home/components/HomeReverse1999Overview.vue
@@ -75,7 +75,9 @@
         <div class="version-info-time">
           <ClockCircleOutlined class="version-info-time-icon" />
           <span class="version-info-time-label">版本时间：</span>
-          <span class="version-info-time-value">{{ formatTime(overview.startTime) }} ~ {{ formatTime(overview.endTime) }}</span>
+          <span class="version-info-time-value"
+            >{{ formatTime(overview.startTime) }} ~ {{ formatTime(overview.endTime) }}</span
+          >
         </div>
       </div>
 
@@ -133,7 +135,9 @@ const activeActivities = computed(() => {
 
 const versionCover = computed(() => {
   if (failedVersionCover.value) return ''
-  return props.overview.cover || props.overview.activities.find(activity => activity.cover)?.cover || ''
+  return (
+    props.overview.cover || props.overview.activities.find(activity => activity.cover)?.cover || ''
+  )
 })
 
 const remainingCountdownStyle = computed<CSSProperties>(() => ({
@@ -210,7 +214,11 @@ const formatTime = (value: string) =>
   border: 1px solid transparent;
   border-radius: 10px;
   background:
-    radial-gradient(ellipse at 78% 20%, color-mix(in srgb, var(--r1999-accent) 14%, transparent), transparent 55%),
+    radial-gradient(
+      ellipse at 78% 20%,
+      color-mix(in srgb, var(--r1999-accent) 14%, transparent),
+      transparent 55%
+    ),
     radial-gradient(ellipse at 90% 85%, rgba(64, 128, 255, 0.18), transparent 60%),
     linear-gradient(135deg, #0b1220 0%, #101a2e 55%, #0e1a2b 100%);
 }

--- a/frontend/src/views/home/components/HomeScrollHint.vue
+++ b/frontend/src/views/home/components/HomeScrollHint.vue
@@ -1,6 +1,11 @@
 <template>
   <Transition name="scroll-hint">
-    <button v-if="visible" class="scroll-hint" aria-label="向下滚动查看更多内容" @click="scrollDown">
+    <button
+      v-if="visible"
+      class="scroll-hint"
+      aria-label="向下滚动查看更多内容"
+      @click="scrollDown"
+    >
       <span class="scroll-hint-text">下方还有更多内容</span>
       <DownOutlined class="scroll-hint-arrow" />
     </button>

--- a/frontend/src/views/home/components/HomeSraActivityOverview.vue
+++ b/frontend/src/views/home/components/HomeSraActivityOverview.vue
@@ -280,7 +280,11 @@ const formatTime = (value: string) =>
   border: 1px solid transparent;
   border-radius: 10px;
   background:
-    radial-gradient(ellipse at 78% 20%, color-mix(in srgb, var(--sra-accent) 14%, transparent), transparent 55%),
+    radial-gradient(
+      ellipse at 78% 20%,
+      color-mix(in srgb, var(--sra-accent) 14%, transparent),
+      transparent 55%
+    ),
     radial-gradient(ellipse at 90% 85%, rgba(64, 128, 255, 0.18), transparent 60%),
     linear-gradient(135deg, #0b1220 0%, #101a2e 55%, #0e1a2b 100%);
 }

--- a/frontend/src/views/plan/tables/MaaPlanTable.vue
+++ b/frontend/src/views/plan/tables/MaaPlanTable.vue
@@ -170,7 +170,6 @@ const props = defineProps<Props>()
 // 使用数据协调器 - 单一数据源
 const coordinator = usePlanDataCoordinator()
 
-
 // 临时自定义关卡输入
 const tempCustomStages = ref({
   custom_stage_1: '',

--- a/frontend/src/views/queue/components/QueueItemManager.vue
+++ b/frontend/src/views/queue/components/QueueItemManager.vue
@@ -22,9 +22,19 @@
       </div>
 
       <!-- 拖拽内容区域 -->
-      <draggable v-model="queueItems" group="queueItems" item-key="id" :animation="200" :disabled="loading"
-        ghost-class="ghost" chosen-class="chosen" drag-class="drag" handle=".drag-handle"
-        class="draggable-container" @end="onDragEnd">
+      <draggable
+        v-model="queueItems"
+        group="queueItems"
+        item-key="id"
+        :animation="200"
+        :disabled="loading"
+        ghost-class="ghost"
+        chosen-class="chosen"
+        drag-class="drag"
+        handle=".drag-handle"
+        class="draggable-container"
+        @end="onDragEnd"
+      >
         <template #item="{ element: record, index }">
           <div class="draggable-row" :class="{ 'row-dragging': loading }">
             <div class="row-cell drag-cell">
@@ -34,12 +44,25 @@
             </div>
             <div class="row-cell index-cell">{{ index + 1 }}</div>
             <div class="row-cell script-cell">
-              <a-select v-model:value="record.script" size="small" style="width: 200px" class="script-select"
-                placeholder="请选择脚本" :options="scriptOptions" allow-clear @change="updateQueueItemScript(record)" />
+              <a-select
+                v-model:value="record.script"
+                size="small"
+                style="width: 200px"
+                class="script-select"
+                placeholder="请选择脚本"
+                :options="scriptOptions"
+                allow-clear
+                @change="updateQueueItemScript(record)"
+              />
             </div>
             <div class="row-cell actions-cell">
               <a-space>
-                <a-popconfirm title="确定要删除这个任务吗？" ok-text="确定" cancel-text="取消" @confirm="deleteQueueItem(record.id)">
+                <a-popconfirm
+                  title="确定要删除这个任务吗？"
+                  ok-text="确定"
+                  cancel-text="取消"
+                  @confirm="deleteQueueItem(record.id)"
+                >
                   <a-button size="middle" danger>
                     <DeleteOutlined />
                     删除

--- a/frontend/src/views/queue/components/TimeSetManager.vue
+++ b/frontend/src/views/queue/components/TimeSetManager.vue
@@ -2,8 +2,12 @@
   <a-card title="定时列表" class="time-set-card">
     <template #extra>
       <a-space>
-        <a-button type="primary" :loading="loading" :disabled="!props.queueId || props.queueId.trim() === ''"
-          @click="addTimeSet">
+        <a-button
+          type="primary"
+          :loading="loading"
+          :disabled="!props.queueId || props.queueId.trim() === ''"
+          @click="addTimeSet"
+        >
           <template #icon>
             <PlusOutlined />
           </template>
@@ -25,9 +29,19 @@
       </div>
 
       <!-- 拖拽内容区域 -->
-      <draggable v-model="timeSets" group="timeSets" item-key="id" :animation="200" :disabled="loading"
-        ghost-class="ghost" chosen-class="chosen" drag-class="drag" handle=".drag-handle"
-        class="draggable-container" @end="onDragEnd">
+      <draggable
+        v-model="timeSets"
+        group="timeSets"
+        item-key="id"
+        :animation="200"
+        :disabled="loading"
+        ghost-class="ghost"
+        chosen-class="chosen"
+        drag-class="drag"
+        handle=".drag-handle"
+        class="draggable-container"
+        @end="onDragEnd"
+      >
         <template #item="{ element: record, index }">
           <div class="draggable-row" :class="{ 'row-dragging': loading }">
             <div class="row-cell drag-cell">
@@ -37,16 +51,30 @@
             </div>
             <div class="row-cell index-cell">{{ index + 1 }}</div>
             <div class="row-cell status-cell">
-              <a-select v-model:value="record.enabled" size="small" style="width: 80px" class="status-select"
-                @change="updateTimeSetStatus(record)">
+              <a-select
+                v-model:value="record.enabled"
+                size="small"
+                style="width: 80px"
+                class="status-select"
+                @change="updateTimeSetStatus(record)"
+              >
                 <a-select-option :value="true">启用</a-select-option>
                 <a-select-option :value="false">禁用</a-select-option>
               </a-select>
             </div>
             <div class="row-cell days-cell">
-              <a-select v-model:value="record.days" mode="multiple" size="small" style="width: 100%"
-                placeholder="请选择执行周期" :disabled="loading" @change="updateTimeSetDays(record)" :maxTagCount="7"
-                :bordered="false" class="days-select">
+              <a-select
+                v-model:value="record.days"
+                mode="multiple"
+                size="small"
+                style="width: 100%"
+                placeholder="请选择执行周期"
+                :disabled="loading"
+                :max-tag-count="7"
+                :bordered="false"
+                class="days-select"
+                @change="updateTimeSetDays(record)"
+              >
                 <a-select-option value="Monday">周一</a-select-option>
                 <a-select-option value="Tuesday">周二</a-select-option>
                 <a-select-option value="Wednesday">周三</a-select-option>
@@ -57,12 +85,23 @@
               </a-select>
             </div>
             <div class="row-cell time-cell">
-              <a-time-picker v-model:value="record.timeValue" format="HH:mm" placeholder="请选择时间" size="small"
-                :disabled="loading" @change="updateTimeSetTime(record)" />
+              <a-time-picker
+                v-model:value="record.timeValue"
+                format="HH:mm"
+                placeholder="请选择时间"
+                size="small"
+                :disabled="loading"
+                @change="updateTimeSetTime(record)"
+              />
             </div>
             <div class="row-cell actions-cell">
               <a-space>
-                <a-popconfirm title="确定要删除这个定时吗？" ok-text="确定" cancel-text="取消" @confirm="deleteTimeSet(record.id)">
+                <a-popconfirm
+                  title="确定要删除这个定时吗？"
+                  ok-text="确定"
+                  cancel-text="取消"
+                  @confirm="deleteTimeSet(record.id)"
+                >
                   <a-button size="middle" danger>
                     <DeleteOutlined />
                     删除
@@ -1201,7 +1240,9 @@ const onDragEnd = async (evt: any) => {
   transition: background 0.2s ease;
 }
 
-[data-theme='dark'] .ant-picker-dropdown .ant-picker-time-panel-column::-webkit-scrollbar-thumb:hover {
+[data-theme='dark']
+  .ant-picker-dropdown
+  .ant-picker-time-panel-column::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.45);
 }
 </style>

--- a/frontend/src/views/queue/index.vue
+++ b/frontend/src/views/queue/index.vue
@@ -20,8 +20,13 @@
             新建队列
           </a-button>
 
-          <a-popconfirm v-if="queueList.length > 0" title="确定要删除这个队列吗？" ok-text="确定" cancel-text="取消"
-            @confirm="handleRemoveQueue(activeQueueId)">
+          <a-popconfirm
+            v-if="queueList.length > 0"
+            title="确定要删除这个队列吗？"
+            ok-text="确定"
+            cancel-text="取消"
+            @confirm="handleRemoveQueue(activeQueueId)"
+          >
             <a-button danger size="large" :disabled="!activeQueueId">
               <template #icon>
                 <DeleteOutlined />
@@ -63,9 +68,14 @@
           <!-- 队列按钮组 -->
           <div class="queue-buttons-container">
             <a-space wrap size="middle">
-              <a-button v-for="queue in queueList" :key="queue.id"
-                :type="activeQueueId === queue.id ? 'primary' : 'default'" size="large" class="queue-button"
-                @click="onQueueChange(queue.id)">
+              <a-button
+                v-for="queue in queueList"
+                :key="queue.id"
+                :type="activeQueueId === queue.id ? 'primary' : 'default'"
+                size="large"
+                class="queue-button"
+                @click="onQueueChange(queue.id)"
+              >
                 {{ queue.name }}
               </a-button>
             </a-space>
@@ -86,9 +96,15 @@
               </a-button>
             </div>
             <div v-else class="queue-title-edit">
-              <a-input ref="queueNameInputRef" v-model:value="currentQueueName" placeholder="请输入队列名称"
-                class="queue-title-input" :maxlength="50" @blur="finishEditQueueName"
-                @press-enter="finishEditQueueName" />
+              <a-input
+                ref="queueNameInputRef"
+                v-model:value="currentQueueName"
+                placeholder="请输入队列名称"
+                class="queue-title-input"
+                :maxlength="50"
+                @blur="finishEditQueueName"
+                @press-enter="finishEditQueueName"
+              />
             </div>
           </div>
         </template>
@@ -104,8 +120,12 @@
                     <QuestionCircleOutlined class="help-icon" />
                   </a-tooltip>
                 </div>
-                <a-select v-model:value="currentStartUpEnabled" style="width: 100%" size="large"
-                  @change="(value: any) => handleConfigChange('StartUpEnabled', value)">
+                <a-select
+                  v-model:value="currentStartUpEnabled"
+                  style="width: 100%"
+                  size="large"
+                  @change="(value: any) => handleConfigChange('StartUpEnabled', value)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -119,8 +139,12 @@
                     <QuestionCircleOutlined class="help-icon" />
                   </a-tooltip>
                 </div>
-                <a-select v-model:value="currentTimeEnabled" style="width: 100%" size="large"
-                  @change="(value: any) => handleConfigChange('TimeEnabled', value)">
+                <a-select
+                  v-model:value="currentTimeEnabled"
+                  style="width: 100%"
+                  size="large"
+                  @change="(value: any) => handleConfigChange('TimeEnabled', value)"
+                >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
                 </a-select>
@@ -134,9 +158,14 @@
                     <QuestionCircleOutlined class="help-icon" />
                   </a-tooltip>
                 </div>
-                <a-select v-model:value="currentAfterAccomplish" style="width: 100%" :options="afterAccomplishOptions"
-                  placeholder="请选择操作" size="large"
-                  @change="(value: any) => handleConfigChange('AfterAccomplish', value)" />
+                <a-select
+                  v-model:value="currentAfterAccomplish"
+                  style="width: 100%"
+                  :options="afterAccomplishOptions"
+                  placeholder="请选择操作"
+                  size="large"
+                  @change="(value: any) => handleConfigChange('AfterAccomplish', value)"
+                />
               </div>
             </a-col>
           </a-row>
@@ -145,14 +174,24 @@
 
         <!-- 定时项管理 -->
         <a-col :span="24" class="manager-col">
-          <TimeSetManager v-if="activeQueueId && currentQueueData" :queue-id="activeQueueId"
-            :time-sets="currentTimeSets" style="font-size: 14px" @refresh="refreshTimeSets" />
+          <TimeSetManager
+            v-if="activeQueueId && currentQueueData"
+            :queue-id="activeQueueId"
+            :time-sets="currentTimeSets"
+            style="font-size: 14px"
+            @refresh="refreshTimeSets"
+          />
         </a-col>
 
         <!-- 队列项管理 -->
         <a-col :span="24" class="manager-col">
-          <QueueItemManager v-if="activeQueueId && currentQueueData" :queue-id="activeQueueId"
-            :queue-items="currentQueueItems" style="font-size: 14px" @refresh="refreshQueueItems" />
+          <QueueItemManager
+            v-if="activeQueueId && currentQueueData"
+            :queue-id="activeQueueId"
+            :queue-items="currentQueueItems"
+            style="font-size: 14px"
+            @refresh="refreshQueueItems"
+          />
         </a-col>
       </a-card>
     </div>
@@ -798,7 +837,6 @@ onUnmounted(() => {
 }
 
 @keyframes pulse {
-
   0%,
   100% {
     opacity: 0.6;

--- a/frontend/src/views/scheduler/SchedulerTaskControl.vue
+++ b/frontend/src/views/scheduler/SchedulerTaskControl.vue
@@ -13,7 +13,7 @@
             :disabled="disabled"
             size="large"
             @change="onTaskChange"
-            @dropdownVisibleChange="onDropdownVisibleChange"
+            @dropdown-visible-change="onDropdownVisibleChange"
           />
           <a-select
             v-if="status !== '运行'"
@@ -57,7 +57,7 @@
             allow-clear
             size="large"
             @change="onResumeScriptChange"
-            @dropdownVisibleChange="onResumeDropdownVisibleChange"
+            @dropdown-visible-change="onResumeDropdownVisibleChange"
           />
           <a-button
             :type="status === '运行' ? 'default' : 'primary'"

--- a/frontend/src/views/scheduler/TaskOverviewPanel.vue
+++ b/frontend/src/views/scheduler/TaskOverviewPanel.vue
@@ -78,7 +78,6 @@ const getScriptStats = (scripts: Script[]) => {
 
 // 处理 WebSocket 消息
 const handleWSMessage = (message: WSMessage) => {
-
   if (message.type === 'Update') {
     // 处理 task_info 数据（完整的脚本和用户数据）
     if (message.data?.task_info && Array.isArray(message.data.task_info)) {

--- a/frontend/src/views/scheduler/useSchedulerLogic.ts
+++ b/frontend/src/views/scheduler/useSchedulerLogic.ts
@@ -150,14 +150,21 @@ export function useSchedulerLogic() {
       const queueId = data.queueId
       const taskName = data.taskName
       const taskType = data.taskType
-      logger.info(`收到新任务信号: 任务ID=${taskId}, 队列ID=${queueId}, 任务名称=${taskName}, 任务类型=${taskType}`)
+      logger.info(
+        `收到新任务信号: 任务ID=${taskId}, 队列ID=${queueId}, 任务名称=${taskName}, 任务类型=${taskType}`
+      )
 
       // 创建新的调度台
       createSchedulerTabForTask(taskId, queueId, taskName, taskType)
     }
   }
 
-  const createSchedulerTabForTask = (taskId: string, queueId?: string, taskName?: string, taskType?: string) => {
+  const createSchedulerTabForTask = (
+    taskId: string,
+    queueId?: string,
+    taskName?: string,
+    taskType?: string
+  ) => {
     // 使用现有的addSchedulerTab函数创建新调度台，并传入特定的配置选项
     const newTab = addSchedulerTab({
       title: `调度台${tabCounter}`,
@@ -207,7 +214,12 @@ export function useSchedulerLogic() {
   watchTabsChanges()
 
   // Tab 管理
-  const addSchedulerTab = (options?: { title?: string; status?: string; websocketId?: string; selectedTaskId?: string }) => {
+  const addSchedulerTab = (options?: {
+    title?: string
+    status?: string
+    websocketId?: string
+    selectedTaskId?: string
+  }) => {
     tabCounter++
     const status = options?.status || '空闲'
     // 使用更安全的类型断言，确保状态值是有效的SchedulerStatus
@@ -531,25 +543,28 @@ export function useSchedulerLogic() {
     }
 
     // 创建新订阅，不再needCache，因为keep-alive保持组件存活
-    const subscriptionId = ws.subscribe(
-      { id: tab.websocketId },
-      message => handleWebSocketMessage(tab, message)
+    const subscriptionId = ws.subscribe({ id: tab.websocketId }, message =>
+      handleWebSocketMessage(tab, message)
     )
 
     // 将订阅ID保存到tab中，以便后续取消订阅
     tab.subscriptionId = subscriptionId
-    logger.info(`新建WebSocket订阅: ${JSON.stringify({
-      key: tab.key,
-      websocketId: tab.websocketId,
-      subscriptionId,
-    })}`)
+    logger.info(
+      `新建WebSocket订阅: ${JSON.stringify({
+        key: tab.key,
+        websocketId: tab.websocketId,
+        subscriptionId,
+      })}`
+    )
 
     // 验证订阅是否成功建立
     if (!subscriptionId) {
-      logger.error(`WebSocket订阅创建失败！: ${JSON.stringify({
-        key: tab.key,
-        websocketId: tab.websocketId,
-      })}`)
+      logger.error(
+        `WebSocket订阅创建失败！: ${JSON.stringify({
+          key: tab.key,
+          websocketId: tab.websocketId,
+        })}`
+      )
       message.error('WebSocket订阅创建失败，可能无法接收任务消息')
     }
   }
@@ -643,7 +658,8 @@ export function useSchedulerLogic() {
       if (data.task_info && Array.isArray(data.task_info)) {
         // 完整脚本+用户数据，直接保存
         tab.overviewData = (data.task_info as any[]).map(s => ({
-          script_id: s.script_id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          script_id:
+            s.script_id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
           name: s.name || '未知脚本',
           status: s.status || '等待',
           user_list: s.userList ? [...s.userList] : [],
@@ -691,10 +707,12 @@ export function useSchedulerLogic() {
         const newContent = data.log
         if (tab.lastLogContent !== newContent) {
           tab.lastLogContent = newContent
-          logger.debug(`更新日志内容: ${JSON.stringify({
-            tabKey: tab.key,
-            contentLength: newContent.length
-          })}`)
+          logger.debug(
+            `更新日志内容: ${JSON.stringify({
+              tabKey: tab.key,
+              contentLength: newContent.length,
+            })}`
+          )
         }
       } else if (typeof data.log === 'object') {
         let newContent = ''
@@ -705,10 +723,12 @@ export function useSchedulerLogic() {
 
         if (tab.lastLogContent !== newContent) {
           tab.lastLogContent = newContent
-          logger.debug(`更新日志对象: ${JSON.stringify({
-            tabKey: tab.key,
-            contentLength: newContent.length
-          })}`)
+          logger.debug(
+            `更新日志对象: ${JSON.stringify({
+              tabKey: tab.key,
+              contentLength: newContent.length,
+            })}`
+          )
         }
       }
     }
@@ -721,15 +741,24 @@ export function useSchedulerLogic() {
 
     if (data.Error) {
       const errorMsg = String(data.Error).toLowerCase()
-      const taskLabel = taskOptions.value.find(item => item.value === tab.selectedTaskId)?.label || ''
+      const taskLabel =
+        taskOptions.value.find(item => item.value === tab.selectedTaskId)?.label || ''
       const isMaaEndTask = [taskLabel, tab.runningTaskLabel, tab.runningModeLabel]
         .filter(Boolean)
         .some(value => value?.toLowerCase().includes('maaend') ?? false)
 
       // 根据错误内容匹配具体的 noisy 模式音频
-      if (errorMsg.includes('adb') && (errorMsg.includes('连接') || errorMsg.includes('connection'))) {
+      if (
+        errorMsg.includes('adb') &&
+        (errorMsg.includes('连接') || errorMsg.includes('connection'))
+      ) {
         await playSound('maa_adb_connection_error')
-      } else if (errorMsg.includes('模拟器') && (errorMsg.includes('未检测') || errorMsg.includes('not detected') || errorMsg.includes('找不到'))) {
+      } else if (
+        errorMsg.includes('模拟器') &&
+        (errorMsg.includes('未检测') ||
+          errorMsg.includes('not detected') ||
+          errorMsg.includes('找不到'))
+      ) {
         await playSound('maa_no_emulator_detected')
       } else if (errorMsg.includes('登录') && errorMsg.includes('失败')) {
         await playSound('maa_prts_login_failed')
@@ -783,12 +812,24 @@ export function useSchedulerLogic() {
 
       // 匹配成功信息的 noisy 模式音频
       if (infoMsg.includes('skland') || infoMsg.includes('森空岛')) {
-        if (infoMsg.includes('签到成功') || infoMsg.includes('checkin success') || infoMsg.includes('成功')) {
+        if (
+          infoMsg.includes('签到成功') ||
+          infoMsg.includes('checkin success') ||
+          infoMsg.includes('成功')
+        ) {
           await playSound('skland_checkin_success')
-        } else if (infoMsg.includes('签到失败') || infoMsg.includes('checkin failed') || infoMsg.includes('失败')) {
+        } else if (
+          infoMsg.includes('签到失败') ||
+          infoMsg.includes('checkin failed') ||
+          infoMsg.includes('失败')
+        ) {
           await playSound('skland_checkin_failed')
         }
-      } else if (infoMsg.includes('六星') || infoMsg.includes('6星') || infoMsg.includes('six star')) {
+      } else if (
+        infoMsg.includes('六星') ||
+        infoMsg.includes('6星') ||
+        infoMsg.includes('six star')
+      ) {
         await playSound('six_star_report')
       } else if (infoMsg.includes('adb') && infoMsg.includes('成功')) {
         await playSound('adb_success')
@@ -850,15 +891,19 @@ export function useSchedulerLogic() {
       if (tabIndex !== -1) {
         const updatedTab: SchedulerTab = { ...tab }
         schedulerTabs.value.splice(tabIndex, 1, updatedTab)
-        logger.debug(`已强制更新schedulerTabs，当前tabs状态: ${JSON.stringify(schedulerTabs.value)}`)
+        logger.debug(
+          `已强制更新schedulerTabs，当前tabs状态: ${JSON.stringify(schedulerTabs.value)}`
+        )
       }
 
       if (tab.subscriptionId) {
-        logger.info(`任务完成，清理WebSocket订阅: ${JSON.stringify({
-          key: tab.key,
-          subscriptionId: tab.subscriptionId,
-          websocketId: tab.websocketId,
-        })}`)
+        logger.info(
+          `任务完成，清理WebSocket订阅: ${JSON.stringify({
+            key: tab.key,
+            subscriptionId: tab.subscriptionId,
+            websocketId: tab.websocketId,
+          })}`
+        )
         try {
           ws.unsubscribe(tab.subscriptionId)
         } catch (error) {
@@ -869,10 +914,12 @@ export function useSchedulerLogic() {
       }
 
       if (tab.websocketId) {
-        logger.info(`任务完成，清理websocketId: ${JSON.stringify({
-          key: tab.key,
-          websocketId: tab.websocketId,
-        })}`)
+        logger.info(
+          `任务完成，清理websocketId: ${JSON.stringify({
+            key: tab.key,
+            websocketId: tab.websocketId,
+          })}`
+        )
         tab.websocketId = null
       }
 
@@ -921,7 +968,7 @@ export function useSchedulerLogic() {
               name: s.name,
               status: s.status,
               userList: s.user_list, // 转换回后端格式
-            }))
+            })),
           },
         }
         try {
@@ -1057,14 +1104,14 @@ export function useSchedulerLogic() {
       if (response.code === 200 && response.signal) {
         // 将后端返回的 PowerOut.signal 转换为 PowerIn.signal
         const signalMap: Record<string, PowerIn.signal> = {
-          'NoAction': PowerIn.signal.NO_ACTION,
-          'Shutdown': PowerIn.signal.SHUTDOWN,
-          'ShutdownForce': PowerIn.signal.SHUTDOWN_FORCE,
-          'Reboot': PowerIn.signal.REBOOT,
-          'Hibernate': PowerIn.signal.HIBERNATE,
-          'Sleep': PowerIn.signal.SLEEP,
-          'KillSelf': PowerIn.signal.KILL_SELF,
-          'Logoff': PowerIn.signal.LOGOFF,
+          NoAction: PowerIn.signal.NO_ACTION,
+          Shutdown: PowerIn.signal.SHUTDOWN,
+          ShutdownForce: PowerIn.signal.SHUTDOWN_FORCE,
+          Reboot: PowerIn.signal.REBOOT,
+          Hibernate: PowerIn.signal.HIBERNATE,
+          Sleep: PowerIn.signal.SLEEP,
+          KillSelf: PowerIn.signal.KILL_SELF,
+          Logoff: PowerIn.signal.LOGOFF,
         }
         const mappedSignal = signalMap[response.signal]
         if (mappedSignal) {
@@ -1200,11 +1247,13 @@ export function useSchedulerLogic() {
     try {
       schedulerTabs.value.forEach(tab => {
         if (tab.status === '运行' && tab.websocketId) {
-          logger.info(`初始化阶段检查运行中标签的订阅: ${JSON.stringify({
-            key: tab.key,
-            websocketId: tab.websocketId,
-            hasSubscription: !!tab.subscriptionId,
-          })}`)
+          logger.info(
+            `初始化阶段检查运行中标签的订阅: ${JSON.stringify({
+              key: tab.key,
+              websocketId: tab.websocketId,
+              hasSubscription: !!tab.subscriptionId,
+            })}`
+          )
           // subscribeToTask 会自动跳过已有订阅，保持缓存标记不丢失
           subscribeToTask(tab)
         }
@@ -1245,12 +1294,14 @@ export function useSchedulerLogic() {
   const debugSubscriptionStatus = () => {
     logger.info('当前调度台订阅状态:')
     schedulerTabs.value.forEach(tab => {
-      logger.info(`- Tab ${tab.key} (${tab.title}): ${JSON.stringify({
-        status: tab.status,
-        websocketId: tab.websocketId,
-        subscriptionId: tab.subscriptionId,
-        hasSubscription: !!tab.subscriptionId,
-      })}`)
+      logger.info(
+        `- Tab ${tab.key} (${tab.title}): ${JSON.stringify({
+          status: tab.status,
+          websocketId: tab.websocketId,
+          subscriptionId: tab.subscriptionId,
+          hasSubscription: !!tab.subscriptionId,
+        })}`
+      )
     })
     logger.info(`WebSocket状态: ${JSON.stringify(ws.status.value)}`)
   }
@@ -1276,11 +1327,13 @@ export function useSchedulerLogic() {
     logger.info('清理所有WebSocket订阅')
     schedulerTabs.value.forEach(tab => {
       if (tab.subscriptionId) {
-        logger.info(`清理订阅: ${JSON.stringify({
-          key: tab.key,
-          status: tab.status,
-          subscriptionId: tab.subscriptionId,
-        })}`)
+        logger.info(
+          `清理订阅: ${JSON.stringify({
+            key: tab.key,
+            status: tab.status,
+            subscriptionId: tab.subscriptionId,
+          })}`
+        )
         try {
           ws.unsubscribe(tab.subscriptionId)
         } catch (error) {

--- a/frontend/src/views/scripts/components/ScriptCreateDialog.vue
+++ b/frontend/src/views/scripts/components/ScriptCreateDialog.vue
@@ -155,10 +155,7 @@
                 <a-radio :value="template.downloadUrl" />
               </label>
             </a-radio-group>
-            <a-empty
-              v-else
-              :description="templateKeyword ? '未找到匹配的模板' : '暂无可用模板'"
-            >
+            <a-empty v-else :description="templateKeyword ? '未找到匹配的模板' : '暂无可用模板'">
               <a-button v-if="templateKeyword" @click="templateKeyword = ''">清空搜索</a-button>
               <a-button v-else @click="chooseCustomConfig">改为自定义配置</a-button>
             </a-empty>

--- a/frontend/src/views/setting/TabFunction.vue
+++ b/frontend/src/views/setting/TabFunction.vue
@@ -3,12 +3,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons-vue'
 import type { GlobalConfig } from '@/api'
 import { handleExternalLink } from '@/utils/openExternal'
 
-const {
-  settings,
-  historyRetentionOptions,
-  voiceTypeOptions,
-  handleSettingChange,
-} = defineProps<{
+const { settings, historyRetentionOptions, voiceTypeOptions, handleSettingChange } = defineProps<{
   settings: GlobalConfig
   historyRetentionOptions: { label: string; value: number }[]
   voiceTypeOptions: { label: string; value: string }[]
@@ -30,8 +25,12 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Start?.IfSelfStart" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Start', 'IfSelfStart', checked)">
+            <a-select
+              :value="settings.Start?.IfSelfStart"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Start', 'IfSelfStart', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -45,9 +44,14 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Start?.IfMinimizeDirectly" size="large" style="width: 100%" @change="
-              (checked: any) => handleSettingChange('Start', 'IfMinimizeDirectly', checked)
-            ">
+            <a-select
+              :value="settings.Start?.IfMinimizeDirectly"
+              size="large"
+              style="width: 100%"
+              @change="
+                (checked: any) => handleSettingChange('Start', 'IfMinimizeDirectly', checked)
+              "
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -69,22 +73,33 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Function?.HistoryRetentionTime" :options="historyRetentionOptions" size="large"
-              style="width: 100%" @change="
+            <a-select
+              :value="settings.Function?.HistoryRetentionTime"
+              :options="historyRetentionOptions"
+              size="large"
+              style="width: 100%"
+              @change="
                 (value: any) => handleSettingChange('Function', 'HistoryRetentionTime', value)
-              " />
+              "
+            />
           </div>
         </a-col>
         <a-col :span="8">
           <div class="form-item-vertical">
             <div class="form-label-wrapper">
               <span class="form-label">静默模式</span>
-              <a-tooltip title="启用后将各代理窗口置于后台运行，减少对前台的干扰。反馈问题、故障排查时，请关闭此功能以便检查相关窗口情况。">
+              <a-tooltip
+                title="启用后将各代理窗口置于后台运行，减少对前台的干扰。反馈问题、故障排查时，请关闭此功能以便检查相关窗口情况。"
+              >
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Function?.IfSilence" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Function', 'IfSilence', checked)">
+            <a-select
+              :value="settings.Function?.IfSilence"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Function', 'IfSilence', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -98,8 +113,12 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Function?.IfAllowSleep" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Function', 'IfAllowSleep', checked)">
+            <a-select
+              :value="settings.Function?.IfAllowSleep"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Function', 'IfAllowSleep', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -140,16 +159,28 @@ const {
                     </p>
                     <ul style="margin: 8px 0; padding-left: 16px">
                       <li>
-                        <a href="https://www.bilibili.com/protocal/licence.html" class="tooltip-link"
-                          @click="handleExternalLink">《哔哩哔哩弹幕网用户使用协议》</a>
+                        <a
+                          href="https://www.bilibili.com/protocal/licence.html"
+                          class="tooltip-link"
+                          @click="handleExternalLink"
+                          >《哔哩哔哩弹幕网用户使用协议》</a
+                        >
                       </li>
                       <li>
-                        <a href="https://www.bilibili.com/blackboard/privacy-pc.html" class="tooltip-link"
-                          @click="handleExternalLink">《哔哩哔哩隐私政策》</a>
+                        <a
+                          href="https://www.bilibili.com/blackboard/privacy-pc.html"
+                          class="tooltip-link"
+                          @click="handleExternalLink"
+                          >《哔哩哔哩隐私政策》</a
+                        >
                       </li>
                       <li>
-                        <a href="https://game.bilibili.com/yhxy" class="tooltip-link"
-                          @click="handleExternalLink">《哔哩哔哩游戏中心用户协议》</a>
+                        <a
+                          href="https://game.bilibili.com/yhxy"
+                          class="tooltip-link"
+                          @click="handleExternalLink"
+                          >《哔哩哔哩游戏中心用户协议》</a
+                        >
                       </li>
                     </ul>
                   </div>
@@ -157,9 +188,14 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Function?.IfAgreeBilibili" size="large" style="width: 100%" @change="
-              (checked: any) => handleSettingChange('Function', 'IfAgreeBilibili', checked)
-            ">
+            <a-select
+              :value="settings.Function?.IfAgreeBilibili"
+              size="large"
+              style="width: 100%"
+              @change="
+                (checked: any) => handleSettingChange('Function', 'IfAgreeBilibili', checked)
+              "
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -172,16 +208,10 @@ const {
               <a-tooltip>
                 <template #title>
                   <div style="max-width: 300px">
-                    <p>
-                      屏蔽部分模拟器广告，支持的广告类型如下：
-                    </p>
+                    <p>屏蔽部分模拟器广告，支持的广告类型如下：</p>
                     <ul style="margin: 8px 0; padding-left: 16px">
-                      <li>
-                        <strong>MuMu模拟器</strong>：启动时广告
-                      </li>
-                      <li>
-                        <strong>雷电模拟器</strong>：启动时广告、桌面广告
-                      </li>
+                      <li><strong>MuMu模拟器</strong>：启动时广告</li>
+                      <li><strong>雷电模拟器</strong>：启动时广告、桌面广告</li>
                     </ul>
                   </div>
                 </template>
@@ -215,8 +245,12 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Voice?.Enabled" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Voice', 'Enabled', checked)">
+            <a-select
+              :value="settings.Voice?.Enabled"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Voice', 'Enabled', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -230,8 +264,14 @@ const {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Voice?.Type" :options="voiceTypeOptions" :disabled="!settings.Voice?.Enabled"
-              size="large" style="width: 100%" @change="(value: any) => handleSettingChange('Voice', 'Type', value)" />
+            <a-select
+              :value="settings.Voice?.Type"
+              :options="voiceTypeOptions"
+              :disabled="!settings.Voice?.Enabled"
+              size="large"
+              style="width: 100%"
+              @change="(value: any) => handleSettingChange('Voice', 'Type', value)"
+            />
           </div>
         </a-col>
       </a-row>

--- a/frontend/src/views/setting/TabNotify.vue
+++ b/frontend/src/views/setting/TabNotify.vue
@@ -26,8 +26,14 @@ const handleWebhookChange = async () => {
     <div class="form-section">
       <div class="section-header">
         <h3>通知内容</h3>
-        <a-button type="primary" :loading="testingNotify" size="small" class="section-update-button primary-style"
-          @click="testNotify">发送测试通知</a-button>
+        <a-button
+          type="primary"
+          :loading="testingNotify"
+          size="small"
+          class="section-update-button primary-style"
+          @click="testNotify"
+          >发送测试通知</a-button
+        >
       </div>
       <a-row :gutter="24">
         <a-col :span="8">
@@ -38,9 +44,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.SendTaskResultTime" :options="sendTaskResultTimeOptions" size="large"
+            <a-select
+              :value="settings.Notify?.SendTaskResultTime"
+              :options="sendTaskResultTimeOptions"
+              size="large"
               style="width: 100%"
-              @change="(value: any) => handleSettingChange('Notify', 'SendTaskResultTime', value)" />
+              @change="(value: any) => handleSettingChange('Notify', 'SendTaskResultTime', value)"
+            />
           </div>
         </a-col>
         <a-col :span="8">
@@ -51,8 +61,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfSendStatistic" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfSendStatistic', checked)">
+            <a-select
+              :value="settings.Notify?.IfSendStatistic"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfSendStatistic', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -66,8 +80,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfSendSixStar" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfSendSixStar', checked)">
+            <a-select
+              :value="settings.Notify?.IfSendSixStar"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfSendSixStar', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -89,8 +107,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfPushPlyer" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfPushPlyer', checked)">
+            <a-select
+              :value="settings.Notify?.IfPushPlyer"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfPushPlyer', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -102,8 +124,12 @@ const handleWebhookChange = async () => {
     <div class="form-section">
       <div class="section-header">
         <h3>邮件通知</h3>
-        <a href="https://doc.auto-mas.top/docs/advanced-features/notification.html#smtp-%E9%82%AE%E4%BB%B6%E6%8E%A8%E9%80%81%E6%B8%A0%E9%81%93"
-          class="section-doc-link" title="查看电子邮箱配置文档" @click="handleExternalLink">
+        <a
+          href="https://doc.auto-mas.top/docs/advanced-features/notification.html#smtp-%E9%82%AE%E4%BB%B6%E6%8E%A8%E9%80%81%E6%B8%A0%E9%81%93"
+          class="section-doc-link"
+          title="查看电子邮箱配置文档"
+          @click="handleExternalLink"
+        >
           文档
         </a>
       </div>
@@ -116,8 +142,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfSendMail" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfSendMail', checked)">
+            <a-select
+              :value="settings.Notify?.IfSendMail"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfSendMail', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -131,9 +161,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Notify?.SMTPServerAddress" :disabled="!settings.Notify?.IfSendMail"
-              placeholder="请输入发信邮箱SMTP服务器地址" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'SMTPServerAddress', e.target.value)" />
+            <a-input
+              :value="settings.Notify?.SMTPServerAddress"
+              :disabled="!settings.Notify?.IfSendMail"
+              placeholder="请输入发信邮箱SMTP服务器地址"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'SMTPServerAddress', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -146,9 +180,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Notify?.FromAddress" :disabled="!settings.Notify?.IfSendMail"
-              placeholder="请输入发信邮箱地址" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'FromAddress', e.target.value)" />
+            <a-input
+              :value="settings.Notify?.FromAddress"
+              :disabled="!settings.Notify?.IfSendMail"
+              placeholder="请输入发信邮箱地址"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'FromAddress', e.target.value)"
+            />
           </div>
         </a-col>
         <a-col :span="12">
@@ -159,9 +197,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input-password :value="settings.Notify?.AuthorizationCode" :disabled="!settings.Notify?.IfSendMail"
-              placeholder="请输入发信邮箱授权码" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'AuthorizationCode', e.target.value)" />
+            <a-input-password
+              :value="settings.Notify?.AuthorizationCode"
+              :disabled="!settings.Notify?.IfSendMail"
+              placeholder="请输入发信邮箱授权码"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'AuthorizationCode', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -174,9 +216,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Notify?.ToAddress" :disabled="!settings.Notify?.IfSendMail"
-              placeholder="请输入收信邮箱地址" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'ToAddress', e.target.value)" />
+            <a-input
+              :value="settings.Notify?.ToAddress"
+              :disabled="!settings.Notify?.IfSendMail"
+              placeholder="请输入收信邮箱地址"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'ToAddress', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -185,8 +231,12 @@ const handleWebhookChange = async () => {
     <div class="form-section">
       <div class="section-header">
         <h3>Server酱通知</h3>
-        <a href="https://doc.auto-mas.top/docs/advanced-features/notification.html#serverchan-%E9%80%9A%E7%9F%A5%E6%8E%A8%E9%80%81%E6%B8%A0%E9%81%93"
-          class="section-doc-link" title="查看Server酱配置文档" @click="handleExternalLink">
+        <a
+          href="https://doc.auto-mas.top/docs/advanced-features/notification.html#serverchan-%E9%80%9A%E7%9F%A5%E6%8E%A8%E9%80%81%E6%B8%A0%E9%81%93"
+          class="section-doc-link"
+          title="查看Server酱配置文档"
+          @click="handleExternalLink"
+        >
           文档
         </a>
       </div>
@@ -202,8 +252,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfServerChan" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfServerChan', checked)">
+            <a-select
+              :value="settings.Notify?.IfServerChan"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfServerChan', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -220,9 +274,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Notify?.ServerChanKey" :disabled="!settings.Notify?.IfServerChan"
-              placeholder="请输入Server酱SendKey" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'ServerChanKey', e.target.value)" />
+            <a-input
+              :value="settings.Notify?.ServerChanKey"
+              :disabled="!settings.Notify?.IfServerChan"
+              placeholder="请输入Server酱SendKey"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'ServerChanKey', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -241,8 +299,12 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Notify?.IfKoishiSupport" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Notify', 'IfKoishiSupport', checked)">
+            <a-select
+              :value="settings.Notify?.IfKoishiSupport"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Notify', 'IfKoishiSupport', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -258,9 +320,15 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Notify?.KoishiServerAddress" :disabled="!settings.Notify?.IfKoishiSupport"
-              placeholder="ws://localhost:5140/AUTO_MAS" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'KoishiServerAddress', e.target.value)" />
+            <a-input
+              :value="settings.Notify?.KoishiServerAddress"
+              :disabled="!settings.Notify?.IfKoishiSupport"
+              placeholder="ws://localhost:5140/AUTO_MAS"
+              size="large"
+              @blur="
+                (e: any) => handleSettingChange('Notify', 'KoishiServerAddress', e.target.value)
+              "
+            />
           </div>
         </a-col>
         <a-col :span="12">
@@ -271,9 +339,13 @@ const handleWebhookChange = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input-password :value="settings.Notify?.KoishiToken" :disabled="!settings.Notify?.IfKoishiSupport"
-              placeholder="请输入Koishi Token" size="large"
-              @blur="(e: any) => handleSettingChange('Notify', 'KoishiToken', e.target.value)" />
+            <a-input-password
+              :value="settings.Notify?.KoishiToken"
+              :disabled="!settings.Notify?.IfKoishiSupport"
+              placeholder="请输入Koishi Token"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Notify', 'KoishiToken', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -282,14 +354,17 @@ const handleWebhookChange = async () => {
     <div class="form-section">
       <div class="section-header">
         <h3>自定义 Webhook 通知</h3>
-        <a href="https://doc.auto-mas.top/docs/advanced-features/notification.html" class="section-doc-link"
-          title="查看自定义Webhook配置文档" @click="handleExternalLink">
+        <a
+          href="https://doc.auto-mas.top/docs/advanced-features/notification.html"
+          class="section-doc-link"
+          title="查看自定义Webhook配置文档"
+          @click="handleExternalLink"
+        >
           文档
         </a>
       </div>
       <WebhookManager mode="global" @change="handleWebhookChange" />
     </div>
-
   </div>
 </template>
 
@@ -341,9 +416,11 @@ const handleWebhookChange = async () => {
   transition:
     transform 0.16s ease,
     box-shadow 0.16s ease;
-  background: linear-gradient(135deg,
-      var(--ant-color-primary),
-      var(--ant-color-primary-hover)) !important;
+  background: linear-gradient(
+    135deg,
+    var(--ant-color-primary),
+    var(--ant-color-primary-hover)
+  ) !important;
   border: 1px solid var(--ant-color-primary) !important;
   /* subtle border to match doc-link rhythm */
   color: #fff !important;

--- a/frontend/src/views/setting/TabOthers.vue
+++ b/frontend/src/views/setting/TabOthers.vue
@@ -63,7 +63,6 @@ const copyAllInfo = async () => {
     document.body.removeChild(textArea)
   }
 }
-
 </script>
 <template>
   <div class="tab-content">
@@ -74,7 +73,8 @@ const copyAllInfo = async () => {
           <template #icon>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
               <path
-                d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z" />
+                d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+              />
             </svg>
           </template>
           检查更新
@@ -89,8 +89,12 @@ const copyAllInfo = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Update?.IfAutoUpdate" size="large" style="width: 100%"
-              @change="(checked: any) => handleSettingChange('Update', 'IfAutoUpdate', checked)">
+            <a-select
+              :value="settings.Update?.IfAutoUpdate"
+              size="large"
+              style="width: 100%"
+              @change="(checked: any) => handleSettingChange('Update', 'IfAutoUpdate', checked)"
+            >
               <a-select-option :value="true">是</a-select-option>
               <a-select-option :value="false">否</a-select-option>
             </a-select>
@@ -104,20 +108,32 @@ const copyAllInfo = async () => {
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Update?.Source" :options="updateSourceOptions" size="large" style="width: 100%"
-              @change="(value: any) => handleSettingChange('Update', 'Source', value)" />
+            <a-select
+              :value="settings.Update?.Source"
+              :options="updateSourceOptions"
+              size="large"
+              style="width: 100%"
+              @change="(value: any) => handleSettingChange('Update', 'Source', value)"
+            />
           </div>
         </a-col>
         <a-col :span="8">
           <div class="form-item-vertical">
             <div class="form-label-wrapper">
               <span class="form-label">更新渠道</span>
-              <a-tooltip title="稳定版：BUG 较少，无法第一时间体验新功能；公测版：包含最新功能，但可能存在较多 BUG">
+              <a-tooltip
+                title="稳定版：BUG 较少，无法第一时间体验新功能；公测版：包含最新功能，但可能存在较多 BUG"
+              >
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-select :value="settings.Update?.Channel" :options="updateChannelOptions" size="large" style="width: 100%"
-              @change="(value: any) => handleSettingChange('Update', 'Channel', value)" />
+            <a-select
+              :value="settings.Update?.Channel"
+              :options="updateChannelOptions"
+              size="large"
+              style="width: 100%"
+              @change="(value: any) => handleSettingChange('Update', 'Channel', value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -126,12 +142,18 @@ const copyAllInfo = async () => {
           <div class="form-item-vertical">
             <div class="form-label-wrapper">
               <span class="form-label">网络代理地址</span>
-              <a-tooltip title="使用网络代理软件时，若出现网络连接问题，请尝试设置代理地址，此设置全局生效">
+              <a-tooltip
+                title="使用网络代理软件时，若出现网络连接问题，请尝试设置代理地址，此设置全局生效"
+              >
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input :value="settings.Update?.ProxyAddress" placeholder="请输入网络代理地址" size="large"
-              @blur="(e: any) => handleSettingChange('Update', 'ProxyAddress', e.target.value)" />
+            <a-input
+              :value="settings.Update?.ProxyAddress"
+              placeholder="请输入网络代理地址"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Update', 'ProxyAddress', e.target.value)"
+            />
           </div>
         </a-col>
         <a-col :span="12">
@@ -142,18 +164,26 @@ const copyAllInfo = async () => {
                 <template #title>
                   <div>
                     Mirror酱CDK是使用Mirror源进行高速下载的凭证，可前往
-                    <a href="https://mirrorchyan.com/zh/get-start?source=auto-mas-setting" class="tooltip-link"
-                      @click="handleExternalLink">Mirror酱官网</a>
+                    <a
+                      href="https://mirrorchyan.com/zh/get-start?source=auto-mas-setting"
+                      class="tooltip-link"
+                      @click="handleExternalLink"
+                      >Mirror酱官网</a
+                    >
                     获取
                   </div>
                 </template>
                 <QuestionCircleOutlined class="help-icon" />
               </a-tooltip>
             </div>
-            <a-input-password :value="settings.Update?.MirrorChyanCDK"
-              :disabled="settings.Update?.Source !== 'MirrorChyan'" placeholder="使用Mirror源时请输入Mirror酱CDK"
-              :visibility-toggle="true" size="large"
-              @blur="(e: any) => handleSettingChange('Update', 'MirrorChyanCDK', e.target.value)" />
+            <a-input-password
+              :value="settings.Update?.MirrorChyanCDK"
+              :disabled="settings.Update?.Source !== 'MirrorChyan'"
+              placeholder="使用Mirror源时请输入Mirror酱CDK"
+              :visibility-toggle="true"
+              size="large"
+              @blur="(e: any) => handleSettingChange('Update', 'MirrorChyanCDK', e.target.value)"
+            />
           </div>
         </a-col>
       </a-row>
@@ -172,7 +202,9 @@ const copyAllInfo = async () => {
             <div class="link-content">
               <h4>软件官网</h4>
               <p>查看最新版本和功能介绍</p>
-              <a href="https://auto-mas.top" class="link-button" @click="handleExternalLink">访问官网</a>
+              <a href="https://auto-mas.top" class="link-button" @click="handleExternalLink"
+                >访问官网</a
+              >
             </div>
           </div>
         </div>
@@ -184,8 +216,12 @@ const copyAllInfo = async () => {
             <div class="link-content">
               <h4>GitHub仓库</h4>
               <p>查看源代码、提交issue和捐赠</p>
-              <a href="https://github.com/AUTO-MAS-Project/AUTO-MAS" class="link-button"
-                @click="handleExternalLink">访问仓库</a>
+              <a
+                href="https://github.com/AUTO-MAS-Project/AUTO-MAS"
+                class="link-button"
+                @click="handleExternalLink"
+                >访问仓库</a
+              >
             </div>
           </div>
         </div>
@@ -197,7 +233,9 @@ const copyAllInfo = async () => {
             <div class="link-content">
               <h4>用户QQ群</h4>
               <p>加入社区，获取帮助和交流</p>
-              <a :href="MAS_QQ_GROUP_URL" class="link-button" @click="handleExternalLink">加入群聊</a>
+              <a :href="MAS_QQ_GROUP_URL" class="link-button" @click="handleExternalLink"
+                >加入群聊</a
+              >
             </div>
           </div>
         </div>

--- a/frontend/src/views/tools/TabArknightsPC.vue
+++ b/frontend/src/views/tools/TabArknightsPC.vue
@@ -2,439 +2,507 @@
 import { QuestionCircleOutlined, WarningOutlined, ThunderboltOutlined } from '@ant-design/icons-vue'
 import type { ToolsConfig_ArknightsPC } from '@/api'
 
-const { config, disabled, onFieldChange, recordingKeyField, startRecordKey, stopRecordKey } = defineProps<{
+const { config, disabled, onFieldChange, recordingKeyField, startRecordKey, stopRecordKey } =
+  defineProps<{
     config: ToolsConfig_ArknightsPC
     disabled?: boolean
-    onFieldChange?: (key: string, value: any) => void
-    recordingKeyField?: string | null
-    startRecordKey?: (fieldName: string) => void
-    stopRecordKey?: () => void
-}>()
+    onFieldChange: (key: string, value: any) => void
+    recordingKeyField: string | null
+    startRecordKey: (fieldName: string) => void
+    stopRecordKey: () => void
+  }>()
 
 // 处理字段变更
 const handleChange = (key: string, value: any) => {
-    if (onFieldChange) {
-        onFieldChange(key, value)
-    }
+  if (onFieldChange) {
+    onFieldChange(key, value)
+  }
 }
 
 // 检查是否正在录制指定字段
 const isRecording = (fieldName: string) => {
-    return recordingKeyField === fieldName
+  return recordingKeyField === fieldName
 }
 </script>
 
 <template>
-    <div class="tab-content">
-        <!-- 工具简介 -->
-        <div class="tool-intro">
-            <!-- 工具简介 -->
-            <div class="detail-card intro-card">
-                <div class="card-header">
-                    <QuestionCircleOutlined />
-                    <span>工具简介</span>
-                </div>
-                <div class="card-content">
-                    <p class="intro-text">
-                        尽管明日方舟已上线暂停时部署功能，但选中干员与跳帧操作仍未实现。本工具旨在提供极限操作支持，改善您的游戏体验。
-                    </p>
-                </div>
-            </div>
-
-            <div class="intro-divider"></div>
-
-            <!-- 使用要求 -->
-            <div class="detail-card requirement-card">
-                <div class="card-header">
-                    <WarningOutlined />
-                    <span>使用要求</span>
-                </div>
-                <div class="card-content">
-                    <div class="content-item">
-                        <span class="item-dot"></span>
-                        <span>游戏 UI 缩放设为 <strong>100%</strong></span>
-                    </div>
-                    <div class="content-item">
-                        <span class="item-dot"></span>
-                        <span>屏幕比例 <strong>16:9</strong> <span class="item-hint">（推荐 1280×720 / 1920×1080）</span></span>
-                    </div>
-                </div>
-            </div>
-
-            <div class="intro-divider"></div>
-
-            <!-- 工具性能 -->
-            <div class="detail-card performance-card">
-                <div class="card-header">
-                    <ThunderboltOutlined />
-                    <span>工具性能</span>
-                </div>
-                <div class="card-content">
-                    <div class="content-item">
-                        <span class="item-dot"></span>
-                        <span>操作精度：<strong>每帧 2 次有效操作</strong></span>
-                    </div>
-                </div>
-            </div>
+  <div class="tab-content">
+    <!-- 工具简介 -->
+    <div class="tool-intro">
+      <!-- 工具简介 -->
+      <div class="detail-card intro-card">
+        <div class="card-header">
+          <QuestionCircleOutlined />
+          <span>工具简介</span>
         </div>
-
-        <div class="form-section">
-            <div class="section-header">
-                <h3>基础设置</h3>
-            </div>
-            <a-row :gutter="24">
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">明日方舟 PC 划火柴</span>
-                            <a-tooltip title="是否启用明日方舟 PC 端划火柴工具">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-switch :checked="config.Enabled" :disabled="disabled"
-                            @change="handleChange('Enabled', $event)" />
-                    </div>
-                </a-col>
-            </a-row>
+        <div class="card-content">
+          <p class="intro-text">
+            尽管明日方舟已上线暂停时部署功能，但选中干员与跳帧操作仍未实现。本工具旨在提供极限操作支持，改善您的游戏体验。
+          </p>
         </div>
+      </div>
 
-        <div class="form-section">
-            <div class="section-header">
-                <h3>键位配置</h3>
-            </div>
-            <a-row :gutter="24">
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">划火柴功能暂停</span>
-                            <a-tooltip title="暂停划火柴工具运行的键位">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.PauseKey"
-                            :placeholder="isRecording('PauseKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('PauseKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('PauseKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled" @click="startRecordKey?.('PauseKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
+      <div class="intro-divider"></div>
 
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">选中已部署干员</span>
-                            <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键选中干员">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.SelectDeployedKey"
-                            :placeholder="isRecording('SelectDeployedKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('SelectDeployedKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('SelectDeployedKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled"
-                                    @click="startRecordKey?.('SelectDeployedKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
-
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">释放技能</span>
-                            <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键使释放干员技能">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.UseSkillKey"
-                            :placeholder="isRecording('UseSkillKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('UseSkillKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('UseSkillKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled" @click="startRecordKey?.('UseSkillKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
-
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">撤退干员</span>
-                            <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键撤退干员">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.RetreatKey"
-                            :placeholder="isRecording('RetreatKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('RetreatKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('RetreatKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled" @click="startRecordKey?.('RetreatKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
-
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">下一帧</span>
-                            <a-tooltip title="让游戏向前进 1 帧">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.NextFrameKey"
-                            :placeholder="isRecording('NextFrameKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('NextFrameKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('NextFrameKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled" @click="startRecordKey?.('NextFrameKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
-
-                <a-col :span="12">
-                    <div class="form-item-vertical">
-                        <div class="form-label-wrapper">
-                            <span class="form-label">自定义退出/暂停</span>
-                            <a-tooltip title="自定义的退出/暂停键位，仅战斗中有效">
-                                <QuestionCircleOutlined class="help-icon" />
-                            </a-tooltip>
-                        </div>
-                        <a-input :value="config.AnotherQuitKey"
-                            :placeholder="isRecording('AnotherQuitKey') ? '请按下键位...' : '点击录制按钮修改'" size="large"
-                            :disabled="disabled || !config.Enabled || isRecording('AnotherQuitKey')" readonly
-                            style="cursor: not-allowed;">
-                            <template #suffix>
-                                <a-button v-if="!isRecording('AnotherQuitKey')" type="default" size="small"
-                                    :disabled="disabled || !config.Enabled" @click="startRecordKey?.('AnotherQuitKey')">
-                                    录制
-                                </a-button>
-                                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
-                                    取消
-                                </a-button>
-                            </template>
-                        </a-input>
-                    </div>
-                </a-col>
-            </a-row>
+      <!-- 使用要求 -->
+      <div class="detail-card requirement-card">
+        <div class="card-header">
+          <WarningOutlined />
+          <span>使用要求</span>
         </div>
+        <div class="card-content">
+          <div class="content-item">
+            <span class="item-dot"></span>
+            <span>游戏 UI 缩放设为 <strong>100%</strong></span>
+          </div>
+          <div class="content-item">
+            <span class="item-dot"></span>
+            <span
+              >屏幕比例 <strong>16:9</strong>
+              <span class="item-hint">（推荐 1280×720 / 1920×1080）</span></span
+            >
+          </div>
+        </div>
+      </div>
+
+      <div class="intro-divider"></div>
+
+      <!-- 工具性能 -->
+      <div class="detail-card performance-card">
+        <div class="card-header">
+          <ThunderboltOutlined />
+          <span>工具性能</span>
+        </div>
+        <div class="card-content">
+          <div class="content-item">
+            <span class="item-dot"></span>
+            <span>操作精度：<strong>每帧 2 次有效操作</strong></span>
+          </div>
+        </div>
+      </div>
     </div>
+
+    <div class="form-section">
+      <div class="section-header">
+        <h3>基础设置</h3>
+      </div>
+      <a-row :gutter="24">
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">明日方舟 PC 划火柴</span>
+              <a-tooltip title="是否启用明日方舟 PC 端划火柴工具">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-switch
+              :checked="config.Enabled"
+              :disabled="disabled"
+              @change="handleChange('Enabled', $event)"
+            />
+          </div>
+        </a-col>
+      </a-row>
+    </div>
+
+    <div class="form-section">
+      <div class="section-header">
+        <h3>键位配置</h3>
+      </div>
+      <a-row :gutter="24">
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">划火柴功能暂停</span>
+              <a-tooltip title="暂停划火柴工具运行的键位">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.PauseKey"
+              :placeholder="isRecording('PauseKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('PauseKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('PauseKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('PauseKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">选中已部署干员</span>
+              <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键选中干员">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.SelectDeployedKey"
+              :placeholder="isRecording('SelectDeployedKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('SelectDeployedKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('SelectDeployedKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('SelectDeployedKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">释放技能</span>
+              <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键使释放干员技能">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.UseSkillKey"
+              :placeholder="isRecording('UseSkillKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('UseSkillKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('UseSkillKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('UseSkillKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">撤退干员</span>
+              <a-tooltip title="游戏暂停时，鼠标悬浮于已部署干员上，按此键撤退干员">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.RetreatKey"
+              :placeholder="isRecording('RetreatKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('RetreatKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('RetreatKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('RetreatKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">下一帧</span>
+              <a-tooltip title="让游戏向前进 1 帧">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.NextFrameKey"
+              :placeholder="isRecording('NextFrameKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('NextFrameKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('NextFrameKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('NextFrameKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">自定义退出/暂停</span>
+              <a-tooltip title="自定义的退出/暂停键位，仅战斗中有效">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-input
+              :value="config.AnotherQuitKey"
+              :placeholder="isRecording('AnotherQuitKey') ? '请按下键位...' : '点击录制按钮修改'"
+              size="large"
+              :disabled="disabled || !config.Enabled || isRecording('AnotherQuitKey')"
+              readonly
+              style="cursor: not-allowed"
+            >
+              <template #suffix>
+                <a-button
+                  v-if="!isRecording('AnotherQuitKey')"
+                  type="default"
+                  size="small"
+                  :disabled="disabled || !config.Enabled"
+                  @click="startRecordKey?.('AnotherQuitKey')"
+                >
+                  录制
+                </a-button>
+                <a-button v-else type="primary" danger size="small" @click="stopRecordKey?.()">
+                  取消
+                </a-button>
+              </template>
+            </a-input>
+          </div>
+        </a-col>
+      </a-row>
+    </div>
+  </div>
 </template>
 <style scoped>
 /* 工具简介 */
 .tool-intro {
-    background: var(--ant-color-bg-container);
-    border: 1px solid var(--ant-color-border);
-    border-radius: 8px;
-    padding: 16px 20px;
-    margin-bottom: 20px;
-    display: flex;
-    flex-direction: row;
-    align-items: stretch;
-    gap: 0;
-    transition: all 0.3s ease;
+  background: var(--ant-color-bg-container);
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 0;
+  transition: all 0.3s ease;
 }
 
 .tool-intro:hover {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 .intro-divider {
-    width: 1px;
-    background: linear-gradient(to bottom, transparent, var(--ant-color-border), transparent);
-    align-self: stretch;
-    flex-shrink: 0;
+  width: 1px;
+  background: linear-gradient(to bottom, transparent, var(--ant-color-border), transparent);
+  align-self: stretch;
+  flex-shrink: 0;
 }
 
 .detail-card {
-    flex: 1;
-    padding: 0 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
+  flex: 1;
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
 /* 工具简介卡片 */
 .intro-card {
-    border-left: 3px solid var(--ant-color-info);
-    background: linear-gradient(to right, var(--ant-color-info-bg), transparent);
-    margin-left: -1px;
-    border-radius: 6px 0 0 6px;
+  border-left: 3px solid var(--ant-color-info);
+  background: linear-gradient(to right, var(--ant-color-info-bg), transparent);
+  margin-left: -1px;
+  border-radius: 6px 0 0 6px;
 }
 
 .intro-card .card-header {
-    color: var(--ant-color-info-hover);
+  color: var(--ant-color-info-hover);
 }
 
 .intro-card .intro-text {
-    margin: 0;
-    font-size: 13px;
-    line-height: 1.7;
-    color: var(--ant-color-text-secondary);
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--ant-color-text-secondary);
 }
 
 /* 使用要求卡片 */
 .requirement-card {
-    border-left: 3px solid var(--ant-color-warning);
-    background: linear-gradient(to right, var(--ant-color-warning-bg), transparent);
-    margin-left: -1px;
-    border-radius: 6px 0 0 6px;
+  border-left: 3px solid var(--ant-color-warning);
+  background: linear-gradient(to right, var(--ant-color-warning-bg), transparent);
+  margin-left: -1px;
+  border-radius: 6px 0 0 6px;
 }
 
 .requirement-card .card-header {
-    color: var(--ant-color-warning);
+  color: var(--ant-color-warning);
 }
 
 .requirement-card .item-dot {
-    background: var(--ant-color-warning);
+  background: var(--ant-color-warning);
 }
 
 .requirement-card .content-item strong {
-    color: var(--ant-color-warning);
-    background: rgba(250, 173, 20, 0.15);
+  color: var(--ant-color-warning);
+  background: rgba(250, 173, 20, 0.15);
 }
 
 /* 工具性能卡片 */
 .performance-card {
-    border-left: 3px solid var(--ant-color-primary);
-    background: linear-gradient(to right, var(--ant-color-primary-bg), transparent);
-    margin-left: -1px;
-    border-radius: 6px 0 0 6px;
+  border-left: 3px solid var(--ant-color-primary);
+  background: linear-gradient(to right, var(--ant-color-primary-bg), transparent);
+  margin-left: -1px;
+  border-radius: 6px 0 0 6px;
 }
 
 .performance-card .card-header {
-    color: var(--ant-color-primary-hover);
+  color: var(--ant-color-primary-hover);
 }
 
 .performance-card .item-dot {
-    background: var(--ant-color-primary);
+  background: var(--ant-color-primary);
 }
 
 .performance-card .content-item strong {
-    color: var(--ant-color-primary-hover);
-    background: rgba(24, 144, 255, 0.15);
+  color: var(--ant-color-primary-hover);
+  background: rgba(24, 144, 255, 0.15);
 }
 
 .card-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 8px;
-    font-size: 13px;
-    font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .card-header :deep(.anticon) {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .performance-icon {
-    width: 14px;
-    height: 14px;
+  width: 14px;
+  height: 14px;
 }
 
 .card-content {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .content-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--ant-color-text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ant-color-text);
 }
 
 .item-dot {
-    width: 4px;
-    height: 4px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .content-item strong {
-    font-weight: 600;
-    padding: 1px 6px;
-    border-radius: 3px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
 }
 
 .item-hint {
-    color: var(--ant-color-text-tertiary);
-    font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+  font-size: 12px;
 }
 
 /* 响应式调整 */
 @media (max-width: 1200px) {
-    .tool-intro {
-        flex-direction: column;
-        gap: 12px;
-    }
+  .tool-intro {
+    flex-direction: column;
+    gap: 12px;
+  }
 
-    .intro-divider {
-        width: auto;
-        height: 1px;
-        background: linear-gradient(to right, transparent, var(--ant-color-border), transparent);
-    }
+  .intro-divider {
+    width: auto;
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--ant-color-border), transparent);
+  }
 
-    .detail-card {
-        padding: 12px 16px;
-        border-radius: 6px;
-        margin-left: 0;
-    }
+  .detail-card {
+    padding: 12px 16px;
+    border-radius: 6px;
+    margin-left: 0;
+  }
 
-    .intro-card {
-        border-left: 3px solid var(--ant-color-info);
-        background: linear-gradient(135deg, var(--ant-color-info-bg) 0%, rgba(230, 244, 255, 0.3) 100%);
-    }
+  .intro-card {
+    border-left: 3px solid var(--ant-color-info);
+    background: linear-gradient(135deg, var(--ant-color-info-bg) 0%, rgba(230, 244, 255, 0.3) 100%);
+  }
 
-    .requirement-card {
-        border-left: 3px solid var(--ant-color-warning);
-        background: linear-gradient(135deg, var(--ant-color-warning-bg) 0%, rgba(255, 251, 230, 0.3) 100%);
-    }
+  .requirement-card {
+    border-left: 3px solid var(--ant-color-warning);
+    background: linear-gradient(
+      135deg,
+      var(--ant-color-warning-bg) 0%,
+      rgba(255, 251, 230, 0.3) 100%
+    );
+  }
 
-    .performance-card {
-        border-left: 3px solid var(--ant-color-primary);
-        background: linear-gradient(135deg, var(--ant-color-primary-bg) 0%, rgba(230, 244, 255, 0.3) 100%);
-    }
+  .performance-card {
+    border-left: 3px solid var(--ant-color-primary);
+    background: linear-gradient(
+      135deg,
+      var(--ant-color-primary-bg) 0%,
+      rgba(230, 244, 255, 0.3) 100%
+    );
+  }
 }
 </style>

--- a/frontend/src/views/tools/index.vue
+++ b/frontend/src/views/tools/index.vue
@@ -18,36 +18,36 @@ const activeKey = ref('arknightspc')
 
 // 工具数据
 const toolsConfig = reactive<ToolsConfig>({
-    ArknightsPC: {
-        Enabled: false,
-        PauseKey: 'f10',
-        SelectDeployedKey: 'w',
-        UseSkillKey: 'r',
-        RetreatKey: 't',
-        NextFrameKey: 'f',
-        AnotherQuitKey: 'space',
-        Status: '-',
-    },
+  ArknightsPC: {
+    Enabled: false,
+    PauseKey: 'f10',
+    SelectDeployedKey: 'w',
+    UseSkillKey: 'r',
+    RetreatKey: 't',
+    NextFrameKey: 'f',
+    AnotherQuitKey: 'space',
+    Status: '-',
+  },
 })
 
 // 本地编辑状态
 const editingConfig = reactive<ToolsConfig>({
-    ArknightsPC: {
-        Enabled: false,
-        PauseKey: 'f10',
-        SelectDeployedKey: 'w',
-        UseSkillKey: 'r',
-        RetreatKey: 't',
-        NextFrameKey: 'f',
-        AnotherQuitKey: 'space',
-        Status: '-',
-    },
+  ArknightsPC: {
+    Enabled: false,
+    PauseKey: 'f10',
+    SelectDeployedKey: 'w',
+    UseSkillKey: 'r',
+    RetreatKey: 't',
+    NextFrameKey: 'f',
+    AnotherQuitKey: 'space',
+    Status: '-',
+  },
 })
 
 // 使用通用的状态标签解析
 const arknightsPCStatusTag = useStatusTag(
-    () => toolsConfig.ArknightsPC?.Status,
-    createStatusTag('未启用', 'default')
+  () => toolsConfig.ArknightsPC?.Status,
+  createStatusTag('未启用', 'default')
 )
 
 // 轮询定时器
@@ -59,104 +59,104 @@ let isMounted = true
 
 // 仅更新状态（不影响编辑状态，不触发 loading）
 const updateStatus = async () => {
-    try {
-        // 直接调用 Service 而非 getTools()，避免 loading 状态切换导致组件重渲染闪烁
-        const response = await Service.getToolsApiToolsGetPost()
-        if (!isMounted) return
-        if (response.code !== 200 || !response.data) {
-            throw new Error(response.message || '工具状态响应无效')
-        }
-        const data = response.data
-        statusPollFailed = false
-        if (data.ArknightsPC?.Status) {
-            // 只更新 toolsConfig 的状态，不更新 editingConfig
-            // 这样轮询只影响状态标签显示，不会触发编辑表单重新渲染
-            toolsConfig.ArknightsPC!.Status = data.ArknightsPC.Status
-        }
-    } catch (error) {
-        if (!statusPollFailed) {
-            const errorMsg = error instanceof Error ? error.message : String(error)
-            logger.warn(`更新工具状态失败，将继续重试: ${errorMsg}`)
-            statusPollFailed = true
-        }
+  try {
+    // 直接调用 Service 而非 getTools()，避免 loading 状态切换导致组件重渲染闪烁
+    const response = await Service.getToolsApiToolsGetPost()
+    if (!isMounted) return
+    if (response.code !== 200 || !response.data) {
+      throw new Error(response.message || '工具状态响应无效')
     }
+    const data = response.data
+    statusPollFailed = false
+    if (data.ArknightsPC?.Status) {
+      // 只更新 toolsConfig 的状态，不更新 editingConfig
+      // 这样轮询只影响状态标签显示，不会触发编辑表单重新渲染
+      toolsConfig.ArknightsPC!.Status = data.ArknightsPC.Status
+    }
+  } catch (error) {
+    if (!statusPollFailed) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.warn(`更新工具状态失败，将继续重试: ${errorMsg}`)
+      statusPollFailed = true
+    }
+  }
 }
 
 // 启动状态轮询
 const startStatusPolling = () => {
-    if (pollTimer) {
-        clearInterval(pollTimer)
-    }
-    pollTimer = setInterval(() => {
-        updateStatus()
-    }, 1000) // 每秒更新一次
+  if (pollTimer) {
+    clearInterval(pollTimer)
+  }
+  pollTimer = setInterval(() => {
+    updateStatus()
+  }, 1000) // 每秒更新一次
 }
 
 // 停止状态轮询
 const stopStatusPolling = () => {
-    if (pollTimer) {
-        clearInterval(pollTimer)
-        pollTimer = null
-    }
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
 }
 
 // 加载配置
 const loadTools = async () => {
-    try {
-        const data = await getTools()
-        // 确保 ArknightsPC 配置存在
-        if (!data.ArknightsPC) {
-            data.ArknightsPC = {
-                Enabled: false,
-                PauseKey: 'f10',
-                SelectDeployedKey: 'w',
-                UseSkillKey: 'r',
-                RetreatKey: 't',
-                NextFrameKey: 'f',
-                AnotherQuitKey: 'space',
-                Status: '-',
-            }
-        }
-        // 游戏签到由侧边栏独立页面单独维护，工具页只接管明日方舟 PC 配置。
-        Object.assign(toolsConfig, { ArknightsPC: data.ArknightsPC })
-        Object.assign(editingConfig, {
-            ArknightsPC: JSON.parse(JSON.stringify(data.ArknightsPC)),
-        })
-        logger.info('工具加载完成')
-    } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`加载工具失败: ${errorMsg}`)
+  try {
+    const data = await getTools()
+    // 确保 ArknightsPC 配置存在
+    if (!data.ArknightsPC) {
+      data.ArknightsPC = {
+        Enabled: false,
+        PauseKey: 'f10',
+        SelectDeployedKey: 'w',
+        UseSkillKey: 'r',
+        RetreatKey: 't',
+        NextFrameKey: 'f',
+        AnotherQuitKey: 'space',
+        Status: '-',
+      }
     }
+    // 游戏签到由侧边栏独立页面单独维护，工具页只接管明日方舟 PC 配置。
+    Object.assign(toolsConfig, { ArknightsPC: data.ArknightsPC })
+    Object.assign(editingConfig, {
+      ArknightsPC: JSON.parse(JSON.stringify(data.ArknightsPC)),
+    })
+    logger.info('工具加载完成')
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`加载工具失败: ${errorMsg}`)
+  }
 }
 
 // 保存单个字段的变更（实时保存）
 const handleFieldChange = async (key: string, value: any) => {
-    if (!editingConfig.ArknightsPC) return
+  if (!editingConfig.ArknightsPC) return
 
-    const previousValue = (editingConfig.ArknightsPC as any)[key]
-    try {
-        // 更新编辑状态
-        (editingConfig.ArknightsPC as any)[key] = value
+  const previousValue = (editingConfig.ArknightsPC as any)[key]
+  try {
+    // 更新编辑状态
+    ;(editingConfig.ArknightsPC as any)[key] = value
 
-        // 只提交当前字段，避免旧状态覆盖运行中的工具配置。
-        await updateTools({
-            ArknightsPC: { [key]: value },
-        })
+    // 只提交当前字段，避免旧状态覆盖运行中的工具配置。
+    await updateTools({
+      ArknightsPC: { [key]: value },
+    })
 
-        // 保存成功后只同步修改的字段到 toolsConfig，不触碰 Status
-        if (toolsConfig.ArknightsPC && key !== 'Status') {
-            (toolsConfig.ArknightsPC as any)[key] = value
-        }
-
-        logger.info(`${key} 已保存`)
-    } catch (error) {
-        // 并发保存时只回滚仍保持本次值的字段，避免覆盖用户后续输入。
-        if ((editingConfig.ArknightsPC as any)[key] === value) {
-            (editingConfig.ArknightsPC as any)[key] = previousValue
-        }
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        logger.error(`保存 ${key} 失败: ${errorMsg}`)
+    // 保存成功后只同步修改的字段到 toolsConfig，不触碰 Status
+    if (toolsConfig.ArknightsPC && key !== 'Status') {
+      ;(toolsConfig.ArknightsPC as any)[key] = value
     }
+
+    logger.info(`${key} 已保存`)
+  } catch (error) {
+    // 并发保存时只回滚仍保持本次值的字段，避免覆盖用户后续输入。
+    if ((editingConfig.ArknightsPC as any)[key] === value) {
+      ;(editingConfig.ArknightsPC as any)[key] = previousValue
+    }
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`保存 ${key} 失败: ${errorMsg}`)
+  }
 }
 
 // 键位录制状态
@@ -164,285 +164,291 @@ const recordingKeyField = ref<string | null>(null)
 
 // 开始录制键位
 const startRecordKey = (fieldName: string) => {
-    recordingKeyField.value = fieldName
-    logger.info(`开始录制键位: ${fieldName}`)
+  recordingKeyField.value = fieldName
+  logger.info(`开始录制键位: ${fieldName}`)
 }
 
 // 停止录制键位
 const stopRecordKey = () => {
-    recordingKeyField.value = null
+  recordingKeyField.value = null
 }
 
 // 键盘事件处理 - 捕获单个键
 const handleKeyDown = async (event: KeyboardEvent) => {
-    if (!recordingKeyField.value) return
+  if (!recordingKeyField.value) return
 
-    event.preventDefault()
-    event.stopPropagation()
+  event.preventDefault()
+  event.stopPropagation()
 
-    // 获取按键名称
-    let keyName: string
+  // 获取按键名称
+  let keyName: string
 
-    // 特殊键处理
-    if (event.key === ' ') {
-        keyName = 'space'
-    } else if (event.key.length === 1) {
-        // 单字符键，转为小写
-        keyName = event.key.toLowerCase()
-    } else {
-        // 功能键（如 F1-F12, Escape, Enter 等）
-        keyName = event.key.toLowerCase()
-    }
+  // 特殊键处理
+  if (event.key === ' ') {
+    keyName = 'space'
+  } else if (event.key.length === 1) {
+    // 单字符键，转为小写
+    keyName = event.key.toLowerCase()
+  } else {
+    // 功能键（如 F1-F12, Escape, Enter 等）
+    keyName = event.key.toLowerCase()
+  }
 
-    const fieldName = recordingKeyField.value
+  const fieldName = recordingKeyField.value
 
-    // 停止录制
-    stopRecordKey()
+  // 停止录制
+  stopRecordKey()
 
-    // 立即保存
-    await handleFieldChange(fieldName, keyName)
+  // 立即保存
+  await handleFieldChange(fieldName, keyName)
 }
 
 // 使用 VueUse 的 useEventListener 管理键盘事件
 useEventListener(document, 'keydown', handleKeyDown)
 useEventListener(window, 'focus', () => void updateStatus())
 useEventListener(document, 'visibilitychange', () => {
-    if (document.visibilityState === 'visible') {
-        void updateStatus()
-    }
+  if (document.visibilityState === 'visible') {
+    void updateStatus()
+  }
 })
 
 // 生命周期：加载配置并启动轮询
 onMounted(async () => {
-    await loadTools()
-    startStatusPolling()
+  await loadTools()
+  startStatusPolling()
 })
 
 // 生命周期：停止轮询，标记组件已卸载
 onUnmounted(() => {
-    isMounted = false
-    stopStatusPolling()
+  isMounted = false
+  stopStatusPolling()
 })
 </script>
 
 <template>
-    <div class="settings-container">
-        <div class="settings-header">
-            <h1 class="page-title">工具</h1>
-        </div>
-        <div class="settings-content">
-            <a-tabs v-model:active-key="activeKey" type="card" :loading="loading" class="settings-tabs">
-                <a-tab-pane key="arknightspc">
-                    <template #tab>
-                        <span style="display: flex; align-items: center; gap: 8px;">
-                            <span>明日方舟PC端</span>
-                            <a-tag v-if="arknightsPCStatusTag" :color="arknightsPCStatusTag.color"
-                                style="margin: 0; font-size: 12px;">
-                                {{ arknightsPCStatusTag.text }}
-                            </a-tag>
-                        </span>
-                    </template>
-                    <TabArknightsPC v-if="editingConfig.ArknightsPC" :config="editingConfig.ArknightsPC"
-                        :disabled="loading" :on-field-change="handleFieldChange"
-                        :recording-key-field="recordingKeyField" :start-record-key="startRecordKey"
-                        :stop-record-key="stopRecordKey" />
-                </a-tab-pane>
-            </a-tabs>
-        </div>
-
-
+  <div class="settings-container">
+    <div class="settings-header">
+      <h1 class="page-title">工具</h1>
     </div>
+    <div class="settings-content">
+      <a-tabs v-model:active-key="activeKey" type="card" :loading="loading" class="settings-tabs">
+        <a-tab-pane key="arknightspc">
+          <template #tab>
+            <span style="display: flex; align-items: center; gap: 8px">
+              <span>明日方舟PC端</span>
+              <a-tag
+                v-if="arknightsPCStatusTag"
+                :color="arknightsPCStatusTag.color"
+                style="margin: 0; font-size: 12px"
+              >
+                {{ arknightsPCStatusTag.text }}
+              </a-tag>
+            </span>
+          </template>
+          <TabArknightsPC
+            v-if="editingConfig.ArknightsPC"
+            :config="editingConfig.ArknightsPC"
+            :disabled="loading"
+            :on-field-change="handleFieldChange"
+            :recording-key-field="recordingKeyField"
+            :start-record-key="startRecordKey"
+            :stop-record-key="stopRecordKey"
+          />
+        </a-tab-pane>
+      </a-tabs>
+    </div>
+  </div>
 </template>
 
 <style scoped>
 /* 统一样式，使用 :deep 作用到子组件内部 */
 .settings-container {
-    /* Allow the settings page to expand with the window width */
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    /* Use full viewport min-height so the page can grow and scroll */
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+  /* Allow the settings page to expand with the window width */
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  /* Use full viewport min-height so the page can grow and scroll */
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .settings-header {
-    margin-bottom: 16px;
-    padding: 0 4px;
+  margin-bottom: 16px;
+  padding: 0 4px;
 }
 
 .page-title {
-    margin: 0;
-    font-size: 32px;
-    font-weight: 700;
-    color: var(--ant-color-text);
-    background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .settings-content {
-    background: var(--ant-color-bg-container);
-    /* Rounded on all corners for a consistent card look */
-    border-radius: 12px;
-    width: 100%;
-    flex: 1;
-    /* allow inner scrolling and cooperate with flexbox
+  background: var(--ant-color-bg-container);
+  /* Rounded on all corners for a consistent card look */
+  border-radius: 12px;
+  width: 100%;
+  flex: 1;
+  /* allow inner scrolling and cooperate with flexbox
      min-height:0 prevents flex children from overflowing the container */
-    min-height: 0;
-    overflow: auto;
-    display: flex;
-    flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .settings-tabs {
-    margin: 0;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    padding: 12px;
-    /* ensure children with overflow:auto can scroll inside this flex item */
-    min-height: 0;
+  margin: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  /* ensure children with overflow:auto can scroll inside this flex item */
+  min-height: 0;
 }
 
 .settings-tabs :deep(.ant-tabs-nav) {
-    padding: 0;
-    margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 .settings-tabs :deep(.ant-tabs-content-holder) {
-    flex: 1;
-    overflow: auto;
+  flex: 1;
+  overflow: auto;
 }
 
 .settings-tabs :deep(.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab) {
-    background: transparent;
-    border: 1px solid var(--ant-color-border);
-    border-radius: 8px 8px 0 0;
-    margin-right: 8px;
+  background: transparent;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px 8px 0 0;
+  margin-right: 8px;
 }
 
 .settings-tabs :deep(.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab-active) {
-    background: var(--ant-color-bg-container);
-    border-bottom-color: var(--ant-color-bg-container);
+  background: var(--ant-color-bg-container);
+  border-bottom-color: var(--ant-color-bg-container);
 }
 
 :deep(.tab-content) {
-    padding: 24px;
-    width: 100%;
+  padding: 24px;
+  width: 100%;
 }
 
 :deep(.form-section) {
-    margin-bottom: 32px;
+  margin-bottom: 32px;
 }
 
 :deep(.form-section:last-child) {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 :deep(.section-header) {
-    margin-bottom: 20px;
-    padding-bottom: 8px;
-    border-bottom: 2px solid var(--ant-color-border-secondary);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--ant-color-border-secondary);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 :deep(.section-header h3) {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 700;
-    color: var(--ant-color-text);
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 :deep(.section-header h3::before) {
-    content: '';
-    width: 4px;
-    height: 24px;
-    background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-    border-radius: 2px;
+  content: '';
+  width: 4px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  border-radius: 2px;
 }
 
 :deep(.section-description) {
-    margin: 4px 0 0;
-    font-size: 13px;
-    color: var(--ant-color-text-secondary);
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--ant-color-text-secondary);
 }
 
 :deep(.form-item-vertical) {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
 }
 
 :deep(.form-label-wrapper) {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 :deep(.form-label) {
-    font-weight: 600;
-    color: var(--ant-color-text);
-    font-size: 14px;
+  font-weight: 600;
+  color: var(--ant-color-text);
+  font-size: 14px;
 }
 
 :deep(.help-icon) {
-    color: #8c8c8c;
-    font-size: 14px;
+  color: #8c8c8c;
+  font-size: 14px;
 }
 
 /* Tab 标签中的状态标签样式 - 与脚本管理页统一 */
 .settings-tabs :deep(.ant-tabs-tab) {
-    .ant-tag {
-        font-size: 11px;
-        font-weight: 500;
-        border-radius: 4px;
-        margin: 0;
-        border: 1px solid rgba(0, 0, 0, 0.15);
-    }
+  .ant-tag {
+    font-size: 11px;
+    font-weight: 500;
+    border-radius: 4px;
+    margin: 0;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+  }
 }
 
 /* Tab 内容区域滚动条样式 */
 .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar {
-    width: 8px !important;
-    height: 8px !important;
-    display: block !important;
+  width: 8px !important;
+  height: 8px !important;
+  display: block !important;
 }
 
 .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-track {
-    background: var(--ant-color-bg-container);
-    border-radius: 4px;
+  background: var(--ant-color-bg-container);
+  border-radius: 4px;
 }
 
 .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
-    transition: background 0.2s ease;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  transition: background 0.2s ease;
 }
 
 .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.25);
 }
 
 /* 深色模式下的滚动条样式 */
 :root.dark .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-track {
-    background: var(--ant-color-bg-elevated);
+  background: var(--ant-color-bg-elevated);
 }
 
 :root.dark .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.15);
 }
 
 :root.dark .settings-tabs :deep(.ant-tabs-content-holder)::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.25);
 }
 </style>


### PR DESCRIPTION
## 摘要

- 修复 97 个 vue-tsc 类型错误（OkNte 编辑视图可空配置、Window/Performance 调试接口类型、selectFolder 无效参数等），\yarn typecheck\ 全量通过
- 清理 4768 个 ESLint 问题（prettier 格式漂移与 vue 规则为主），\yarn lint\ 恢复 0 errors / 0 warnings
- \yarn test\ 56/56 通过