### PR TITLE
fix(notify): 修复系统通知标题或内容过长导致推送失败

### DIFF
--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -44,9 +44,23 @@ Config = LazyProxy("app.core", "Config")
 
 SMTP_TIMEOUT_SECONDS = 15
 
+# Windows 通知最终写入 NOTIFYICONDATA 的定长字段：标题落在 szInfoTitle（64 字符）、
+# 正文落在 szInfo（256 字符）。plyer 直接把字符串塞进 ctypes 定长数组，超长会抛
+# ValueError，且各留一位给结尾空字符，因此推送前先截断。
+PLYER_TITLE_LIMIT = 63
+PLYER_MESSAGE_LIMIT = 255
+
+
+def clip_notify_text(text: str, limit: int) -> str:
+    """按 Windows 通知字段上限截断文本，超出部分以省略号收尾。"""
+
+    if len(text) <= limit:
+        return text
+
+    return f"{text[: limit - 1]}…"
+
 
 class Notification:
-
     async def push_plyer(self, title: str, message: str, ticker: str, t: int) -> None:
         """
         推送系统通知
@@ -71,8 +85,8 @@ class Notification:
         if notification.notify is not None:
             await asyncio.to_thread(
                 notification.notify,
-                title=title,
-                message=message,
+                title=clip_notify_text(title, PLYER_TITLE_LIMIT),
+                message=clip_notify_text(message, PLYER_MESSAGE_LIMIT),
                 app_name="AUTO-MAS",
                 app_icon=(Path.cwd() / "res/icons/AUTO-MAS.ico").as_posix(),
                 timeout=t,
@@ -221,7 +235,6 @@ class Notification:
 
         # 替换模板变量
         try:
-
             # 准备模板变量
             template_vars = {
                 "title": title,

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -44,20 +44,37 @@ Config = LazyProxy("app.core", "Config")
 
 SMTP_TIMEOUT_SECONDS = 15
 
-# Windows 通知最终写入 NOTIFYICONDATA 的定长字段：标题落在 szInfoTitle（64 字符）、
-# 正文落在 szInfo（256 字符）。plyer 直接把字符串塞进 ctypes 定长数组，超长会抛
-# ValueError，且各留一位给结尾空字符，因此推送前先截断。
+# Windows 通知最终写入 NOTIFYICONDATA 的定长字段：标题落在 szInfoTitle（64 个
+# UTF-16 代码单元）、正文落在 szInfo（256 个）。plyer 直接把字符串塞进 ctypes 定长
+# 数组，超长会抛 ValueError，且各留一位给结尾空字符，因此推送前先截断。
 PLYER_TITLE_LIMIT = 63
 PLYER_MESSAGE_LIMIT = 255
 
 
 def clip_notify_text(text: str, limit: int) -> str:
-    """按 Windows 通知字段上限截断文本，超出部分以省略号收尾。"""
+    """
+    按 Windows 通知字段上限截断文本，超出部分以省略号收尾
 
