### PR TITLE
feat(notify): 自定义 Webhook 新增 {gamedate} 变量

### DIFF
--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Literal
 
 from app.models.config import Webhook
+from app.utils.constants import UTC4
 from app.utils import LazyProxy, get_logger
 
 logger = get_logger("通知服务")
@@ -279,6 +280,9 @@ class Notification:
                 "datetime": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 "date": datetime.now().strftime("%Y-%m-%d"),
                 "time": datetime.now().strftime("%H:%M:%S"),
+                # 游戏日（东 4 区），与历史记录归档的日期分组一致。
+                # {date} 保持本地日期语义不变。
+                "gamedate": datetime.now(tz=UTC4).strftime("%Y-%m-%d"),
             }
 
             logger.debug("开始解析 Webhook 消息模板")

--- a/frontend/src/components/WebhookManager.vue
+++ b/frontend/src/components/WebhookManager.vue
@@ -135,7 +135,7 @@
           <a-textarea
             v-model:value="formData.template"
             :rows="6"
-            placeholder="请输入消息模板，支持变量: {title}, {content}, {datetime}, {date}, {time}"
+            placeholder="请输入消息模板，支持变量: {title}, {content}, {datetime}, {date}, {time}, {gamedate}"
           />
           <div class="template-help">
             <a-typography-text type="secondary" style="font-size: 12px">

--- a/frontend/src/utils/webhookTemplates.ts
+++ b/frontend/src/utils/webhookTemplates.ts
@@ -127,4 +127,5 @@ export const TEMPLATE_VARIABLES = [
   { name: '{datetime}', description: '完整日期时间 (YYYY-MM-DD HH:MM:SS)' },
   { name: '{date}', description: '日期 (YYYY-MM-DD)' },
   { name: '{time}', description: '时间 (HH:MM:SS)' },
+  { name: '{gamedate}', description: '游戏日 (YYYY-MM-DD，东4区，与历史记录归档一致)' },
 ]

--- a/res/version.json
+++ b/res/version.json
@@ -4,7 +4,8 @@
         "v5.5.0-beta.2": {
             "新增功能": [
                 "日志处理 新增日志处理钩子层并支持成功/失败标志正则匹配 by [@qiyinxi](https://github.com/qiyinxi)",
-                "MaaFW专项 新增 MaaFW 脚本类型，通过外壳外部运行 MaaFramework 项目（MAS 主进程不加载任何项目 DLL）：编辑页读取项目 interface.json 后选择控制器、资源与任务，支持 ADB 模拟器与 Win32 PC 游戏两条控制链路；已适配 MFAAvalonia（M9A / MaaKes）与 MXU（MaaEnd / MaaYYs）两类外壳，运行期接管外壳配置并在收尾时原样还原，关闭外壳自身的更新与通知以免与 MAS 抢同一批文件或重复推送；运行判定按外壳家族取日志来源（MXU 读进程 stdout），逐任务判定不绑定外壳界面语言 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MaaFW专项 新增 MaaFW 脚本类型，通过外壳外部运行 MaaFramework 项目（MAS 主进程不加载任何项目 DLL）：编辑页读取项目 interface.json 后选择控制器、资源与任务，支持 ADB 模拟器与 Win32 PC 游戏两条控制链路；已适配 MFAAvalonia（M9A / MaaKes）与 MXU（MaaEnd / MaaYYs）两类外壳，运行期接管外壳配置并在收尾时原样还原，关闭外壳自身的更新与通知以免与 MAS 抢同一批文件或重复推送；运行判定按外壳家族取日志来源（MXU 读进程 stdout），逐任务判定不绑定外壳界面语言 by [@qiyinxi](https://github.com/qiyinxi)",
+                "自定义 Webhook 新增 {gamedate} 变量，可在推送模板中引用与历史记录归档一致的游戏日"
             ],
             "程序优化": [
                 "架构优化 新增 utils/services 平台层，按通用与 Windows 能力拆分底层实现，非 Windows 环境跳过 Windows 专用初始化 by [@HarcoChen](https://github.com/HarcoChen)",


### PR DESCRIPTION
## 背景

历史记录按游戏日（东 4 区，国服 04:00 换日）分组归档，而通知模板此前只能取到本地日期，用户无法在推送内容里引用与历史记录一致的日期。

## 改动

自定义 Webhook 新增 `{gamedate}` 变量，前端变量说明与占位符同步更新。

`{date}` 保持本地日期语义不变——用户已配置的模板不该被静默改语义。

## 关于通知标题日期

初版曾把 18 处通知标题与统计报告的日期一并改为游戏日，使其与历史归档一致。经讨论后回退：**标题回答的是「我什么时候跑的」，用本地时间更自然**；改为游戏日会让 UTC+8 用户在本地 00:00–04:00 跑的任务标题显示前一天，是全体用户可见的破坏性变化，代价大于收益。

因此本 PR 只提供 `{gamedate}` 变量，让需要对齐历史记录的用户在自己的模板里自行引用。#466 中「通知日期与归档日期差一天」的部分不再按统一口径处理。

## 验证

`pytest tests` 522 passed / 3 skipped，与合并基线一致（2 项预存在失败与本 PR 无关：`test_headless_import` 缺 `pyautogui`、`test_src_config_transactions` 把 `%TEMP%\other-src` 写死不清理）。

Refs #466

## Sourcery 摘要

为自定义 Webhook 模板添加可选的比赛日期变量，同时不改变现有日期语义。

新功能：
- 添加 `{gamedate}` 自定义 Webhook 模板变量，使用与历史记录分组一致的 UTC+4 比赛日期。

增强功能：
- 保留 `{date}` 的现有本地日期含义，同时更新 Webhook UI 以说明新变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional game-date variable to custom Webhook templates without changing existing date semantics.

New Features:
- Add a `{gamedate}` custom Webhook template variable using the UTC+4 game date aligned with historical record grouping.

Enhancements:
- Preserve the existing local-date meaning of `{date}` while updating the Webhook UI to document the new variable.

</details>