### PR TITLE
fix(oknte): 修复脚本配置目录含只读文件时备份与复原失败

### DIFF
--- a/app/task/OkNte/manager.py
+++ b/app/task/OkNte/manager.py
@@ -32,6 +32,7 @@ from app.models.ConfigBase import MultipleConfig
 from app.services import Notify
 from app.utils import get_logger, ProcessManager
 from app.utils.constants import TASK_MODE_ZH
+from app.utils.io import force_rmtree
 from app.tools.game_sign_notify import (
     append_task_game_sign_summary,
     mark_task_game_sign_summary_consumed,
@@ -101,7 +102,9 @@ class OkNteManager(TaskExecuteBase):
                 and self.script_info.user_list[0].name == "暂未加载"
             ):
                 self.script_info.user_list = [
-                    UserItem(user_id=str(uid), name=config.get("Info", "Name"), status="等待")
+                    UserItem(
+                        user_id=str(uid), name=config.get("Info", "Name"), status="等待"
+                    )
                     for uid, config in Config.ScriptConfig[script_uid].UserData.items()
                     if config.get("Info", "Status")
                     and config.get("Info", "RemainedDay") != 0
@@ -162,7 +165,7 @@ class OkNteManager(TaskExecuteBase):
                 self.script_config.get("Script", "ConfigPath")
             )
             self.temp_path = Path.cwd() / f"data/{self.script_info.script_id}/Temp"
-            shutil.rmtree(self.temp_path, ignore_errors=True)
+            force_rmtree(self.temp_path)
             self.temp_path.mkdir(parents=True, exist_ok=True)
             if self.script_config_path.exists():
                 self.had_original_script_config = True
@@ -182,28 +185,40 @@ class OkNteManager(TaskExecuteBase):
             and self.script_config
         ):
             return
-        if self.script_config.get("Script", "ConfigPathMode") == "Folder":
-            if not self.had_original_script_config:
-                logger.info(f"清理任务期写入的 OK-NTE 脚本配置目录: {self.script_config_path}")
-                shutil.rmtree(self.script_config_path, ignore_errors=True)
-            else:
-                logger.info(f"复原 OK-NTE 脚本配置文件: {self.temp_path}")
-                tmp_dst = self.script_config_path.with_name(
-                    self.script_config_path.name + ".tmp"
-                )
-                shutil.rmtree(tmp_dst, ignore_errors=True)
-                shutil.copytree(self.temp_path, tmp_dst, dirs_exist_ok=True)
-                shutil.rmtree(self.script_config_path, ignore_errors=True)
-                tmp_dst.rename(self.script_config_path)
-        elif self.script_config.get("Script", "ConfigPathMode") == "File":
-            if (self.temp_path / "config.temp").exists():
-                logger.info(f"复原 OK-NTE 脚本配置文件: {self.temp_path / 'config.temp'}")
-                shutil.copy(self.temp_path / "config.temp", self.script_config_path)
-            elif not self.had_original_script_config:
-                logger.info(f"清理任务期写入的 OK-NTE 脚本配置文件: {self.script_config_path}")
-                with suppress(FileNotFoundError):
-                    self.script_config_path.unlink()
-        shutil.rmtree(self.temp_path, ignore_errors=True)
+
+        # 复原属于收尾清理, 失败不应掩盖任务本身的异常, 也不应中断后续解锁与回写
+        try:
+            if self.script_config.get("Script", "ConfigPathMode") == "Folder":
+                if not self.had_original_script_config:
+                    logger.info(
+                        f"清理任务期写入的 OK-NTE 脚本配置目录: {self.script_config_path}"
+                    )
+                    force_rmtree(self.script_config_path)
+                else:
+                    logger.info(f"复原 OK-NTE 脚本配置文件: {self.temp_path}")
+                    tmp_dst = self.script_config_path.with_name(
+                        self.script_config_path.name + ".tmp"
+                    )
+                    force_rmtree(tmp_dst)
+                    shutil.copytree(self.temp_path, tmp_dst, dirs_exist_ok=True)
+                    force_rmtree(self.script_config_path)
+                    tmp_dst.rename(self.script_config_path)
+            elif self.script_config.get("Script", "ConfigPathMode") == "File":
+                if (self.temp_path / "config.temp").exists():
+                    logger.info(
+                        f"复原 OK-NTE 脚本配置文件: {self.temp_path / 'config.temp'}"
+                    )
+                    shutil.copy(self.temp_path / "config.temp", self.script_config_path)
+                elif not self.had_original_script_config:
+                    logger.info(
+                        f"清理任务期写入的 OK-NTE 脚本配置文件: {self.script_config_path}"
+                    )
+                    with suppress(FileNotFoundError):
+                        self.script_config_path.unlink()
+        except Exception as e:
+            logger.opt(exception=True).warning(f"复原 OK-NTE 脚本配置失败: {e}")
+        finally:
+            force_rmtree(self.temp_path)
 
     async def main_task(self):
         self.check_result = await self.check()
