### PR TITLE
fix(schedule): 启动时队列的「每日首次」取当天日期的时机推后

### DIFF
--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -26,6 +26,7 @@ import os
 import time
 from pathlib import Path
 from datetime import datetime
+
 from typing import Dict, Literal
 
 from .config import (
@@ -787,7 +788,6 @@ class _TaskManager:
             return
 
         self._startup_queue_running = True
-        curday = datetime.now().strftime("%Y-%m-%d")
 
         try:
             await asyncio.sleep(10)
@@ -795,6 +795,10 @@ class _TaskManager:
             if not MainConnection.is_connected:
                 logger.info("主 WebSocket 已断开，启动时任务等待下次连接后运行")
                 return
+
+            # 必须在等待之后取值：若在等待前取，冷启动恰好落在跨日前 10 秒时，
+            # 比较和写入的都是前一天，会漏跑新的一天或在同一天跑两次。
+            curday = datetime.now().strftime("%Y-%m-%d")
 
             self._startup_queue_started = True
             logger.info("开始运行启动时任务")

--- a/res/version.json
+++ b/res/version.json
@@ -25,7 +25,8 @@
                 "修复系统通知标题或内容过长时推送失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MAA专项 修复任务生成时无条件覆盖用户原生高级配置的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "通知服务 自定义 Webhook 推送本地/内网目标绕过代理 by [@ArmedHelicopter](https://github.com/ArmedHelicopter)",
-                "修复 M9A 任务跨过本地午夜后日志监控仍读取前一天文件、导致任务被误判超时的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 M9A 任务跨过本地午夜后日志监控仍读取前一天文件、导致任务被误判超时的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复启动时队列的「每日首次」在跨日前十秒内冷启动时，可能漏跑当天或在同一天重复运行的问题"
             ]
         },
         "v5.5.0-beta.1": {


### PR DESCRIPTION
## 问题

`start_startup_queue()` 里 `curday` 在 `await asyncio.sleep(10)` **之前**取值，而判定与写入都发生在等待之后：

```python
curday = datetime.now().strftime("%Y-%m-%d")   # ← 取值

try:
    await asyncio.sleep(10)                     # ← 等待 10 秒
    if not MainConnection.is_connected:
        return
    ...
    elif StartUpMode == "DailyFirst":
        if queue.get("Data", "LastStartupTime") == curday:   # ← 判定
            continue
        ...
        await queue.set("Data", "LastStartupTime", curday)   # ← 写入
```

冷启动恰好落在跨日前 10 秒内时，比较和写入的都是前一天，两个方向都会出错：

- **漏跑**：若队列前一天已跑过，判等成立被跳过，而等待结束时按语义已经该跑了。此时 `_startup_queue_started` 已置 True，本次进程内不再有机会，新的一天的启动运行整个丢失，直到用户下次重启应用。
- **重复跑**：若此时该跑，跑完写入的是前一天的日期；当天再次启动应用时判等不成立，同一天会跑第二次。

`start_startup_queue` 挂在 `MainConnection.on_connect`，断线早退时下次连接会用新鲜的 `curday` 重算，因此陈旧窗口确实只有这 10 秒。

## 改动

`curday` 的取值挪到等待与连接检查之后，三行，无行为面扩大。

## 日期口径保持本地不变

「每日首次启动」按用户自己的一天计算是既定设计，本 PR 不改这一点，只修取值时机。

## 验证

`pytest tests` 523 passed / 3 skipped / 0 failed。
