### PR TITLE
fix(hsr): 修复托管任务开关点击导致界面报错

### DIFF
--- a/frontend/src/views/EditView/User/HSRUserEdit/ManagedTaskSection.vue
+++ b/frontend/src/views/EditView/User/HSRUserEdit/ManagedTaskSection.vue
@@ -40,13 +40,14 @@
                 <div class="task-row-summary">{{ taskSummary(task) }}</div>
               </div>
               <div class="task-row-actions">
-                <a-switch
-                  :checked="Boolean(taskSwitch[task.key])"
-                  :disabled="saving"
-                  size="small"
-                  @click.stop
-                  @change="emit('taskToggle', task.key, Boolean($event))"
-                />
+                <span @click.stop>
+                  <a-switch
+                    :checked="Boolean(taskSwitch[task.key])"
+                    :disabled="saving"
+                    size="small"
+                    @change="emit('taskToggle', task.key, Boolean($event))"
+                  />
+                </span>
                 <a-tag :color="engineColor(mappedEngine(task))">
                   {{ engineLabel(mappedEngine(task)) }}
                 </a-tag>

--- a/res/version.json
+++ b/res/version.json
@@ -11,7 +11,8 @@
             ],
             "开发流程": [],
             "修复BUG": [
-                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复 HSR 托管任务列表中点击任务开关导致界面报错的问题"
             ]
         },
         "v5.5.0-beta.1": {


### PR DESCRIPTION
## 摘要
- `@click.stop` 直接挂在 `<a-switch>` 上，而 ant-design-vue 的 Switch emit 的是 `click(checked: boolean, event)`，第一个实参是布尔值而非 Event，`.stop` 修饰符对其调用 `stopPropagation()` 必然抛错。
- 改为 `<span @click.stop>` 包裹，与 `MaaEndUserEdit/TaskConfigSection.vue:27` 既有写法一致，不引入新样式。
- 线上表现：Sentry `AUTO-MAS-DESKTOP-F` / `AUTO-MAS-DESKTOP-C`，30 天内共 150 次，culprit 均为 `HSRUserEdit`。

## 检查
- `corepack yarn typecheck` 退出码 0
- `corepack yarn eslint` 对改动文件无告警
- `corepack yarn test`：18 个测试文件、126 个测试通过
- 未做人工验证：需要在 HSR 托管任务列表里点击开关，确认不再报错且行级选中行为不受影响

## Sourcery 总结

修复 HSR 托管任务列表中切换任务开关时的界面错误。

错误修复：
- 修复点击 HSR 托管任务开关时报错的问题。

功能增强：
- 保持开关点击与任务行选择行为隔离，避免事件冒泡影响行级交互。

维护事项：
- 更新资源版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复 HSR 托管任务列表中切换任务开关时的界面错误。

Bug Fixes:
- 修复 HSR 托管任务开关点击时报错的问题。

Enhancements:
- 保持开关点击与任务行选择行为隔离，避免事件冒泡影响行级交互。

Chores:
- 更新资源版本信息。

</details>