### PR TITLE
fix(task): 计时改用单调时钟，系统时钟跳变不再误判超时与写偏归档

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 import asyncio
+import time
 import weakref
 from datetime import datetime
 from abc import ABC, abstractmethod
@@ -228,6 +229,40 @@ class TaskExecuteBase(ABC):
     task: asyncio.Task | None = None
     _task_group: asyncio.TaskGroup | None = None
     accomplish: asyncio.Event = field(default_factory=asyncio.Event)
+
+    # 日志停滞判定的内部状态，按阶段分桶：{key: (上次推进的 latest_time, 单调读数)}
+    # 不加类型注解，避免被 @dataclass 收作字段。
+    _log_progress = None
+
+    def is_log_stalled(
+        self, latest_time: datetime, minutes: float, key: str = "default"
+    ) -> bool:
+        """日志是否已停滞超过给定分钟数。
+
+        不能直接用 ``datetime.now() - latest_time``：两端都是墙钟，系统时钟
+        跳变（夏令时切换、NTP 校时）会让差值凭空增加一小时，把正常运行的
+        任务误判为超时。这里只用 ``latest_time`` 判断“是否有推进”，实际计时
+        交给单调时钟。
+
+        Args:
+            latest_time (datetime): 最近一条日志的时间戳。
+            minutes (float): 允许的最长无新日志时间，单位分钟。
+            key (str): 阶段标识。同一任务的不同阶段（如资源下载与正式运行）
+                各自独立计时，避免阶段切换时互相干扰。
+
+        Returns:
+            bool: 超过阈值返回 True。
+        """
+
+        if self._log_progress is None:
+            self._log_progress = {}
+
+        now = time.monotonic()
+        previous = self._log_progress.get(key)
+        if previous is None or previous[0] != latest_time:
+            self._log_progress[key] = (latest_time, now)
+            return False
+        return now - previous[1] > minutes * 60
 
     @abstractmethod
     async def main_task(self): ...

--- a/app/task/HSR/manager.py
+++ b/app/task/HSR/manager.py
@@ -749,9 +749,7 @@ class HSRManager(TaskExecuteBase):
                     if log_item.status in ("未开始监看日志", "HSR 正常运行中"):
                         log_item.status = "未捕获到日志"
 
