### PR TITLE
fix(hsr): 将「无法切换到指定游戏界面」补充为任务失败关键词

### DIFF
--- a/app/task/HSR/tools/log_detect.py
+++ b/app/task/HSR/tools/log_detect.py
@@ -68,6 +68,8 @@ HSR_CHINESE_FAILURE_MARKERS: tuple[str, ...] = (
     "货币战争开拓者名称为空",         # CosmicStrifeTask.py:34
     "旷宇纷争-货币战争任务失败",      # CosmicStrifeTask.py:63
     "旷宇纷争-货币战争刷开局任务失败",  # CosmicStrifeTask.py:50
+    # ---- M7A 切换游戏界面失败（对应日志「发生错误 无法切换到指定游戏界面」）----
+    "无法切换到指定游戏界面",
 )
 HSR_BENIGN_FAILURE_MARKERS: tuple[str, ...] = (
     "未找到匹配文字",

--- a/res/version.json
+++ b/res/version.json
@@ -15,7 +15,8 @@
             ],
             "修复BUG": [
                 "SRC专项 修复任务结束后进程残留、异常清理时配置丢失及 traceback 日志误判人工接管问题 by [@Craun718](https://github.com/Craun718)",
-                "MaaEnd专项 修复脚本正常退出后 AUTO-MAS 仍持续等待、导致后续调度无法执行的问题 by [@HarcoChen](https://github.com/HarcoChen)"
+                "MaaEnd专项 修复脚本正常退出后 AUTO-MAS 仍持续等待、导致后续调度无法执行的问题 by [@HarcoChen](https://github.com/HarcoChen)",
+                "HSR专项 修复 M7A 切换游戏界面失败（无法切换到指定游戏界面）时未触发任务失败重启、导致任务长时间挂起的问题 by [@1w1w11w1](https://github.com/1w1w11w1)"
             ]
         },
         "v5.4.0": {


### PR DESCRIPTION
- M7A 在切换游戏界面失败时输出「发生错误 无法切换到指定游戏界面」，但该短语不在任务失败关键词列表中，`has_failure_output` 因未命中而把任务判为成功，MAS 不会触发任务失败重启流程，导致任务长时间挂起直到命令超时才结束。
- 将「无法切换到指定游戏界面」补充进 `HSR_CHINESE_FAILURE_MARKERS`，出现该致命流程错误日志时立即判定任务失败并触发重启。

## Summary by Sourcery

将游戏界面切换失败日志纳入崩溃任务检测，确保相关任务能够及时失败并重启。

Bug Fixes:
- 识别 M7A「无法切换到指定游戏界面」错误并立即判定任务失败，以触发自动重启而避免任务挂起至命令超时。

Chores:
- 更新版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将游戏界面切换失败日志纳入崩溃任务检测，确保相关任务能够及时失败并重启。

Bug Fixes:
- 识别 M7A「无法切换到指定游戏界面」错误并立即判定任务失败，以触发自动重启而避免任务挂起至命令超时。

Chores:
- 更新版本信息。

</details>