### PR TITLE
fix(push_log): 多账号任务节点详情按用户分组并入报告

### DIFF
--- a/.agents/skills/mas-script-specialized-adapter/SKILL.md
+++ b/.agents/skills/mas-script-specialized-adapter/SKILL.md
@@ -58,7 +58,7 @@ description: >-
 - 配置与 schema：`app/models/config.py`、`app/models/schema.py`
 - 注册与 API：`app/core/config.py`、`app/api/scripts.py`、`app/core/task_manager.py`、`app/utils/constants.py`
 - 任务模块：`app/task/Xxx/` 的 `manager`、`AutoProxy`，按架构需要增加 `ScriptConfig`
-- 日志采集推送：需要把脚本运行日志关键节点推送至任务报告时，用通用组件 `log_box`（用法见 [logbox-api.md](references/logbox-api.md)），专项只喂参数（日志路径/规则/处理器）并注入 sink；报告聚合与追加复用通用工具 `app/tools/push_log.py`（`build_push_log_text` / `append_push_log`），专项不要自行拼接实现。「是否展示节点详情」由专项（或其用户配置）的开关在**是否创建/启用 log_box 的入口**消费（关闭即不创建，省采集开销），不要给 log_box 加通用开关，也不要在聚合层采后过滤（参考 okww 用户级 `Notify.PushLogEnabled`）
+- 日志采集推送：需要把脚本运行日志关键节点推送至任务报告时，用通用组件 `log_box`（用法见 [logbox-api.md](references/logbox-api.md)），专项只喂参数（日志路径/规则/处理器）并注入 sink；报告聚合与追加复用通用工具 `app/tools/push_log.py`（`build_user_result_text` 按用户交错组装「用户结果行+节点」并入 result / `append_push_log`），专项不要自行拼接实现。「是否展示节点详情」由专项（或其用户配置）的开关在**是否创建/启用 log_box 的入口**消费（关闭即不创建，省采集开销），不要给 log_box 加通用开关，也不要在聚合层采后过滤（参考 okww 用户级 `Notify.PushLogEnabled`）
 - 前端入口：`Scripts.vue`、`ScriptTable.vue`、router、`types/script.ts`、相关 composable、脚本/用户编辑页
 - Electron 能力：仅当需要注册表、文件系统或进程发现时增加 `electron/services`、IPC、preload 与类型声明
 - 生成代码：后端 schema 变更后运行生成器，禁止手改 `frontend/src/api/**`

--- a/.agents/skills/mas-script-specialized-adapter/references/logbox-api.md
+++ b/.agents/skills/mas-script-specialized-adapter/references/logbox-api.md
@@ -134,7 +134,7 @@ log_box（会失去可视化 UI），log_box 也不要反向暴露 web 配置（
 - **通用脚本**：`PushLogEnabled`（web UI 配置）控制是否采集并聚合推送日志。
 - **OK-WW专项**：用户级 `Notify.PushLogEnabled`（用户编辑页「是否采集节点详情」，与快速配置同排）
   ——关闭时 **AutoProxy 侧不创建 log_box**（不读日志、不翻译、不匹配），该用户 push_log 为空，
-  报告聚合（`build_push_log_text`）自然不含其节点详情。参考实现：`app/task/Okww/AutoProxy.py`
+  报告聚合（`build_user_result_text`）自然只有结果行、不含其节点详情。参考实现：`app/task/Okww/AutoProxy.py`
   的 `prepare()` 按开关启停 + `final_task()` 判空收尾。
 
 **给未来适配器的模式**：开关 = 专项自己的配置项，在专项**是否创建/启用 log_box** 的
@@ -230,20 +230,23 @@ def resolve(results):
 push_log 落进 `cur_user_item.push_log`（`list[(log_type, text)]`）后，后续聚合与
 追加统一走 `app/tools/push_log.py`，专项**不要**自行拼接实现：
 