@@ -232,7 +247,9 @@ class OkNteManager(TaskExecuteBase):
             sub_check = await method.check()
             if sub_check != "Pass":
                 self.check_result = sub_check
-                current_user = self.script_info.user_list[self.script_info.current_index]
+                current_user = self.script_info.user_list[
+                    self.script_info.current_index
+                ]
                 if current_user.status == "等待":
                     current_user.status = "异常"
                 await Publisher.send(
@@ -341,11 +358,11 @@ class OkNteManager(TaskExecuteBase):
 
         try:
             if self.task_info.mode == "AutoProxy" and self.user_config is not None:
-                await script_cfg.UserData.load(
-                    await self.user_config.toDict()
-                )
+                await script_cfg.UserData.load(await self.user_config.toDict())
         except Exception:
-            logger.opt(exception=True).warning("on_crash 写回 UserConfig 失败，放弃本次状态变更")
+            logger.opt(exception=True).warning(
+                "on_crash 写回 UserConfig 失败，放弃本次状态变更"
+            )
         await Publisher.send(
             id=self.task_info.task_id,
             type=protocol.TASK_NOTICE,

--- a/app/utils/io.py
+++ b/app/utils/io.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import json
 import json5
 import os
+import shutil
+import stat
 import threading
 import tomllib
 from contextlib import suppress
@@ -53,10 +55,10 @@ _CODECS: dict[str, tuple[Any, Any]] = {
         lambda data: json5.loads(decode_bytes(data)),
     ),
     ".jsonl": (
-        lambda d, encoding: "\n".join(
-            json.dumps(i, ensure_ascii=False) for i in d
-        ).encode(encoding)
-        + b"\n",
+        lambda d, encoding: (
+            "\n".join(json.dumps(i, ensure_ascii=False) for i in d).encode(encoding)
+            + b"\n"
+        ),
         lambda data: [
             json.loads(d) for d in decode_bytes(data).splitlines() if d.strip()
         ],
@@ -78,6 +80,28 @@ _ALIASES: dict[str, str] = {
 
 # 进程内串行锁, 避免并发竞争写
 _WRITE_LOCK = threading.Lock()
+
+
+def force_rmtree(path: Path) -> None:
+    """
+    删除目录树, 遇到只读文件先清除只读位再重试
+
+    ``shutil.rmtree(..., ignore_errors=True)`` 在 Windows 上删不掉只读文件且
+    静默跳过, 残留文件会让随后的 ``copytree`` 覆盖时抛 ``PermissionError``;
+    脚本配置目录里的 ``.git`` 对象正是只读的。清除只读位后仍失败的条目按原
+    ``ignore_errors`` 语义忽略。
+
+    Args:
+        path: 待删除的目录路径
+    """
+
+    def _retry_without_readonly(func: Any, target: Any, _exc: BaseException) -> None:
+        with suppress(OSError):
+            os.chmod(target, stat.S_IWRITE)
+            func(target)
+
+    with suppress(FileNotFoundError):
+        shutil.rmtree(path, onexc=_retry_without_readonly)
 
 
 def atomic_write(path: Path, data: bytes) -> None:

--- a/res/version.json
+++ b/res/version.json
@@ -11,7 +11,8 @@
             ],
             "开发流程": [],
             "修复BUG": [
-                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复 OK-NTE 脚本配置目录含只读文件时备份与复原失败的问题"
             ]
         },
         "v5.5.0-beta.1": {

--- a/tests/tools/test_io_force_rmtree.py
+++ b/tests/tools/test_io_force_rmtree.py
@@ -1,0 +1,45 @@
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.utils.io import force_rmtree
+
+
+class ForceRmtreeTest(unittest.TestCase):
+    def _make_tree_with_readonly_file(self) -> tuple[Path, Path]:
+        root = Path(tempfile.mkdtemp())
+        nested = root / "objects" / "pack"
+        nested.mkdir(parents=True)
+        readonly = nested / "pack-0001.idx"
+        readonly.write_bytes(b"payload")
+        os.chmod(readonly, stat.S_IREAD)
+        return root, readonly
+
+    def test_removes_tree_containing_readonly_file(self):
+        root, readonly = self._make_tree_with_readonly_file()
+        self.addCleanup(self._cleanup, root, readonly)
+
+        force_rmtree(root)
+
+        self.assertFalse(root.exists())
+
+    def test_missing_path_is_noop(self):
+        root = Path(tempfile.mkdtemp())
+        force_rmtree(root)
+
+        force_rmtree(root)
+
+        self.assertFalse(root.exists())
+
+    @staticmethod
+    def _cleanup(root: Path, readonly: Path) -> None:
+        if readonly.exists():
+            os.chmod(readonly, stat.S_IWRITE)
+        if root.exists():
+            force_rmtree(root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 用户的 ok-nte 配置目录里带 `.git`，而 git 的 pack 对象在 Windows 上是只读的。`shutil.rmtree(..., ignore_errors=True)` 删不掉只读文件且静默跳过，残留文件让随后的 `copytree(..., dirs_exist_ok=True)` 覆盖时抛 `PermissionError`。
- 失败沿 `prepare` → `final_task` → `on_crash` 级联：后两者的收尾清理走同一个 `_restore_script_config_from_temp`，同一个错误连抛三次，最终裹进 `ExceptionGroup` 以「Task exception was never retrieved」落地——用户的脚本配置既没复原，错误也没抛到界面上。
- 新增 `app/utils/io.force_rmtree`（清除只读位后重试，仍失败的条目按原 `ignore_errors` 语义忽略）；`_restore_script_config_from_temp` 自身兜住异常并降级为告警，临时目录清理移入 `finally`。
- 线上表现：Sentry `AUTO-MAS-BACKEND-2H`，7 天 69 次，release `auto-mas@v5.4.0-beta.8`。

## 检查
- 新增 `tests/tools/test_io_force_rmtree.py`：2 个用例通过（含只读文件树的删除）
- `python -m pytest tests --collect-only -q`：收集 166 个，退出码 0
- `ruff format` 无残留改动
- 未做人工验证：需要一个含 `.git` 的 OK-NTE 配置目录跑一次 AutoProxy，确认备份、复原与异常路径都不再报错

## 未一并处理
`app/task/general/manager.py:149` 与 `app/task/general/AutoProxy.py:547` 是同一个 `rmtree(ignore_errors=True)` + `copytree` 组合，可能存在同类问题。本 PR 只修 OK-NTE 这条线上报的路径，通用脚本那条线是否要一并换成 `force_rmtree` 请维护者定夺。

## Sourcery 摘要

使 OK-NTE 配置备份和恢复能够适应只读文件，同时保留任务错误处理和清理逻辑。

错误修复：
- 防止 OK-NTE 脚本配置备份和恢复在配置目录包含只读文件（例如 Git pack 对象）时失败。
- 确保恢复失败会作为警告记录，而不会掩盖任务错误，也不会中断清理和状态更新。

增强功能：
- 添加可复用的、支持只读文件的目录树删除功能，并将其用于 OK-NTE 临时文件和脚本配置的清理。

测试：
- 添加对删除包含只读文件的目录树以及处理缺失路径的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make OK-NTE configuration backup and restoration resilient to read-only files while preserving task error handling and cleanup.

Bug Fixes:
- Prevent OK-NTE script configuration backup and restoration from failing when configuration directories contain read-only files, such as Git pack objects.
- Ensure restoration failures are logged as warnings without masking task errors or interrupting cleanup and state updates.

Enhancements:
- Add reusable read-only-aware directory-tree removal support and use it for OK-NTE temporary and script configuration cleanup.

Tests:
- Add coverage for deleting directory trees containing read-only files and for handling missing paths.

</details>