### PR TITLE
feat(task): 单独运行脚本任务不再受单日代理次数上限约束

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -181,6 +181,11 @@ class TaskItem(ABC):
             self._change_dirty = False
 
     @property
+    def is_queue_task(self) -> bool:
+        """任务是否由计划队列发起；否则为用户单独运行的脚本任务"""
+        return self.queue_id is not None
+
+    @property
     def asdict(self) -> list:
         """将 TaskItem 转换为字典形式"""
         return [

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -111,12 +111,12 @@ class AutoProxyTask(TaskExecuteBase):
         if self.is_virtual_update_user:
             return "Pass"
 
-        if self.script_config.get(
-            "Run", "ProxyTimesLimit"
-        ) != 0 and self.cur_user_config.get(
-            "Data", "ProxyTimes"
-        ) >= self.script_config.get(
-            "Run", "ProxyTimesLimit"
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
+        if (
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
         ):
             self.cur_user_item.status = "跳过"
             return "今日代理次数已达上限, 跳过该用户"

--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -288,12 +288,12 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def check(self) -> str:
 
-        if self.script_config.get(
-            "Run", "ProxyTimesLimit"
-        ) != 0 and self.cur_user_config.get(
-            "Data", "ProxyTimes"
-        ) >= self.script_config.get(
-            "Run", "ProxyTimesLimit"
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
+        if (
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
         ):
             self.cur_user_item.status = "跳过"
             return "今日代理次数已达上限, 跳过该用户"

--- a/app/task/MaaEnd/AutoProxy.py
+++ b/app/task/MaaEnd/AutoProxy.py
@@ -77,12 +77,12 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def check(self) -> str:
 
-        if self.script_config.get(
-            "Run", "ProxyTimesLimit"
-        ) != 0 and self.cur_user_config.get(
-            "Data", "ProxyTimes"
-        ) >= self.script_config.get(
-            "Run", "ProxyTimesLimit"
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
+        if (
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
         ):
             self.cur_user_item.status = "跳过"
             return "今日代理次数已达上限, 跳过该用户"

--- a/app/task/OkNte/AutoProxy.py
+++ b/app/task/OkNte/AutoProxy.py
@@ -235,8 +235,10 @@ class AutoProxyTask(TaskExecuteBase):
             return "请设置 OK-NTE 脚本路径"
 
         await self._reset_daily_proxy_count()
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
         if (
-            self.script_config.get("Run", "ProxyTimesLimit") != 0
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
             and self.cur_user_config.get("Data", "ProxyTimes")
             >= self.script_config.get("Run", "ProxyTimesLimit")
         ):

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -201,8 +201,10 @@ class AutoProxyTask(TaskExecuteBase):
             return "请设置ok-ww脚本路径"
         if not (root / _OKWW_REL_APP_JSON).is_file():
             return "请设置ok-ww脚本路径"
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
         if (
-            self.script_config.get("Run", "ProxyTimesLimit") != 0
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
             and self.cur_user_config.get("Data", "ProxyTimes")
             >= self.script_config.get("Run", "ProxyTimesLimit")
         ):

--- a/app/task/SRC/AutoProxy.py
+++ b/app/task/SRC/AutoProxy.py
@@ -105,11 +105,13 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def check(self) -> str:
 
-        if self.script_config.get(
-            "Run", "ProxyTimesLimit"
-        ) != 0 and self.cur_user_config.get(
-            "Data", "ProxyTimes"
-        ) >= self.script_config.get("Run", "ProxyTimesLimit"):
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
+        if (
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
+        ):
             self.cur_user_item.status = "跳过"
             return "今日代理次数已达上限, 跳过该用户"
 

--- a/app/task/general/AutoProxy.py
+++ b/app/task/general/AutoProxy.py
@@ -124,12 +124,12 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def check(self) -> str:
 
-        if self.script_config.get(
-            "Run", "ProxyTimesLimit"
-        ) != 0 and self.cur_user_config.get(
-            "Data", "ProxyTimes"
-        ) >= self.script_config.get(
-            "Run", "ProxyTimesLimit"
+        # 单独运行脚本是用户主动指定的一次性运行，不受单日代理次数上限约束
+        if (
+            self.task_info.is_queue_task
+            and self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
         ):
             self.cur_user_item.status = "跳过"
             return "今日代理次数已达上限, 跳过该用户"

--- a/res/version.json
+++ b/res/version.json
@@ -11,7 +11,8 @@
                 "回滚启动时的遮罩 by [@HarcoChen](https://github.com/HarcoChen)",
                 "匿名遥测 接入 Electron 主进程与渲染进程错误上报，增加应用启动、后端启动和任务执行的性能指标，抑制无异常的日志事件并遮蔽上报内容中的本机用户名，并关联 Sentry 发布提交与生产部署信息 by [@ClozyA](https://github.com/ClozyA)",
                 "清理无用前端资源、依赖及后端冗余代码 by [@1w1w11w1](https://github.com/1w1w11w1)",
-                "MaaFW项目 interface 解析接上闲置的两级缓存，并对 .json 文件先按严格 JSON 解析、失败再回退 JSON5（json5 是纯 Python 实现，比标准库慢三个数量级）：用户页与脚本页进入耗时由约 5.5 秒降至约 0.12 秒 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MaaFW项目 interface 解析接上闲置的两级缓存，并对 .json 文件先按严格 JSON 解析、失败再回退 JSON5（json5 是纯 Python 实现，比标准库慢三个数量级）：用户页与脚本页进入耗时由约 5.5 秒降至约 0.12 秒 by [@qiyinxi](https://github.com/qiyinxi)",
+                "任务调度 单独运行脚本任务不再受单日代理次数上限约束，该限制仅对计划队列生效 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "开发流程": [
                 "开发环境改用独立的后端端口与 userData 目录，可与已安装的正式版同时运行 by [@qiyinxi](https://github.com/qiyinxi)"


### PR DESCRIPTION
## 摘要

1. 单独运行脚本与执行计划队列在调度器里走同一条 `TaskManager.add_task`，区别只在 `queue_id` 是否为空；此前七个专项适配的 `AutoProxy.check()` 都无条件判定「单日代理次数上限」，导致用户主动点「运行」重跑某个脚本时同样被拦下并跳过用户。
2. `TaskItem` 新增 `is_queue_task` 属性（`queue_id is not None`），把「本次任务是否由计划队列发起」这一判据收敛到数据层一处；MAA / SRC / MaaEnd / M9A / 通用 / OK-WW / OK-NTE 七处 `check()` 的次数上限判定统一加上该前置条件，单独运行时直接放行，队列任务行为不变。
3. 只解除闸门，不改计数：单独运行照旧写 `Data/ProxyTimes` 与 `Info/RemainedDay`，历史记录与「代理天数」口径保持原样。HSR 与 MaaFW 本就没有该上限判定，未涉及。

## 验证

- `python -m pytest tests -q`：522 passed / 2 failed / 3 skipped。两项失败是 dev 既存基线（`tests/test_headless_import.py` 的 pyautogui 模块级导入、`tests/task/test_src_config_transactions.py` 依赖 `%TEMP%` 残留），已分别提为 #468 与 #467，与本 PR 无关。
- `python -m pytest tests --collect-only -q` 退出码 0。
- 本地临时脚本对七个专项各跑三种组合（队列任务超限 / 单独运行超限 / 队列任务未超限）：队列超限一律返回「今日代理次数已达上限, 跳过该用户」并置为「跳过」，单独运行超限全部放行到各自后续检查，队列未超限不受影响。按 `tests/AGENTS.md`「功能边界的测试不提交」，该脚本未入库。
- `ruff format`（0.15.14，与 weekly-format 同版本）对改动前后各跑一遍比对，本 PR 新增的代码块与格式化输出逐字一致；这些文件在 dev 上已有既存格式化漂移，本 PR 未顺带格式化。
- 未做实机手测：需要在装有对应专项脚本的环境里把某用户跑到当日上限后，再从调度台单独运行该脚本确认不再跳过。

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

允许用户发起的脚本运行在达到每日代理限制后继续执行，同时保留对计划任务的现有限制。

新功能：
- 允许手动运行的脚本任务绕过每日代理数量限制，同时保留对计划队列任务的限制。

改进：
- 添加共享的任务级指示器，用于区分计划队列任务和用户发起的脚本运行。
- 在受影响的脚本集成中应用一致的代理限制处理方式，同时不改变代理数量跟踪或历史记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow user-initiated script runs to proceed after the daily proxy limit while retaining the existing restriction for scheduled tasks.

New Features:
- Allow manually run script tasks to bypass the daily proxy-count limit while preserving the limit for scheduled queue tasks.

Enhancements:
- Add a shared task-level indicator for distinguishing scheduled queue tasks from user-initiated script runs.
- Apply consistent proxy-limit handling across the affected script integrations without changing proxy-count tracking or historical accounting.

</details>