-- `build_push_log_text(users, has_uncompleted)`：聚合各用户 push_log 为报告文本，
-  每条条目独占一行；「失败」类型条目仅在任务存在未完成用户时纳入（与 MAS 原生
-  推送策略一致）。专项在 `manager.final_task` 汇总时调用。
+- `build_user_result_text(users, has_uncompleted)`：按用户交错组装「用户结果行 +
+  该用户节点详情」报告文本——每个用户先输出 `用户名: 用户result` 结果行，随后
+  紧跟该用户采集的节点（每条独占一行），多账号任务时各用户节点归属清晰；
+  「失败」类型条目仅在任务存在未完成用户时纳入（与 MAS 原生推送策略一致）。
+  专项在 `manager.final_task` 汇总时**用它替代原 result 拼接**（节点并入 result，
+  `push_log` 字段置空），不要再单独平铺所有用户节点。
 - `append_push_log(message_text, push_log, separator="\n")`：把推送日志追加到通知
   正文，**默认以单个换行分隔**；专项（如 `tools/notify.py`）按默认调用即可，无需
-  传 `separator`，push_log 为空时原样返回正文。
+  传 `separator`，push_log 为空时原样返回正文（节点并入 result 后此处自然为空）。
 
 ```python
-# manager.final_task：聚合后放入通知消息
+# manager.final_task：按用户交错组装（节点并入 result，push_log 置空）
 has_uncompleted = len(error_user) + len(wait_user) > 0
-push_log_text = build_push_log_text(self.script_info.user_list, has_uncompleted)
-message = {"push_log": push_log_text, ...}
+user_result_text = build_user_result_text(self.script_info.user_list, has_uncompleted)
+message = {"result": user_result_text, "push_log": "", ...}
 
-# tools/notify.py：追加（默认 separator="\n"）
+# tools/notify.py：追加（push_log 为空，append_push_log 原样返回正文）
 message_text = append_push_log(message_text, message.get("push_log"))
 ```
 

--- a/app/task/Okww/manager.py
+++ b/app/task/Okww/manager.py
@@ -36,7 +36,7 @@ from app.tools.game_sign_notify import (
 )
 from app.utils import get_logger, ProcessManager
 from app.utils.constants import TASK_MODE_ZH
-from app.tools.push_log import build_push_log_text
+from app.tools.push_log import build_user_result_text
 
 from .AutoProxy import (
     AutoProxyTask,
@@ -359,19 +359,20 @@ class OkwwManager(TaskExecuteBase):
                     f"{datetime.now().strftime('%m-%d')} | "
                     f"{self.script_info.name or '空白'}的{task_mode}任务报告"
                 )
-                task_result = append_task_game_sign_summary(
-                    self.task_info, self.script_info.result
-                )
-                has_game_sign_summary = task_result != self.script_info.result
-                # 聚合各用户采集的推送日志：每条节点独占一行，不附加用户名。
+                # 按用户交错组装「用户结果行 + 该用户节点详情」：
+                # 多账号任务时各用户节点归属清晰，不再全部平铺。
                 # 「失败」类型仅在本次任务存在未完成用户时纳入报告，
                 # 与 SendTaskResultTime 的「仅失败时」推送策略自然配合（对齐通用脚本）。
-                # 关闭「是否采集节点详情」的用户在 AutoProxy 侧未启 log_box，push_log
-                # 为空，此处按既有逻辑自动跳过，无需再按用户过滤
+                # 关闭「是否采集节点详情」的用户在 AutoProxy 侧未启 log_box，
+                # push_log 为空，自然只有结果行。
                 has_uncompleted = len(error_user) + len(wait_user) > 0
