### PR TITLE
fix(hsr): 将「无法切换到指定游戏界面」补充为任务失败关键词（cherry-pick 至 v5.4.0）

### DIFF
--- a/app/task/HSR/tools/log_detect.py
+++ b/app/task/HSR/tools/log_detect.py
@@ -68,6 +68,8 @@ HSR_CHINESE_FAILURE_MARKERS: tuple[str, ...] = (
     "货币战争开拓者名称为空",         # CosmicStrifeTask.py:34
     "旷宇纷争-货币战争任务失败",      # CosmicStrifeTask.py:63
     "旷宇纷争-货币战争刷开局任务失败",  # CosmicStrifeTask.py:50
+    # ---- M7A 切换游戏界面失败（对应日志「发生错误 无法切换到指定游戏界面」）----
+    "无法切换到指定游戏界面",
 )
 HSR_BENIGN_FAILURE_MARKERS: tuple[str, ...] = (
     "未找到匹配文字",


### PR DESCRIPTION
- 从 dev（PR #430）cherry-pick 纯后端改动到 v5.4.0 发布分支：将「无法切换到指定游戏界面」补充进 HSR 任务失败关键词，M7A 切换游戏界面失败时不再误判为成功、不会长时间挂起后才触发任务失败重启。
- 仅含代码改动，按发布分支热修复惯例未改动 `res/version.json`（changelog 记录已登记在 dev 的 v5.5.0-beta.1）。

## Sourcery 摘要

错误修复：
- 将“无法切换到指定游戏界面”加入 HSR 任务失败关键词，避免界面切换失败被误判为成功或延迟触发失败重启。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 将“无法切换到指定游戏界面”加入 HSR 任务失败关键词，避免界面切换失败被误判为成功或延迟触发失败重启。

</details>