-                dt = start_time.replace(
-                    tzinfo=datetime.now().astimezone().tzinfo
-                ).astimezone(UTC4)
+                dt = start_time.astimezone(UTC4)
                 log_path = Config.build_history_log_path(
                     script_name=self.script_info.name,
                     user_name=user_item.name,

--- a/app/task/HSR/tools/account_switch.py
+++ b/app/task/HSR/tools/account_switch.py
@@ -637,7 +637,7 @@ class HSRAccountSwitcher:
             try:
                 await manager.search_process(
                     ProcessInfo(name=process_name),
-                    datetime.now() + timedelta(seconds=5),
+                    5.0,
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"定位 HSR 游戏进程窗口失败：{e}")

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -23,6 +23,7 @@
 import json
 import uuid
 import asyncio
+import time
 import re
 from pathlib import Path
 from datetime import datetime
@@ -142,6 +143,7 @@ class AutoProxyTask(TaskExecuteBase):
         self.wait_event = asyncio.Event()
         self.user_start_time = datetime.now()
         self.log_start_time = datetime.now()
+        self.log_start_at = time.monotonic()
 
 
     async def main_task(self):
@@ -182,6 +184,7 @@ class AutoProxyTask(TaskExecuteBase):
             self._m9a_failed_task_names.clear()
             self._m9a_failure_signal_seen = False
             self.log_start_time = datetime.now()
+            self.log_start_at = time.monotonic()
             self.cur_user_item.log_record[self.log_start_time] = (
                 self.cur_user_log
             ) = LogRecord()
@@ -696,7 +699,7 @@ class AutoProxyTask(TaskExecuteBase):
                         short_err = short_err[:77] + '...'
                     self.script_info._m9a_err_log.append(short_err)
 
-        elapsed = (datetime.now() - self.log_start_time).total_seconds()
+        elapsed = time.monotonic() - self.log_start_at
         if elapsed > 600:
             self.script_info._m9a_timeout = True
             err_log = getattr(self.script_info, '_m9a_err_log', [])

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -25,7 +25,7 @@ import uuid
 import asyncio
 import re
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from app.core import Config
 from app.core.ws import Publisher, protocol
@@ -543,9 +543,7 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def _wait_for_failure_quiet_period(self) -> None:
         while not self.wait_event.is_set():
-            idle_seconds = (
-                datetime.now() - self.m9a_log_monitor.latest_time
-            ).total_seconds()
+            idle_seconds = self.m9a_log_monitor.seconds_since_progress()
             if idle_seconds >= M9A_FAILURE_QUIET_SECONDS:
                 failed_tasks = "、".join(sorted(self._m9a_failed_task_names)) or "未知任务"
                 self.cur_user_log.status = f"M9A 任务失败: {failed_tasks}"
@@ -625,7 +623,8 @@ class AutoProxyTask(TaskExecuteBase):
                 self.cur_user_log.status = "M9A 进程已异常结束"
             else:
                 self.cur_user_log.status = "M9A 进程已结束"
-        elif datetime.now() - latest_time > timedelta(
+        elif self.is_log_stalled(
+            latest_time,
             minutes=self.script_config.get("Run", "RunTimeLimit")
         ):
             self.cur_user_log.status = "M9A 进程超时"
@@ -783,7 +782,7 @@ class AutoProxyTask(TaskExecuteBase):
             if log_item.status == "M9A 正常运行中":
                 log_item.status = "任务被用户手动中止"
 
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -28,7 +28,7 @@ import asyncio
 import shutil
 from copy import deepcopy
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from app.core import Config
 from app.core.ws import Publisher, protocol
@@ -1009,7 +1009,8 @@ class AutoProxyTask(TaskExecuteBase):
             or not await self.maa_process_manager.is_running()
         ):
             self.cur_user_log.status = "MAA 在完成任务前退出"
-        elif datetime.now() - latest_time > timedelta(
+        elif self.is_log_stalled(
+            latest_time,
             minutes=(
                 # 本次开始唤醒会触发资源热更新时放宽超时，避免把正常更新误判为卡死
                 max(
@@ -1054,7 +1055,7 @@ class AutoProxyTask(TaskExecuteBase):
             if log_item.status == "MAA 正常运行中":
                 log_item.status = "任务被用户手动中止"
 
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/MaaEnd/AutoProxy.py
+++ b/app/task/MaaEnd/AutoProxy.py
@@ -24,7 +24,7 @@ import uuid
 import shutil
 import asyncio
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from app.core import Config
 from app.core.ws import Publisher, protocol
@@ -744,8 +744,10 @@ class AutoProxyTask(TaskExecuteBase):
             if if_stream_end:
                 logger.info("MaaEnd 更新进程已退出，日志锁已释放")
                 self.wait_event.set()
-            elif datetime.now() - latest_time > timedelta(
-                minutes=self.script_config.get("Run", "RunTimeLimit")
+            elif self.is_log_stalled(
+                latest_time,
+                minutes=self.script_config.get("Run", "RunTimeLimit"),
+                key="update_download",
             ):
                 logger.warning("MaaEnd 更新进程超时，日志锁已释放")
                 self.cur_user_log.status = "MaaEnd 更新超时"
@@ -816,7 +818,8 @@ class AutoProxyTask(TaskExecuteBase):
                 except:
                     self.cur_user_log.status = "MaaEnd 任务执行情况解析失败"
 
-        elif datetime.now() - latest_time > timedelta(
+        elif self.is_log_stalled(
+            latest_time,
             minutes=self.script_config.get("Run", "RunTimeLimit")
         ):
             self.cur_user_log.status = "MaaEnd 进程超时"
@@ -850,7 +853,7 @@ class AutoProxyTask(TaskExecuteBase):
 
         user_logs_list = []
         for t, log_item in self.cur_user_item.log_record.items():
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/MaaFW/manager.py
+++ b/app/task/MaaFW/manager.py
@@ -407,7 +407,9 @@ class MaaFWManager(TaskExecuteBase):
         self.terminal_event = asyncio.Event()
         self.terminal_kind: str | None = None
         self.last_log_text = ""
-        self.last_log_at: datetime | None = None
+        # 最近一条外壳日志的单调时钟读数。超时判定不能用墙钟差值：
+        # 时钟前跳会把健康任务立刻判成超时，回拨则让真超时被推迟。
+        self.last_log_at: float | None = None
 
         # LogRecord 的变化不触发任何前端通知（UserItem.__setattr__ 只监听
         # user_id / name / status）。这是事实而非缺陷：它在 _write_history_records
@@ -1392,7 +1394,7 @@ class MaaFWManager(TaskExecuteBase):
         self.terminal_event.clear()
         self.terminal_kind = None
         self.last_log_text = ""
-        self.last_log_at = datetime.now()
+        self.last_log_at = time.monotonic()
         self.log_start_time = datetime.now()
 
         # 自退型外壳（MXU）的运行日志走进程 stdout，故必须接管这条流。
@@ -1476,7 +1478,7 @@ class MaaFWManager(TaskExecuteBase):
 
             if runtime_limit <= 0 or (
                 self.last_log_at is not None
-                and (datetime.now() - self.last_log_at).total_seconds() >= runtime_limit
+                and time.monotonic() - self.last_log_at >= runtime_limit
             ):
                 self._mark_terminal("timeout", "MFW 进程超时")
                 break
@@ -1653,7 +1655,7 @@ class MaaFWManager(TaskExecuteBase):
             # 只改这一处：展示（script_info.log）与终态判定（下方受保护分支）
             # 仍吃完整 log_text，两路互不污染。
             if self._has_substantive_progress(self.last_log_text, log_text):
-                self.last_log_at = datetime.now()
+                self.last_log_at = time.monotonic()
             self.last_log_text = log_text
 
         # 控制器初始化失败压过完成串：外壳排空队列时照样输出完成串，但选中的任务
@@ -2581,7 +2583,7 @@ class MaaFWManager(TaskExecuteBase):
         if owned is None:
             return True
 
-        started = datetime.now()
+        started = time.monotonic()
         pid = owned.pid
         if spec.mode == "LauncherExe":
             client = await asyncio.to_thread(
@@ -2597,7 +2599,7 @@ class MaaFWManager(TaskExecuteBase):
 
         # 与日志等待同理，按次数计而不是墙钟 deadline：测试里 asyncio.sleep 被打成
         # 空转，墙钟写法会变成真的忙等满 wait_time 秒。
-        elapsed = (datetime.now() - started).total_seconds()
+        elapsed = time.monotonic() - started
         remaining = max(0.0, spec.wait_time - elapsed)
         attempts = max(1, int(remaining / _GAME_READY_PROBE_INTERVAL_SECONDS))
         for attempt in range(attempts):

--- a/app/task/MaaFW/manager.py
+++ b/app/task/MaaFW/manager.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import json
 import shutil
 import uuid
@@ -2335,9 +2336,9 @@ class MaaFWManager(TaskExecuteBase):
         if not adb_path or not serial:
             return
 
-        deadline = datetime.now() + timedelta(seconds=_ADB_READY_TIMEOUT_SECONDS)
+        deadline = time.monotonic() + _ADB_READY_TIMEOUT_SECONDS
         attempt = 0
-        while datetime.now() < deadline:
+        while time.monotonic() < deadline:
             attempt += 1
             try:
                 result = await ProcessRunner.run_process(
@@ -2891,7 +2892,6 @@ class MaaFWManager(TaskExecuteBase):
             return
         self.history_written = True
 
-        local_tz = datetime.now().astimezone().tzinfo
         for user in self.script_info.user_list:
             for start_time, log_item in sorted(
                 user.log_record.items(), key=lambda item: item[0]
@@ -2904,7 +2904,7 @@ class MaaFWManager(TaskExecuteBase):
                     if not content:
                         content = ["未捕获到任何日志内容"]
                         status = "未捕获到日志"
-                    log_time = start_time.replace(tzinfo=local_tz).astimezone(UTC4)
+                    log_time = start_time.astimezone(UTC4)
                     log_path = Config.build_history_log_path(
                         script_name=self.script_info.name,
                         user_name=user.name,

--- a/app/task/OkNte/AutoProxy.py
+++ b/app/task/OkNte/AutoProxy.py
@@ -24,7 +24,7 @@ import shlex
 import shutil
 import uuid
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 from app.core import Config
@@ -722,7 +722,8 @@ class AutoProxyTask(TaskExecuteBase):
             elif not await self.oknte_process_manager.is_running():
                 log_status = "OK-NTE 在完成任务前退出"
                 user_item_status = "异常"
-            elif datetime.now() - latest_time > timedelta(
+            elif self.is_log_stalled(
+                latest_time,
                 minutes=self.script_config.get("Run", "RunTimeLimit")
             ):
                 log_status = "OK-NTE 运行超时"
@@ -754,7 +755,7 @@ class AutoProxyTask(TaskExecuteBase):
         # 写入历史记录（对齐 General/SRC/MaaEnd 行为）
         user_logs_list = []
         for t, log_item in self.cur_user_item.log_record.items():
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -17,12 +17,13 @@
 #   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
+import time
 import json
 import shlex
 import shutil
 import uuid
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 from app.core import Config
@@ -428,7 +429,7 @@ class AutoProxyTask(TaskExecuteBase):
                 try:
                     await self.game_manager.search_process(
                         self._game_process_info(),
-                        datetime.now() + timedelta(seconds=3),
+                        3.0,
                     )
                 except RuntimeError:
                     logger.info("检测到其他鸣潮客户端进程，继续启动已配置的游戏")
@@ -610,7 +611,8 @@ class AutoProxyTask(TaskExecuteBase):
             elif not await self.okww_process_manager.is_running():
                 log_status = "OK-WW 在完成任务前退出"
                 user_item_status = "异常"
-            elif datetime.now() - latest_time > timedelta(
+            elif self.is_log_stalled(
+                latest_time,
                 minutes=self.script_config.get("Run", "RunTimeLimit")
             ):
                 log_status = "OK-WW 运行超时"
@@ -646,7 +648,7 @@ class AutoProxyTask(TaskExecuteBase):
         # 写入历史记录（对齐 General/SRC/MaaEnd 行为）
         statistic_paths: list[Path] = []
         for t, log_item in self.cur_user_item.log_record.items():
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,
@@ -753,8 +755,8 @@ class AutoProxyTask(TaskExecuteBase):
 
     async def _wait_okww_exit(self, *, timeout: int = 30) -> None:
         """等待 OK-WW 自然退出（-e 触发），超时后兜底强杀。"""
-        deadline = datetime.now() + timedelta(seconds=timeout)
-        while datetime.now() < deadline:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             if not await self.okww_process_manager.is_running():
                 logger.info("OK-WW 已自行退出")
                 return
@@ -790,7 +792,7 @@ class AutoProxyTask(TaskExecuteBase):
                 try:
                     await self.game_manager.search_process(
                         self._game_process_info(),
-                        datetime.now() + timedelta(seconds=1),
+                        1.0,
                     )
                 except RuntimeError:
                     logger.debug("未找到待关闭的鸣潮客户端进程")

--- a/app/task/SRC/AutoProxy.py
+++ b/app/task/SRC/AutoProxy.py
@@ -22,10 +22,11 @@
 
 import uuid
 import asyncio
+import time
 import re
 from pathlib import Path
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from app.core import Config
 from app.core.ws import Publisher, protocol
@@ -255,7 +256,8 @@ class AutoProxyTask(TaskExecuteBase):
 
             # 静默模式隐藏 SRC 窗口
             if Config.get("Function", "IfSilence"):
-                while datetime.now() - t < timedelta(minutes=1):
+                deadline = time.monotonic() + 60
+                while time.monotonic() < deadline:
                     if await self.src_process_manager.is_visible():
                         await self.src_process_manager.hide_window()
                         break
@@ -264,7 +266,8 @@ class AutoProxyTask(TaskExecuteBase):
             # 等待日志文件生成
             self.script_info.log = "正在启动模拟器...\n模拟器启动成功\n正在登录「崩坏·星穹铁道」\n「崩坏·星穹铁道」登录成功\n正在等待 SRC 日志文件生成"
             if_get_file = False
-            while datetime.now() - t < timedelta(minutes=1):
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
                 for log_file in self.src_log_path.parent.iterdir():
                     if log_file.is_file():
                         with suppress(ValueError):
@@ -582,7 +585,8 @@ class AutoProxyTask(TaskExecuteBase):
             self.cur_user_log.status = "SRC 启动时游戏停留在不支持的页面"
         elif _has_structured_src_log(log_content, "CRITICAL"):
             self.cur_user_log.status = "SRC 发生严重错误"
-        elif datetime.now() - latest_time > timedelta(
+        elif self.is_log_stalled(
+            latest_time,
             minutes=self.script_config.get("Run", "RunTimeLimit")
         ):
             self.cur_user_log.status = "SRC 进程超时"
@@ -636,7 +640,7 @@ class AutoProxyTask(TaskExecuteBase):
 
         user_logs_list = []
         for t, log_item in self.cur_user_item.log_record.items():
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/general/AutoProxy.py
+++ b/app/task/general/AutoProxy.py
@@ -24,6 +24,7 @@ import uuid
 import shlex
 import shutil
 import asyncio
+import time
 import re
 from pathlib import Path
 from contextlib import suppress
@@ -390,7 +391,8 @@ class AutoProxyTask(TaskExecuteBase):
             self.script_info.log = "正在等待脚本日志文件生成"
             if_get_file = False
             target_suffix: int | None = None  # None = 未锁定
-            while datetime.now() - t < timedelta(minutes=1):
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
                 if self.log_use_prefix:
                     prefix_fmt = self.log_format[: -len(_PREFIX_SENTINEL)]
                     pattern = _format_to_prefix_regex(prefix_fmt)
@@ -711,7 +713,8 @@ class AutoProxyTask(TaskExecuteBase):
         # 成功/失败标志按配置模式（子串包含 / 正则）在日志全文中查找
         if self.success_log.search(log) is not None:
             self.cur_user_log.status = "Success!"
-        elif datetime.now() - latest_time > timedelta(
+        elif self.is_log_stalled(
+            latest_time,
             minutes=self.script_config.get("Run", "RunTimeLimit")
         ):
             self.cur_user_log.status = "脚本进程超时"
@@ -756,7 +759,7 @@ class AutoProxyTask(TaskExecuteBase):
         user_logs_list = []
         for t, log_item in self.cur_user_item.log_record.items():
 
-            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            dt = t.astimezone(UTC4)
             log_path = Config.build_history_log_path(
                 script_name=self.script_info.name,
                 user_name=self.cur_user_item.name,

--- a/app/task/general/AutoProxy.py
+++ b/app/task/general/AutoProxy.py
@@ -151,6 +151,7 @@ class AutoProxyTask(TaskExecuteBase):
         self.wait_event = asyncio.Event()
         self.user_start_time = datetime.now()
         self.log_start_time = datetime.now()
+        self.log_start_at = time.monotonic()
 
         self.script_root_path = Path(self.script_config.get("Info", "RootPath"))
         self.script_path = Path(self.script_config.get("Script", "ScriptPath"))
@@ -295,6 +296,7 @@ class AutoProxyTask(TaskExecuteBase):
                 f"用户 {self.cur_user_item.name} - 尝试次数: {i + 1}/{self.script_config.get('Run', 'RunTimesLimit')}"
             )
             self.log_start_time = datetime.now()
+            self.log_start_at = time.monotonic()
             self.cur_user_item.log_record[self.log_start_time] = self.cur_user_log = (
                 LogRecord()
             )
@@ -725,8 +727,9 @@ class AutoProxyTask(TaskExecuteBase):
             elif await self.general_process_manager.is_running():
                 self._process_seen = True
                 self.cur_user_log.status = "通用脚本正常运行中"
-            elif not self._process_seen and datetime.now() - self.log_start_time < timedelta(
-                seconds=_PROCESS_START_GRACE_SECONDS
+            elif (
+                not self._process_seen
+                and time.monotonic() - self.log_start_at < _PROCESS_START_GRACE_SECONDS
             ):
                 # 进程启动宽限期内：可能是启动器拉起工作进程的延迟，或残留进程
                 # 收尾日志触发了回调，不据此判定任务结束

--- a/app/utils/LogMonitor.py
+++ b/app/utils/LogMonitor.py
@@ -74,6 +74,11 @@ class LogMonitor:
         # 日志处理钩子：日志行进入日志内容前逐行预处理（改写）或丢弃
         self.line_hook = line_hook
         self.last_callback_time: datetime = datetime.now()
+        # 节流判定用的单调时钟读数。last_callback_time 还要充当 strptime 的
+        # 基准日期，必须保持墙钟；而墙钟回拨会让节流差值变成负数，接下来
+        # 「跳变幅度」那么久都不再触发回调——文件监控没有兜底超时，停滞
+        # 判定与界面状态会一起冻结。
+        self.last_callback_at = time.monotonic()
         self.log_contents: list[str] = []
         self.latest_time = datetime.now()
         # 最近一次日志推进的单调时钟读数。停滞判定必须用单调时钟：
@@ -224,7 +229,7 @@ class LogMonitor:
                 if log_stat.st_size <= offset:
 
                     # 日志无变化超时调用回调
-                    if datetime.now() - self.last_callback_time > timedelta(minutes=1):
+                    if time.monotonic() - self.last_callback_at > 60:
                         await self.do_callback()
 
                     await asyncio.sleep(1)
@@ -287,12 +292,13 @@ class LogMonitor:
                 await self.do_callback()
                 break
 
-            if datetime.now() - self.last_callback_time > timedelta(seconds=1):
+            if time.monotonic() - self.last_callback_at > 1:
                 await self.do_callback()
 
     async def do_callback(self):
         """安全调用回调函数"""
         self.last_callback_time = datetime.now()
+        self.last_callback_at = time.monotonic()
         try:
             if self.parse_log is None:
                 await self.callback(self.log_contents, self.latest_time)

--- a/app/utils/LogMonitor.py
+++ b/app/utils/LogMonitor.py
@@ -20,6 +20,8 @@
 
 
 import asyncio
+import time
+
 import aiofiles
 from contextlib import suppress
 from datetime import datetime, timedelta, date
@@ -74,6 +76,10 @@ class LogMonitor:
         self.last_callback_time: datetime = datetime.now()
         self.log_contents: list[str] = []
         self.latest_time = datetime.now()
+        # 最近一次日志推进的单调时钟读数。停滞判定必须用单调时钟：
+        # latest_time 与 datetime.now() 都是墙钟，系统时钟跳变（夏令时切换、
+        # NTP 校时）会让两者的差值凭空增加一小时，把正常任务误判为超时。
+        self.latest_progress_at = time.monotonic()
         self.task: asyncio.Task | None = None
 
     async def monitor_file(
@@ -325,6 +331,7 @@ class LogMonitor:
         if if_init:
             self.last_log = log
             self.latest_time = datetime.now()
+            self.latest_progress_at = time.monotonic()
             return
 
         if log == "" or any(_ in log for _ in self.except_logs):
@@ -339,6 +346,12 @@ class LogMonitor:
                     self.last_callback_time,
                 )
                 self.last_log = log_text
+                self.latest_progress_at = time.monotonic()
+
+    def seconds_since_progress(self) -> float:
+        """距最近一次日志推进的秒数，按单调时钟计量。"""
+
+        return time.monotonic() - self.latest_progress_at
 
     async def _consume_new_lines(
         self,

--- a/app/utils/emulator/general.py
+++ b/app/utils/emulator/general.py
@@ -31,6 +31,7 @@ if IS_WINDOWS:
     import win32gui
     import keyboard
 from datetime import datetime, timedelta
+import time
 from pathlib import Path
 from typing import Dict, Any
 
@@ -93,10 +94,8 @@ class GeneralDeviceManager(DeviceBase):
         await self.process_managers[idx].kill()
 
         # 等待进程完全停止
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             if not await self.process_managers[idx].is_running():
                 return DeviceStatus.OFFLINE
 
@@ -140,10 +139,8 @@ class GeneralDeviceManager(DeviceBase):
             logger.warning(f"设备{idx}未在线，当前状态码: {status}")
             return status
 
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
 
             # 检查窗口可见性是否符合预期
             if self.process_managers[idx].main_pid is not None and (

--- a/app/utils/emulator/ldplayer.py
+++ b/app/utils/emulator/ldplayer.py
@@ -30,6 +30,7 @@ if IS_WINDOWS:
     import win32gui
     import keyboard
 from datetime import datetime, timedelta
+import time
 from pydantic import BaseModel
 from pathlib import Path
 
@@ -180,10 +181,8 @@ class LDManager(DeviceBase):
         logger.info(f"开始启动模拟器 {idx}  - {package_name}")
 
         status = DeviceStatus.UNKNOWN  # 初始化status变量
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             status = await self.getStatus(idx)
             if status == DeviceStatus.ONLINE:
                 return (await self.getInfo(idx))[idx]
@@ -210,10 +209,8 @@ class LDManager(DeviceBase):
         if result.returncode != 0:
             raise RuntimeError(f"命令执行失败: {result.stdout}")
 
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             status = await self.getStatus(idx)
             if status == DeviceStatus.ONLINE:
                 await asyncio.sleep(
@@ -258,10 +255,8 @@ class LDManager(DeviceBase):
 
         if result.returncode != 0:
             raise RuntimeError(f"命令执行失败: {result.stdout}")
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             status = await self.getStatus(idx)
             if status == DeviceStatus.OFFLINE:
                 await self._verify_and_restore_instance_config(idx)
@@ -331,10 +326,8 @@ class LDManager(DeviceBase):
 
         result = (await self.get_device_info(idx))[idx]
 
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             # 检查窗口可见性是否符合预期
             if win32gui.IsWindowVisible(result.top_hwnd) == is_visible:
                 return status

--- a/app/utils/emulator/mumu.py
+++ b/app/utils/emulator/mumu.py
@@ -32,6 +32,7 @@ if IS_WINDOWS:
     import win32process
 from contextlib import suppress
 from datetime import datetime, timedelta
+import time
 from pathlib import Path
 
 from app.models.emulator import DeviceStatus, DeviceInfo, DeviceBase
@@ -261,10 +262,8 @@ class MumuManager(DeviceBase):
         from app.core import Config
 
         status = DeviceStatus.UNKNOWN  # 初始化status变量
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             status = await self.getStatus(idx)
             if status == DeviceStatus.ONLINE:
                 if Config.get("Function", "IfBlockAd"):
@@ -310,10 +309,8 @@ class MumuManager(DeviceBase):
         if result.returncode != 0:
             raise RuntimeError(f"命令执行失败: {result.stdout}")
 
-        t = datetime.now()
-        while datetime.now() - t < timedelta(
-            seconds=self.config.get("Info", "MaxWaitTime")
-        ):
+        deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+        while time.monotonic() < deadline:
             status = await self.getStatus(idx)
             if if_close_mumu_nx:
                 if_close_mumu_nx = not await self.close_mumu_nx_window()
@@ -365,10 +362,8 @@ class MumuManager(DeviceBase):
             if result.returncode != 0:
                 raise RuntimeError(f"命令执行失败: {result.stdout}")
 
-            t = datetime.now()
-            while datetime.now() - t < timedelta(
-                seconds=self.config.get("Info", "MaxWaitTime")
-            ):
+            deadline = time.monotonic() + self.config.get("Info", "MaxWaitTime")
+            while time.monotonic() < deadline:
                 status = await self.getStatus(idx)
                 if status == DeviceStatus.OFFLINE:
                     return DeviceStatus.OFFLINE

--- a/app/utils/platform/common/process.py
+++ b/app/utils/platform/common/process.py
@@ -248,7 +248,7 @@ class ProcessManager:
 
             await self.search_process(
                 target_process,
-                datetime.now() + timedelta(seconds=60),
+                60.0,
                 min_create_time=time.time(),
             )
 
@@ -287,26 +287,27 @@ class ProcessManager:
 
         await self.search_process(
             target_process,
-            datetime.now() + timedelta(seconds=60),
+            60.0,
             min_create_time=time.time(),
         )
 
     async def search_process(
         self,
         target_process: ProcessInfo,
-        search_end_time: datetime,
+        timeout_seconds: float = 60.0,
         min_create_time: float | None = None,
     ) -> None:
         """查找目标进程
 
         Args:
             target_process: 期望目标进程信息
-            search_end_time: 搜索截止时间
+            timeout_seconds: 搜索超时秒数，按单调时钟计量，不受系统时钟跳变影响
             min_create_time: 进程创建时间下限（epoch 秒），早于该时刻创建的同名进程视为
                 启动前的残留实例并跳过，避免错误跟踪旧进程（留 2 秒容差吸收时间戳偏差）
         """
 
-        while datetime.now() < search_end_time:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
             for proc in psutil.process_iter(
                 ["pid", "name", "exe", "cmdline", "create_time"]
             ):

--- a/res/version.json
+++ b/res/version.json
@@ -28,7 +28,8 @@
                 "通知服务 自定义 Webhook 推送本地/内网目标绕过代理 by [@ArmedHelicopter](https://github.com/ArmedHelicopter)",
                 "修复 M9A 任务跨过本地午夜后日志监控仍读取前一天文件、导致任务被误判超时的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复启动时队列的「每日首次」在跨日前十秒内冷启动时，可能漏跑当天或在同一天重复运行的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复日志文件在监控期间被替换或截断后，监控可能永远读不到新内容的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复日志文件在监控期间被替换或截断后，监控可能永远读不到新内容的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复系统时钟跳变（夏令时切换、NTP 校时）导致运行中任务被误判超时、模拟器等待提前放弃与历史记录归档时刻偏移一小时的问题"
             ]
         },
         "v5.5.0-beta.1": {

--- a/tests/task/test_maafw_external_manager.py
+++ b/tests/task/test_maafw_external_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+import time
 import tempfile
 from types import SimpleNamespace
 import uuid
@@ -1121,7 +1122,7 @@ class MaaFWExternalManagerTest(unittest.TestCase):
 
                     async def timeout_sleep(delay):
                         if delay == 5:
-                            manager.last_log_at = datetime.now() - timedelta(hours=2)
+                            manager.last_log_at = time.monotonic() - 7200
 
                 async def no_sleep(_delay):
                     return None


### PR DESCRIPTION
## 问题

中国不实行夏令时，以下问题只在使用夏令时的地区发作；**NTP 校时同样会触发，与时区无关的用户也可能遇到**。根因同源：多处依赖本地墙钟做差值或换算，系统时钟跳变时全部失准。

### 1. 超时判定误杀正在运行的任务

`datetime.now() - latest_time` 两端都是墙钟。跳变瞬间凭空多出一小时，而日常时限默认仅 **10 分钟**、剿灭 **40 分钟**（`app/models/config.py` 的 `RoutineTimeLimit` / `AnnihilationTimeLimit` 及其余脚本的 `RunTimeLimit`），脚本只要有几十秒不写日志（战斗中很常见），任务立刻被判「进程超时」并中止。

### 2. 历史归档偏移一小时

`t.replace(tzinfo=datetime.now().astimezone().tzinfo)` 把**当前**的固定偏移套到**过去**的时间戳上——`datetime.now().astimezone().tzinfo` 返回的是当下这一刻的偏移快照，不是具名时区，跨换季点的运行会偏一小时。

### 3. 墙钟忙等循环

模拟器启动等待、进程查找、ADB 就绪等循环用墙钟差值计时，跳变时提前放弃或多等一小时。

## 改动

**停滞判定**移到 `TaskExecuteBase.is_log_stalled()`，按单调时钟计量，`latest_time` 只用于判断日志是否推进；按 `key` 分桶，让同一任务的不同阶段（如 MaaEnd 的资源下载与正式运行）独立计时。放在任务基类而非 `LogMonitor` 上，是因为 `general` 和 `SRC` 会在收尾时 `del` 掉自己的 monitor 属性，从回调里引用它并不安全。

**归档换算**改为 `t.astimezone(UTC4)`，按时间戳自身的偏移换算。

**忙等与超时**统一改用 `time.monotonic()`；`search_process` 的截止时刻参数改为超时秒数（5 个调用点同步更新）。

### 第二轮：补齐遗漏的计时点

首版的扫描只覆盖了 `while datetime.now() - t < ...` 这类循环形式，漏掉了以 `total_seconds()` 比较和在 `if` 条件里比较 `timedelta` 的写法。同根因的墙钟计时还有五处，其中前两处会直接误杀健康任务：

| 位置 | 后果 |
| --- | --- |
| `MaaFW/manager.py` `_wait_for_terminal` 主超时 | 与已改的七个脚本类型是同一个判定。前跳会把健康任务立刻判成「MFW 进程超时」并杀掉 |
| `M9A/AutoProxy.py` 虚拟用户资源更新超时 | 更新本身常需数分钟，前跳会立即中止 |
| `LogMonitor.py` 回调节流 | 日志文件静止时这是唯一的回调触发点，而全部停滞判定都在回调里执行。**回拨**会让差值变负，接下来「跳变幅度」那么久都不再回调，停滞判定与界面状态一起冻结。文件监控没有兜底超时，不像进程监控有 `wait_for` 的 60 秒自愈 |
| `general/AutoProxy.py` 进程启动宽限期 | 前跳跳过 90 秒宽限，误判「脚本在完成任务前退出」 |
| `MaaFW/manager.py` `_await_game_ready` 剩余预算 | 折算归零，只探测一次就报「等待 PC 游戏窗口超时」 |

`last_callback_time` 与 `log_start_time` 还分别充当 `strptime` 的基准日期和监控起始时刻，保留墙钟语义，另加单调伴生字段用于计时。`MaaFW` 的 `last_log_at` 只服务于超时判定，直接改为单调读数，对应测试的构造方式同步调整（`tests/task/test_maafw_external_manager.py`，测试意图不变，只是改用单调时钟制造超时条件）。

已用更宽的模式重扫全仓，其余命中都是缓存新鲜度与节流（`config.py` 的 1 小时缓存、`update.py` 的 4 小时检查间隔），回拨只会拉长节流，不是超时判定。

## 关于秋季回拨的同名覆盖

评审提出过一个疑虑：回拨当天重复出现的 `02:xx` 时段，两次运行是否会算出相同的归档文件名而互相覆盖。**核实后不会。**

归档时间戳的来源逐一追溯过，全部出自 `datetime.now()`（各脚本的 `log_start_time` / `started_at`），而 CPython 的 `datetime.now()` 会设置 `fold`；`astimezone()` 尊重该标记，两次 `02:30` 分别落到不同的东 4 区时刻。`LogMonitor.strptime()` 解析出的 `latest_time` 确实不带 `fold`，但它只服务于停滞判定，不参与归档文件名。

## 未包含

夏令时议题里的「春季跳变当天 02:00–03:00 的定时不触发 / PC 休眠漏跑」需要补跑宽限窗口，属于新增行为而非计时口径修正，需要先定策略（窗口多长、关机一整天后要不要补），本 PR 不含。

## 验证

`pytest tests` 523 passed / 3 skipped / 0 failed。

`is_log_stalled` 另做了行为验证：墙钟跳变一小时不误判、真实停滞超阈值正常触发、阶段分桶互不干扰、实例间状态独立、冬令时归档换算正确、回拨两次运行落到不同文件名、`_log_progress` 未被 `@dataclass` 收作字段。

Refs #465

## Sourcery 摘要

使任务超时、等待循环和日志监控调度能够适应系统时钟变化，同时保留准确的历史归档时间戳。

Bug 修复：
- 防止系统时钟向前或向后跳变时，将正常运行的任务错误地判定为超时。
- 修正夏令时切换和本地时间重复期间的历史归档时间戳。
- 防止时钟变化过早结束模拟器、进程、ADB 和游戏就绪状态的等待循环，或导致日志监控回调冻结。

改进：
- 使用单调时钟和各阶段独立的状态，集中管理日志停滞跟踪。
- 保留用于显示和解析的墙上时钟时间戳，同时使用单调时钟进行耗时和节流判断。
- 更新进程搜索超时逻辑，使用基于持续时间的单调截止时间。

测试：
- 调整 MaaFW 超时测试覆盖范围，以使用单调时间戳。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使任务超时、等待循环和日志监控能够适应系统时钟变化，同时保留准确的归档时间戳。

Bug 修复：
- 防止系统时钟变化导致正常任务被错误地判定为超时，或使日志监控和启动等待过程冻结。
- 确保在夏令时切换和本地时间重复出现的情况下，历史归档时间戳仍然正确。

增强功能：
- 对任务停滞检测、进程搜索、模拟器操作、就绪检查以及其他基于已用时间的判断使用单调时钟，同时保留墙上时钟时间戳用于显示和解析。
- 将日志停滞跟踪集中到任务基类中，并为不同的任务阶段分别维护独立的计时。

测试：
- 更新 MaaFW 超时测试覆盖范围，以使用单调时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make task timeouts, wait loops, and log monitoring resilient to system clock changes while preserving accurate archive timestamps.

Bug Fixes:
- Prevent system clock changes from incorrectly timing out healthy tasks or freezing log monitoring and startup waits.
- Preserve correct historical archive timestamps across daylight-saving transitions and repeated local times.

Enhancements:
- Use monotonic timing for task stall detection, process searches, emulator operations, readiness checks, and other elapsed-time decisions while retaining wall-clock timestamps for display and parsing.
- Centralize log-stall tracking in the task base class with independent timing for separate task phases.

Tests:
- Update MaaFW timeout coverage to use monotonic timestamps.

</details>

</details>