-                push_log_text = build_push_log_text(
+                user_result_text = build_user_result_text(
                     self.script_info.user_list, has_uncompleted
                 )
+                task_result = append_task_game_sign_summary(
+                    self.task_info, user_result_text
+                )
+                has_game_sign_summary = task_result != user_result_text
                 result = {
                     "title": f"{task_mode}任务报告",
                     "script_name": self.script_info.name or "空白",
@@ -381,7 +382,7 @@ class OkwwManager(TaskExecuteBase):
                     "uncompleted_count": len(error_user) + len(wait_user),
                     "result": task_result,
                     "game_sign_summary": has_game_sign_summary,
-                    "push_log": push_log_text,
+                    "push_log": "",  # 节点已并入 result，不再单独推送
                 }
 
                 await Notify.push_plyer(

--- a/app/task/general/manager.py
+++ b/app/task/general/manager.py
@@ -38,7 +38,7 @@ from app.tools.game_sign_notify import (
     append_task_game_sign_summary,
     mark_task_game_sign_summary_consumed,
 )
-from app.tools.push_log import build_push_log_text
+from app.tools.push_log import build_user_result_text
 from .tools import push_notification
 from .AutoProxy import AutoProxyTask
 from .ScriptConfig import ScriptConfigTask
@@ -328,17 +328,18 @@ class GeneralManager(TaskExecuteBase):
             ]
 
             title = f"{datetime.now().strftime('%m-%d')} | {self.script_info.name or '空白'}的{TASK_MODE_ZH[self.task_info.mode]}任务报告"
-            task_result = append_task_game_sign_summary(
-                self.task_info, self.script_info.result
-            )
-            has_game_sign_summary = task_result != self.script_info.result
-            # 聚合各用户采集的推送日志：每条进程信息独占一行，不附加用户名。
-            # 「失败」类型的条目仅在本次任务存在未完成用户时纳入报告，
+            # 按用户交错组装「用户结果行 + 该用户进程信息」：
+            # 多账号任务时各用户信息归属清晰，不再全部平铺。
+            # 「失败」类型条目仅在本次任务存在未完成用户时纳入报告，
             # 与 SendTaskResultTime 的「仅失败时」推送策略自然配合
             has_uncompleted = len(error_user) + len(wait_user) > 0
-            push_log_text = build_push_log_text(
+            user_result_text = build_user_result_text(
                 self.script_info.user_list, has_uncompleted
             )
+            task_result = append_task_game_sign_summary(
+                self.task_info, user_result_text
+            )
+            has_game_sign_summary = task_result != user_result_text
             result = {
                 "title": f"{TASK_MODE_ZH[self.task_info.mode]}任务报告",
                 "script_name": self.script_info.name or "空白",
@@ -348,7 +349,7 @@ class GeneralManager(TaskExecuteBase):
                 "uncompleted_count": len(error_user) + len(wait_user),
                 "result": task_result,
                 "game_sign_summary": has_game_sign_summary,
-                "push_log": push_log_text,
+                "push_log": "",  # 进程信息已并入 result，不再单独推送
             }
 
             await Notify.push_plyer(

--- a/app/tools/push_log.py
+++ b/app/tools/push_log.py
@@ -3,8 +3,9 @@
 供各专项（General / OK-WW 等）统一聚合与追加推送日志，避免每个适配器重复
 实现相同逻辑；未来接入 log_box 的适配器直接复用本模块即可。
 
-- ``build_push_log_text``：聚合各用户的 push_log 为报告文本；「失败」类型
-  条目仅在任务存在未完成用户时纳入（与 MAS 原生推送策略一致）。
+- ``build_user_result_text``：按用户交错组装「用户结果行 + 该用户节点详情」
+  报告文本，多账号任务时各用户节点归属清晰；「失败」类型条目仅在任务存在
+  未完成用户时纳入（与 MAS 原生推送策略一致）。
 - ``append_push_log``：把推送日志追加到通知正文（默认以单个换行分隔）。
 """
 
@@ -15,26 +16,33 @@ from typing import Iterable
 from app.utils.LogPatternExtractor import LOG_TYPE_ERROR
 
 
-def build_push_log_text(users: Iterable, has_uncompleted: bool) -> str:
-    """聚合各用户 push_log 为报告文本（每条条目独占一行，不附加用户名）
+def build_user_result_text(users: Iterable, has_uncompleted: bool) -> str:
+    """按用户交错组装「用户结果行 + 该用户节点详情」报告文本
+
+    每个用户先输出 ``用户名: 用户result`` 结果行，随后紧跟该用户采集的
+    节点详情（每条独占一行），用户块之间以空行分隔；没有采集到节点的
+    用户只输出结果行。多账号任务时各用户节点归属清晰，避免全部平铺在
+    一起无法区分。
 
     Args:
-        users: 用户列表（元素需有 ``push_log`` 属性：
-            ``list[tuple[log_type, text]]``）。
+        users: 用户列表（元素需有 ``name``、``result``、``push_log`` 属性：
+            ``push_log`` 为 ``list[tuple[log_type, text]]``）。
         has_uncompleted: 本次任务是否存在未完成用户；为 False 时「失败」
             类型条目不纳入报告。
 
     Returns:
-        聚合后的推送日志文本（无内容时返回空串）
+        交错后的报告文本（无用户时返回空串）
     """
-    return "\n".join(
+    return "\n\n".join(
         "\n".join(
-            text
-            for log_type, text in user.push_log
-            if log_type != LOG_TYPE_ERROR or has_uncompleted
+            [f"{user.name}: {user.result}"]
+            + [
+                text
+                for log_type, text in user.push_log
+                if log_type != LOG_TYPE_ERROR or has_uncompleted
+            ]
         )
         for user in users
-        if user.push_log
     )
 
 

--- a/res/version.json
+++ b/res/version.json
@@ -24,7 +24,8 @@
                 "MaaEnd专项 修复脚本退出后任务持续等待问题 by [@HarcoChen](https://github.com/HarcoChen)",
                 "HSR专项 修复 M7A 切换界面失败未重启任务问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "修复开机自启动后台任务异常未记录问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
-                "修复通知服务延迟加载导致的 Config/System 错误 by [@AthenaHibou](https://github.com/AthenaHibou)"
+                "修复通知服务延迟加载导致的 Config/System 错误 by [@AthenaHibou](https://github.com/AthenaHibou)",
+                "日志采集 修复多账号任务各用户节点详情被合并推送的问题，报告按用户分开展示节点归属"
             ]
         },
         "v5.4.0": {


### PR DESCRIPTION
原 build_push_log_text 平铺所有用户节点无法区分归属，改为按用户交错
组装「用户结果行+节点」并并入 result，ok-ww/general 同步调整。

## Summary by Sourcery

按用户交错组装任务结果与节点详情，提升多账号任务报告的可读性并统一相关任务模块的推送行为。

Bug Fixes:
- 按用户分组展示多账号任务报告中的节点详情，避免不同用户的节点信息混淆。

Enhancements:
- 统一 General 与 OK-WW 任务报告的结果聚合逻辑，将每个用户的结果行及其节点详情交错并入报告正文。
- 节点详情并入 result 后清空独立的 push_log 字段，同时保留未完成任务的失败节点筛选规则。
- 更新日志推送相关适配器指导文档与 API 说明。

Documentation:
- 更新日志采集与报告聚合文档，说明按用户交错生成结果文本的新用法。

Chores:
- 更新项目版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

按用户交错组装任务结果与节点详情，提升多账号任务报告的可读性并统一相关任务模块的推送行为。

Bug Fixes:
- 按用户分组展示多账号任务报告中的节点详情，避免不同用户的节点信息混淆。

Enhancements:
- 统一 General 与 OK-WW 任务报告的结果聚合逻辑，将每个用户的结果行及其节点详情交错并入报告正文。
- 节点详情并入 result 后清空独立的 push_log 字段，同时保留未完成任务的失败节点筛选规则。
- 更新日志推送相关适配器指导文档与 API 说明。

Documentation:
- 更新日志采集与报告聚合文档，说明按用户交错生成结果文本的新用法。

Chores:
- 更新项目版本信息。

</details>