### PR TITLE
refactor(frontend): 配置任务成败判定改读 outcome 字段

### DIFF
--- a/frontend/src/views/EditView/User/GeneralUserEdit.vue
+++ b/frontend/src/views/EditView/User/GeneralUserEdit.vue
@@ -634,8 +634,7 @@ const handleGeneralConfig = async () => {
           const data = wsMessage.data as unknown as WSTaskCompletedData
           logger.info(`用户 ${formData.userName} 通用配置任务已结束`)
           // 根据结果显示不同消息
-          const result = data.result
-          if (result && !result.includes('异常') && !result.includes('错误')) {
+          if (data.outcome === 'success') {
             message.success(`用户 ${formData.userName} 的配置已完成`)
           }
           // 清理连接

--- a/frontend/src/views/EditView/User/MAAUserEdit.vue
+++ b/frontend/src/views/EditView/User/MAAUserEdit.vue
@@ -1010,8 +1010,7 @@ const handleMAAConfig = async () => {
           const data = wsMessage.data as unknown as WSTaskCompletedData
           logger.info(`用户 ${formData.Info?.Name || formData.userName} MAA配置任务已结束`)
           // 根据结果显示不同消息
-          const result = data.result
-          if (result && !result.includes('异常') && !result.includes('错误')) {
+          if (data.outcome === 'success') {
             message.success(`用户 ${formData.Info?.Name || formData.userName} 的配置已完成`)
           }
           // 清理连接

--- a/frontend/src/views/EditView/User/OkNteUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkNteUserEdit.vue
@@ -570,8 +570,7 @@ const handleOkNteConfig = async () => {
       subscribe({ id: wsId, type: WS_TASK_COMPLETED }, wsMessage => {
         const data = wsMessage.data as unknown as WSTaskCompletedData
         logger.info(`用户 ${formData.userName} OK-NTE 配置任务已结束`)
-        const result = String(data.result || '')
-        if (!result.includes('异常') && !result.includes('错误')) {
+        if (data.outcome === 'success') {
           refreshOkNteConfigEditor()
           message.success(`用户 ${formData.userName} 的 OK-NTE 配置已完成`)
         }

--- a/frontend/src/views/EditView/User/SRCUserEdit.vue
+++ b/frontend/src/views/EditView/User/SRCUserEdit.vue
@@ -366,8 +366,7 @@ const handleSRCConfig = async () => {
           const data = wsMessage.data as unknown as WSTaskCompletedData
           logger.info(`用户 ${formData.Info?.Name || formData.userName} SRC配置任务已结束`)
           // 根据结果显示不同消息
-          const result = data.result
-          if (result && !result.includes('异常') && !result.includes('错误')) {
+          if (data.outcome === 'success') {
             message.success(`用户 ${formData.Info?.Name || formData.userName} 的配置已完成`)
           }
           // 清理连接

--- a/frontend/src/views/Scripts.vue
+++ b/frontend/src/views/Scripts.vue
@@ -1210,8 +1210,7 @@ const handleStartMAAConfig = async (script: Script) => {
           const data = wsMessage.data as unknown as WSTaskCompletedData
           logger.info(`脚本 ${script.name} 配置任务已结束`)
           // 根据结果显示不同消息
-          const result = data.result
-          if (result && !result.includes('异常') && !result.includes('错误')) {
+          if (data.outcome === 'success') {
             message.success(`${script.name} 配置已完成`)
           }
           // 清理连接
@@ -1331,8 +1330,7 @@ const handleStartSRCConfig = async (script: Script) => {
           const data = wsMessage.data as unknown as WSTaskCompletedData
           logger.info(`脚本 ${script.name} 配置任务已结束`)
           // 根据结果显示不同消息
-          const result = data.result
-          if (result && !result.includes('异常') && !result.includes('错误')) {
+          if (data.outcome === 'success') {
             message.success(`${script.name} 配置已完成`)
           }
           // 清理连接

--- a/res/version.json
+++ b/res/version.json
@@ -13,7 +13,8 @@
                 "匿名遥测 接入 Electron 主进程与渲染进程错误上报，增加应用启动、后端启动和任务执行的性能指标，抑制无异常的日志事件并遮蔽上报内容中的本机用户名，并关联 Sentry 发布提交与生产部署信息 by [@ClozyA](https://github.com/ClozyA)",
                 "清理无用前端资源、依赖及后端冗余代码 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "MaaFW项目 interface 解析接上闲置的两级缓存，并对 .json 文件先按严格 JSON 解析、失败再回退 JSON5（json5 是纯 Python 实现，比标准库慢三个数量级）：用户页与脚本页进入耗时由约 5.5 秒降至约 0.12 秒 by [@qiyinxi](https://github.com/qiyinxi)",
-                "任务调度 单独运行脚本任务不再受单日代理次数上限约束，该限制仅对计划队列生效 by [@qiyinxi](https://github.com/qiyinxi)"
+                "任务调度 单独运行脚本任务不再受单日代理次数上限约束，该限制仅对计划队列生效 by [@qiyinxi](https://github.com/qiyinxi)",
+                "配置任务的成败判定改用协议中的机器可读字段，不再匹配结果文本 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "开发流程": [
                 "开发环境改用独立的后端端口与 userData 目录，可与已安装的正式版同时运行 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
#295 的 WS 协议里已经有机器可读的 `outcome`（`success` / `error` / `cancelled`），`useTaskRuntimeState.ts` 当时迁过去了，但配置任务这 6 处仍在用 `result.includes('异常') || result.includes('错误')` 判定成败。这个 PR 把它们补齐。

顺带修掉一个小问题：`result` 是拼出来的摘要文本，取消配置任务时它不含这两个词，于是仍会提示「配置已完成」。

前端 lint 0 error、typecheck 0 error、vitest 127 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

根据任务结果而不是本地化的结果文本来确定前端配置是否成功。

错误修复：
- 使用机器可读的任务结果，防止失败或已取消的配置任务被错误地报告为成功。

增强功能：
- 统一用户编辑器和脚本配置工作流中的任务完成处理方式。

杂项：
- 更新应用程序版本元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Determine frontend configuration success from the task outcome instead of localized result text.

Bug Fixes:
- Use the machine-readable task outcome to prevent failed or cancelled configuration tasks from being incorrectly reported as successful.

Enhancements:
- Standardize task completion handling across user editors and script configuration workflows.

Chores:
- Update application version metadata.

</details>