-    if len(text) <= limit:
+    ``ctypes.c_wchar`` 数组按 UTF-16 代码单元计数，而 ``len()`` 数的是码位：
+    emoji 等非 BMP 字符占 1 个码位却要 2 个代码单元，按码位截断仍会溢出，因此
+    这里按编码后的代码单元数裁剪。截断点落在代理对中间时，``errors="ignore"``
+    会丢弃残缺的那一半。
+
+    Args:
+        text: 待截断的文本
+        limit: 目标字段可用的 UTF-16 代码单元数（已扣除结尾空字符）
+
+    Returns:
+        str: 编码后不超过 ``limit`` 个 UTF-16 代码单元的文本
+    """
+
+    encoded = text.encode("utf-16-le")
+    if len(encoded) // 2 <= limit:
         return text
 
-    return f"{text[: limit - 1]}…"
+    clipped = encoded[: (limit - 1) * 2].decode("utf-16-le", errors="ignore")
+
+    return f"{clipped}…"
 
 
 class Notification:

--- a/res/version.json
+++ b/res/version.json
@@ -11,7 +11,8 @@
             ],
             "开发流程": [],
             "修复BUG": [
-                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复系统通知标题或内容过长时推送失败的问题"
             ]
         },
         "v5.5.0-beta.1": {

--- a/tests/services/test_notification_clip.py
+++ b/tests/services/test_notification_clip.py
@@ -1,3 +1,4 @@
+import ctypes
 import unittest
 
 from app.services.notification import (
@@ -5,6 +6,23 @@ from app.services.notification import (
     PLYER_TITLE_LIMIT,
     clip_notify_text,
 )
+
+EMOJI = "\U0001f600"  # 非 BMP：1 个码位 = 2 个 UTF-16 代码单元
+
+
+def utf16_units(text: str) -> int:
+    return len(text.encode("utf-16-le")) // 2
+
+
+def fits_fixed_field(text: str, limit: int) -> bool:
+    """模拟 plyer 把字符串写入 NOTIFYICONDATA 定长字段（含结尾空字符）。"""
+
+    try:
+        field = (ctypes.c_wchar * (limit + 1))()
+        field.value = text
+    except ValueError:
+        return False
+    return True
 
 
 class ClipNotifyTextTest(unittest.TestCase):
@@ -23,8 +41,37 @@ class ClipNotifyTextTest(unittest.TestCase):
 
         result = clip_notify_text(text, PLYER_MESSAGE_LIMIT)
 
-        self.assertEqual(len(result), PLYER_MESSAGE_LIMIT)
+        self.assertEqual(utf16_units(result), PLYER_MESSAGE_LIMIT)
         self.assertTrue(result.endswith("…"))
+
+    def test_clips_non_bmp_by_utf16_units(self):
+        """emoji 占 1 个码位却要 2 个代码单元，按码位截断会溢出。"""
+
+        text = EMOJI * PLYER_TITLE_LIMIT
+
+        result = clip_notify_text(text, PLYER_TITLE_LIMIT)
+
+        self.assertLessEqual(utf16_units(result), PLYER_TITLE_LIMIT)
+
+    def test_clipped_non_bmp_has_no_broken_surrogate(self):
+        """截断点落在代理对中间时不应留下半个代理对。"""
+
+        text = EMOJI * 100
+
+        result = clip_notify_text(text, PLYER_TITLE_LIMIT)
+
+        self.assertEqual(result.encode("utf-16-le").decode("utf-16-le"), result)
+
+    def test_results_fit_the_fixed_width_field(self):
+        for label, text in (
+            ("纯 BMP", "正" * 500),
+            ("纯 emoji", EMOJI * 500),
+            ("混排", EMOJI * 40 + "正" * 500),
+            ("恰好满", "正" * PLYER_MESSAGE_LIMIT),
+        ):
+            with self.subTest(label):
+                clipped = clip_notify_text(text, PLYER_MESSAGE_LIMIT)
+                self.assertTrue(fits_fixed_field(clipped, PLYER_MESSAGE_LIMIT))
 
     def test_limits_leave_room_for_terminator(self):
         """NOTIFYICONDATA 的 szInfoTitle 为 64、szInfo 为 256，需各留一位空字符。"""

--- a/tests/services/test_notification_clip.py
+++ b/tests/services/test_notification_clip.py
@@ -1,0 +1,37 @@
+import unittest
+
+from app.services.notification import (
+    PLYER_MESSAGE_LIMIT,
+    PLYER_TITLE_LIMIT,
+    clip_notify_text,
+)
+
+
+class ClipNotifyTextTest(unittest.TestCase):
+    def test_keeps_text_within_limit(self):
+        text = "任务已完成"
+
+        self.assertEqual(clip_notify_text(text, PLYER_TITLE_LIMIT), text)
+
+    def test_keeps_text_exactly_at_limit(self):
+        text = "标" * PLYER_TITLE_LIMIT
+
+        self.assertEqual(clip_notify_text(text, PLYER_TITLE_LIMIT), text)
+
+    def test_clips_text_over_limit(self):
+        text = "正" * (PLYER_MESSAGE_LIMIT + 100)
+
+        result = clip_notify_text(text, PLYER_MESSAGE_LIMIT)
+
+        self.assertEqual(len(result), PLYER_MESSAGE_LIMIT)
+        self.assertTrue(result.endswith("…"))
+
+    def test_limits_leave_room_for_terminator(self):
+        """NOTIFYICONDATA 的 szInfoTitle 为 64、szInfo 为 256，需各留一位空字符。"""
+
+        self.assertEqual(PLYER_TITLE_LIMIT, 63)
+        self.assertEqual(PLYER_MESSAGE_LIMIT, 255)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- Windows 通知最终写入 `NOTIFYICONDATA` 的定长字段：标题落在 `szInfoTitle`（64 字符）、正文落在 `szInfo`（256 字符）。plyer 把字符串直接塞进 ctypes 定长数组（`plyer/platforms/win/libs/win_api_defs.py:56-62`），超长时抛 `ValueError: string too long`，推送线程随之崩溃。
- 任务结果、异常原因等文本天然可能超过 256 字符，因此在调用 plyer 前按各字段上限截断，并各留一位给结尾空字符。
- 线上表现：Sentry `AUTO-MAS-BACKEND-Z`（`ValueError: string too long (534, maximum length 256)`，culprit `threading in run`，7 天 32 次）与 `AUTO-MAS-BACKEND-24`（`Shell_NotifyIconW failed`）同属这条链路。

## 检查
- 新增 `tests/services/test_notification_clip.py`：4 个用例通过
- `python -m pytest tests --collect-only -q`：收集 168 个，退出码 0
- `ruff format` 无残留改动
- 未做人工验证：需要触发一次正文超过 256 字符的通知，确认系统通知正常弹出且内容以省略号收尾

## Sourcery 摘要

防止过长的 Windows 通知标题和消息导致系统通知传递崩溃。

错误修复：
- 当标题或消息超过平台固定的字段长度时，通过在末尾添加省略号进行截断，防止 Windows 系统通知失败。

测试：
- 增加对通知文本长度限制、边界行为和省略号截断的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止过长的 Windows 通知标题和消息导致通知发送路径崩溃。

错误修复：
- 当标题或消息超出平台固定字段限制时，通过截断并添加末尾省略号，防止 Windows 系统通知失败。
- 在限制通知文本长度时，正确处理非 BMP 字符。

测试：
- 增加对通知长度边界、省略号截断、UTF-16 大小计算、代理项安全性以及与固定宽度通知字段兼容性的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent oversized Windows notification titles and messages from crashing the notification delivery path.

Bug Fixes:
- Prevent Windows system notifications from failing when titles or messages exceed the platform’s fixed field limits by truncating them with a trailing ellipsis.
- Handle non-BMP characters correctly when enforcing notification text limits.

Tests:
- Add coverage for notification length boundaries, ellipsis truncation, UTF-16 sizing, surrogate safety, and compatibility with fixed-width notification fields.

</details>

</details>