### PR TITLE
fix(log): 记录的读取偏移超过文件长度时归零重读

### DIFF
--- a/app/utils/LogMonitor.py
+++ b/app/utils/LogMonitor.py
@@ -203,6 +203,18 @@ class LogMonitor:
 
                 log_stat = current_path.stat()
 
+                if log_stat.st_size < offset:
+                    # 文件比记录的偏移还短，说明它被替换或截断过。按日期滚动
+                    # 切回旧路径时最容易撞上：offset 是离开前记住的，而文件在
+                    # 离开期间被换掉了，既有的缩水检测只比较在场期间的两次
+                    # stat，对此天然失明。不归零就会永远落进下面的「无变化」
+                    # 分支空转，新内容再也读不到。
+                    logger.info(
+                        f"日志文件已被替换或截断（{log_stat.st_size} < {offset}），从头重读"
+                    )
+                    offset = 0
+                    continue
+
                 if log_stat.st_size <= offset:
 
                     # 日志无变化超时调用回调

--- a/res/version.json
+++ b/res/version.json
@@ -27,7 +27,8 @@
                 "MAA专项 修复任务生成时无条件覆盖用户原生高级配置的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "通知服务 自定义 Webhook 推送本地/内网目标绕过代理 by [@ArmedHelicopter](https://github.com/ArmedHelicopter)",
                 "修复 M9A 任务跨过本地午夜后日志监控仍读取前一天文件、导致任务被误判超时的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复启动时队列的「每日首次」在跨日前十秒内冷启动时，可能漏跑当天或在同一天重复运行的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复启动时队列的「每日首次」在跨日前十秒内冷启动时，可能漏跑当天或在同一天重复运行的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复日志文件在监控期间被替换或截断后，监控可能永远读不到新内容的问题"
             ]
         },
         "v5.5.0-beta.1": {


### PR DESCRIPTION
## 问题

`LogMonitor` 记录的读取偏移可能超过被监控文件的当前长度。此时每轮循环都落进「日志无变化」分支：

```python
if log_stat.st_size <= offset:
    if datetime.now() - self.last_callback_time > timedelta(minutes=1):
        await self.do_callback()
    await asyncio.sleep(1)
    continue
```

于是每秒空转，**新内容再也读不到**，任务最终被误判超时。不会自愈——只有等文件重新长过那个陈旧偏移才恢复，届时还会从中间字节续读，首行是残行。

## 怎么撞上的

最直接的路径是 #472 引入的按日期滚动切换。切换时会记住旧路径的偏移、切回时恢复：

```python
read_offsets[current_path] = offset
current_path = resolved
offset = read_offsets.get(current_path, 0)
```

若旧文件在「离开期间」被删除重建或截断（外部清理、磁盘工具），切回时恢复的偏移就会超过新文件长度。

既有的缩水检测帮不上忙：

```python
if log_stat.st_ino != current_path.stat().st_ino or log_stat.st_size > current_path.stat().st_size:
```

它比较的是**存着的 `log_stat`** 与**当前 stat**，而切换时 `if_mtime_checked` 被置 `False`，会强制上面的 mtime 分支重新执行 `log_stat = current_path.stat()`，把 `log_stat` 刷成新文件的当前 stat。比较变成「小 vs 小」，**对离开期间发生的缩水天然失明**。

路径倒退本身需要时钟回拨跨过午夜（NTP 校正一个走快的时钟，或手动改时间；夏令时回拨是 03:00→02:00，不跨午夜，不会触发），叠加文件被替换，触发条件很窄。但失败形态是静默卡死，没有任何线索指向原因，值得修掉。

## 改动

`st_size < offset` 时归零重读并记一条 info 日志。

选择归零而不是钳制到文件长度：文件既然被替换，其内容就是没读过的新内容，从头读才是正确语义；钳制到末尾会漏掉替换后写入的全部内容。

判据用严格小于——`st_size == offset` 是正常的「暂无新数据」，仍走原分支。

## 为什么不一并重置 log_contents

保留既有 `log_contents` 是刻意的：文件被替换前读到的内容仍然是这次运行日志的一部分，不该丢。按日期滚动的前后两个文件属于**同一次运行**，清空会丢掉切换前的全部内容，写入历史记录的那份也只剩后半截——这正是 #472 修掉的缺陷。

代价是「替换后的文件恰好是已读内容的前缀」这一种情形下会重复几行。实测三种替换方式：替换为全新内容、截断到 0 后写入新内容（logrotate 的 copytruncate）都不重复；只有截断为自身前缀会。

三种选择的对比：

| | 后果 |
| --- | --- |
| 不修 | 永久停摆，新内容再也读不到，任务被误判超时且无任何线索 |
| 连同 `log_contents` 一起重置 | 丢失整轮运行在替换前累积的全部日志 |
| 本 PR | 极窄条件下重复几行日志，内容不丢、监控不卡 |

另需说明：`_sync_and_callback` 的判据是 `len(log_contents) != len(self.log_contents)`，本分支只追加不缩短，读到任何新行长度必然增加，同步必然触发——新内容不会因长度判据而漏发。

## 验证

构造场景实跑（A 读到 offset≈2000 → 切到 B → A 被替换为 46 字节 → 路径倒退回 A）：

| | 修复前 | 修复后 |
| --- | --- | --- |
| 倒退回 A 后能否读到新内容 | 否 | 是 |
| 事后再追加一行能否读到 | 否 | 是 |

回归：日志按日期滚动的五项断言、跨午夜完成标志送达、传 `Path` 的调用方与 dev 行为逐字节一致（含回调次数）均通过。`pytest tests` 523 passed / 3 skipped / 0 failed。
