### PR TITLE
fix(notify): 恢复 LazyProxy 延迟加载，修复服务模块裸名 Config/System NameError

### DIFF
--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -39,13 +39,9 @@ from .config import (
     HSRConfig,
 )
 
-def __getattr__(name: str) -> object:
-    """延迟导入 System，避免 app.services 初始化期间的循环导入。"""
-    if name == "System":
-        from app.services import System
-        return System
-    raise AttributeError(name)
-
+# 延迟加载 System，避免 app.services 初始化期间触发循环导入；
+# 绑定为模块级 LazyProxy（真实对象引用），函数体裸名 System 才能经
+# LOAD_GLOBAL 正常解析（模块级 __getattr__ 只管属性访问、管不到裸名）。
 from app.models.task import (
     ScriptItem,
     TaskExecuteBase,
@@ -53,7 +49,7 @@ from app.models.task import (
     TaskTriggerSource,
     UserItem,
 )
-from app.utils import get_logger
+from app.utils import LazyProxy, get_logger
 from app.task import (
     MaaManager,
     SrcManager,
@@ -66,6 +62,7 @@ from app.task import (
 )
 from app.utils.constants import POWER_SIGN_MAP
 
+System = LazyProxy("app.services", "System")
 
 logger = get_logger("业务调度")
 

--- a/app/services/matomo.py
+++ b/app/services/matomo.py
@@ -27,16 +27,12 @@ import platform
 import time
 from typing import Dict, Any, Optional
 
-def __getattr__(name: str) -> object:
-    """延迟导入 Config，避免 app.services 初始化期间触发 app.core 循环导入。"""
-    if name == "Config":
-        from app.core import Config
-        return Config
-    raise AttributeError(name)
-
-from app.utils import get_logger
+from app.utils import LazyProxy, get_logger
 
 logger = get_logger("信息上报")
+
+# 延迟加载 Config，避免 app.services 初始化期间触发 app.core 循环导入
+Config = LazyProxy("app.core", "Config")
 
 
 class _MatomoHandler:

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -34,17 +34,13 @@ from email.utils import formataddr
 from pathlib import Path
 from typing import Literal
 
-def __getattr__(name: str) -> object:
-    """延迟导入 Config，避免 app.services 初始化期间触发 app.core 循环导入。"""
-    if name == "Config":
-        from app.core import Config
-        return Config
-    raise AttributeError(name)
-
 from app.models.config import Webhook
-from app.utils import get_logger, ImageUtils
+from app.utils import LazyProxy, get_logger, ImageUtils
 
 logger = get_logger("通知服务")
+
+# 延迟加载 Config，避免 app.services 初始化期间触发 app.core 循环导入
+Config = LazyProxy("app.core", "Config")
 
 SMTP_TIMEOUT_SECONDS = 15
 

--- a/app/services/system.py
+++ b/app/services/system.py
@@ -34,16 +34,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, Optional
 
-def __getattr__(name: str) -> object:
-    """延迟导入 Config，避免 app.services 初始化期间触发 app.core 循环导入。"""
-    if name == "Config":
-        from app.core import Config
-        return Config
-    raise AttributeError(name)
-
-from app.utils import ProcessRunner, get_logger
+from app.utils import LazyProxy, ProcessRunner, get_logger
 
 logger = get_logger("系统服务")
+
+# 延迟加载 Config，避免 app.services 初始化期间触发 app.core 循环导入
+Config = LazyProxy("app.core", "Config")
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/services/update.py
+++ b/app/services/update.py
@@ -33,18 +33,14 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 from pathlib import Path
 
-def __getattr__(name: str) -> object:
-    """延迟导入 Config，避免 app.services 初始化期间触发 app.core 循环导入。"""
-    if name == "Config":
-        from app.core import Config
-        return Config
-    raise AttributeError(name)
-
 from app.utils.constants import MIRROR_ERROR_INFO
-from app.utils import ProcessRunner, get_logger
+from app.utils import LazyProxy, ProcessRunner, get_logger
 from .system import System
 
 logger = get_logger("更新服务")
+
+# 延迟加载 Config，避免 app.services 初始化期间触发 app.core 循环导入
+Config = LazyProxy("app.core", "Config")
 
 
 class _UpdateHandler:

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -77,6 +77,35 @@ def __getattr__(name: str):
     return _resolve_lazy(name)
 
 
+class LazyProxy:
+    """惰性代理：首次属性访问时才导入真实对象，避免初始化期间的循环导入。
+
+    与模块级 __getattr__ 不同，它绑定为一个真实的模块全局名，因此函数内的
+    裸全局名引用（LOAD_GLOBAL）也能正常解析；同时转发属性读写，保证
+    ``Config.xxx = yyy`` 这类赋值落到真实对象上。
+    """
+
+    def __init__(self, module: str, name: str) -> None:
+        object.__setattr__(self, "_module", module)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_obj", None)
+
+    def _resolve(self):
+        obj = self.__dict__["_obj"]
+        if obj is None:
+            from importlib import import_module
+
+            obj = getattr(import_module(self._module), self._name)
+            object.__setattr__(self, "_obj", obj)
+        return obj
+
+    def __getattr__(self, attr: str):
+        return getattr(self._resolve(), attr)
+
+    def __setattr__(self, attr: str, value) -> None:
+        setattr(self._resolve(), attr, value)
+
+
 class _LazyModule(types.ModuleType):
     """拦截 import 系统把惰性子模块挂到本包命名空间的副作用。
 

--- a/res/version.json
+++ b/res/version.json
@@ -21,7 +21,8 @@
                 "SRC专项 修复任务结束后进程残留、异常清理时配置丢失及 traceback 日志误判人工接管问题 by [@Craun718](https://github.com/Craun718)",
                 "MaaEnd专项 修复脚本正常退出后 AUTO-MAS 仍持续等待、导致后续调度无法执行的问题 by [@HarcoChen](https://github.com/HarcoChen)",
                 "HSR专项 修复 M7A 切换游戏界面失败（无法切换到指定游戏界面）时未触发任务失败重启、导致任务长时间挂起的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
-                "修复开机自启动设置的后台任务异常被静默忽略的问题：持有任务引用并在失败时记录警告日志 by [@1w1w11w1](https://github.com/1w1w11w1)"
+                "修复开机自启动设置的后台任务异常被静默忽略的问题：持有任务引用并在失败时记录警告日志 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "修复通知服务延迟加载回归：Webhook 测试、通知推送、更新检查、电源调度、匿名遥测等链路调用 Config/System 时抛「name 'Config' is not defined」，恢复 LazyProxy 延迟加载并应用于相关服务模块"
             ]
         },
         "v5.4.0": {


### PR DESCRIPTION
修复通知服务延迟加载回归：Webhook 测试、通知推送、更新检查、电源调度、匿名遥测等链路调用 Config/System 时抛 name 'Config' is not defined。
恢复 app.utils.LazyProxy，并将 notification/matomo/system/update/task_manager 五个模块的延迟依赖改回模块级 Config = LazyProxy("app.core","Config") / System = LazyProxy("app.services","System")。

根因：54057644 把 a3a755ee 引入的 LazyProxy 延迟加载整体回退为模块级 __getattr__；而方法体内的裸名引用（LOAD_GLOBAL）不会触发 __getattr__，故抛 NameError。

## Sourcery 总结

恢复基于代理的延迟依赖加载，使服务模块能够在初始化和运行时安全地使用 Config 和 System。

错误修复：
- 恢复 Config 和 System 引用的延迟加载，以防止通知、遥测、更新、电源调度和 webhook 流程中出现 NameError 错误。

增强功能：
- 重新引入可复用的 LazyProxy，使其能够在首次访问时解析延迟依赖，同时支持属性读取和写入。

杂项：
- 更新应用程序版本元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore proxy-based deferred dependency loading so service modules can safely use Config and System during initialization and runtime.

Bug Fixes:
- Restore lazy loading for Config and System references to prevent NameError failures across notification, telemetry, update, power scheduling, and webhook flows.

Enhancements:
- Reintroduce a reusable LazyProxy that resolves deferred dependencies on first access while supporting attribute reads and writes.

Chores:
- Update the application version metadata.

</details>