### PR TITLE
feat(frontend): 接入 vue-i18n 框架与语言设置

### DIFF
--- a/.agents/skills/mas-frontend-standards/SKILL.md
+++ b/.agents/skills/mas-frontend-standards/SKILL.md
@@ -143,6 +143,8 @@ Pattern 3 is how several `mas-frontend-ui` layout rules are actually enforced. W
 | "Shared state is easiest to put in localStorage." | Shared reactive application state belongs in Pinia; `localStorage` is only the narrow fallback for durable, non-sensitive local preferences. |
 | "Pinia should hold every frontend value." | Keep isolated short-lived state local, and keep persistent authoritative data in its backend or Electron configuration owner. |
 | "I can tweak generated API files." | `src/api` is generated; regenerate through the project command instead. |
+| "New UI text is just a string; inline is faster." | User-facing text goes through the i18n catalog in `src/i18n/locales`. Add the key to `zh-CN.ts` (source language); `en-US.ts` is partial by design and missing keys fall back. |
+| "This Chinese literal is untranslated; I'll translate it." | **Chinese literals that drive logic must stay verbatim** — e.g. `tab.status === '运行'`, `result.includes('异常')`, `SchedulerStatus` values. Translating them breaks behaviour silently, with no error. Leave them and add a comment saying why. |
 | "This UI-only change can ignore engineering rules." | UI tasks still obey module, state, API, and verification boundaries. |
 | "`yarn lint` is failing, so I broke the build." | ~4900 problems and 92 type errors pre-exist on clean `dev`. Scope lint to your own files and compare typecheck against the baseline. |
 | "Lint passed, so the types are fine." | The two are orthogonal. Lint-clean files carry dozens of type errors in this repo. |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,6 +117,7 @@
     "vitest": "^4.1.9",
     "vue": "^3.5.17",
     "vue-eslint-parser": "^10.2.0",
+    "vue-i18n": "^11.4.10",
     "vue-router": "4",
     "vue-tsc": "^2.2.12",
     "vuedraggable": "^4.1.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,12 +17,13 @@ import BackendStartupOverlay from './components/BackendStartupOverlay.vue'
 import CursorEffectLayer from './components/CursorEffectLayer.vue'
 import { useCursorEffectStore } from './stores/cursorEffect'
 import { usePerformanceStore } from './stores/performance'
-import zhCN from 'ant-design-vue/es/locale/zh_CN'
+import { useLocale } from './composables/useLocale.ts'
 
 const logger = window.electronAPI.getLogger('App组件')
 
 const route = useRoute()
 const { antdTheme, initTheme } = useTheme()
+const { antdLocale } = useLocale()
 const { updateVisible, updateData, latestVersion, onUpdateConfirmed } = useUpdateModal()
 const { isClosing } = useAppClosing()
 const { playSound } = useAudioPlayer()
@@ -64,7 +65,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <ConfigProvider :theme="antdTheme" :locale="zhCN">
+  <ConfigProvider :theme="antdTheme" :locale="antdLocale">
     <!-- 初始化页面使用带标题栏的全屏布局 -->
     <div v-if="isInitializationPage" class="initialization-container">
       <TitleBar />

--- a/frontend/src/composables/useLocale.ts
+++ b/frontend/src/composables/useLocale.ts
@@ -1,0 +1,75 @@
+//   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+//   Copyright © 2025-2026 AUTO-MAS Team
+
+import dayjs from 'dayjs'
+import 'dayjs/locale/zh-cn'
+import 'dayjs/locale/en'
+import antdEnUS from 'ant-design-vue/es/locale/en_US'
+import antdZhCN from 'ant-design-vue/es/locale/zh_CN'
+import { computed, ref, watch } from 'vue'
+
+import { i18n, normalizeLocale, type AppLocale } from '@/i18n'
+import { getConfig, saveConfig } from '@/utils/config'
+
+const logger = window.electronAPI.getLogger('语言设置')
+
+const DAYJS_LOCALE: Record<AppLocale, string> = {
+  'zh-CN': 'zh-cn',
+  'en-US': 'en',
+}
+
+const ANTD_LOCALE = {
+  'zh-CN': antdZhCN,
+  'en-US': antdEnUS,
+}
+
+// 模块级单例，与 useTheme 保持同一模式
+const locale = ref<AppLocale>('zh-CN')
+let initialized = false
+
+/** 语言只影响展示层：vue-i18n 词表、dayjs 与 antd 组件内置文案。 */
+function applyLocale(next: AppLocale): void {
+  i18n.global.locale.value = next
+  dayjs.locale(DAYJS_LOCALE[next])
+}
+
+watch(locale, applyLocale, { immediate: true })
+
+/**
+ * 首次启动跟随系统语言，之后以用户在设置里的选择为准。
+ * 语言存在前端配置（Electron 侧）里，不经过后端。
+ */
+async function initLocale(): Promise<void> {
+  if (initialized) return
+  initialized = true
+  try {
+    const config = await getConfig()
+    if (config.language) {
+      locale.value = normalizeLocale(config.language)
+      return
+    }
+    // 未设置过则跟随系统：渲染进程的 navigator.language 即 Electron 的应用语言
+    locale.value = normalizeLocale(navigator.language)
+  } catch (error) {
+    logger.warn(`读取语言设置失败，回退中文: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
+async function setLocale(next: AppLocale): Promise<void> {
+  if (locale.value === next) return
+  locale.value = next
+  try {
+    await saveConfig({ language: next })
+  } catch (error) {
+    logger.error(`保存语言设置失败: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
+export function useLocale() {
+  return {
+    locale,
+    antdLocale: computed(() => ANTD_LOCALE[locale.value]),
+    initLocale,
+    setLocale,
+  }
+}

--- a/frontend/src/composables/useLocale.ts
+++ b/frontend/src/composables/useLocale.ts
@@ -52,7 +52,10 @@ async function initLocale(preloadedConfig?: FrontendConfig): Promise<void> {
     // 未设置过则跟随系统：渲染进程的 navigator.language 即 Electron 的应用语言
     locale.value = normalizeLocale(navigator.language)
   } catch (error) {
-    logger.warn(`读取语言设置失败，回退中文: ${error instanceof Error ? error.message : error}`)
+    // 配置读不出来时仍能拿到系统语言，没必要连它一起放弃——
+    // 「读取失败」和「语言标记不认识」是同一类情况，应给同一个答案。
+    logger.warn(`读取语言设置失败，改用系统语言: ${error instanceof Error ? error.message : error}`)
+    locale.value = normalizeLocale(navigator.language)
   }
 }
 

--- a/frontend/src/composables/useLocale.ts
+++ b/frontend/src/composables/useLocale.ts
@@ -9,7 +9,7 @@ import antdZhCN from 'ant-design-vue/es/locale/zh_CN'
 import { computed, ref, watch } from 'vue'
 
 import { i18n, normalizeLocale, type AppLocale } from '@/i18n'
-import { getConfig, saveConfig } from '@/utils/config'
+import { getConfig, saveConfig, type FrontendConfig } from '@/utils/config'
 
 const logger = window.electronAPI.getLogger('语言设置')
 
@@ -39,11 +39,11 @@ watch(locale, applyLocale, { immediate: true })
  * 首次启动跟随系统语言，之后以用户在设置里的选择为准。
  * 语言存在前端配置（Electron 侧）里，不经过后端。
  */
-async function initLocale(): Promise<void> {
+async function initLocale(preloadedConfig?: FrontendConfig): Promise<void> {
   if (initialized) return
   initialized = true
   try {
-    const config = await getConfig()
+    const config = preloadedConfig ?? (await getConfig())
     if (config.language) {
       locale.value = normalizeLocale(config.language)
       return
@@ -56,7 +56,8 @@ async function initLocale(): Promise<void> {
 }
 
 async function setLocale(next: AppLocale): Promise<void> {
-  if (locale.value === next) return
+  // 不在此处按当前值早退：首启跟随系统时选择器已显示该语言，
+  // 用户再显式选一次的意图是"钉住它"，必须落盘，否则日后仍会跟着系统变。
   locale.value = next
   try {
     await saveConfig({ language: next })
@@ -67,7 +68,8 @@ async function setLocale(next: AppLocale): Promise<void> {
 
 export function useLocale() {
   return {
-    locale,
+    // 只读：改语言必须走 setLocale，否则会跳过持久化
+    locale: computed(() => locale.value),
     antdLocale: computed(() => ANTD_LOCALE[locale.value]),
     initLocale,
     setLocale,

--- a/frontend/src/composables/useLocale.ts
+++ b/frontend/src/composables/useLocale.ts
@@ -6,9 +6,10 @@ import 'dayjs/locale/zh-cn'
 import 'dayjs/locale/en'
 import antdEnUS from 'ant-design-vue/es/locale/en_US'
 import antdZhCN from 'ant-design-vue/es/locale/zh_CN'
+import { message } from 'ant-design-vue'
 import { computed, ref, watch } from 'vue'
 
-import { i18n, normalizeLocale, type AppLocale } from '@/i18n'
+import { i18n, normalizeLocale, t, type AppLocale } from '@/i18n'
 import { getConfig, saveConfig, type FrontendConfig } from '@/utils/config'
 
 const logger = window.electronAPI.getLogger('语言设置')
@@ -55,14 +56,25 @@ async function initLocale(preloadedConfig?: FrontendConfig): Promise<void> {
   }
 }
 
+// saveConfig 是「读全量 → 合并 → 写回」，并发调用会让先发的后完成从而覆盖后发的选择，
+// 所以语言写入必须串行。
+let savePending: Promise<void> = Promise.resolve()
+
 async function setLocale(next: AppLocale): Promise<void> {
   // 不在此处按当前值早退：首启跟随系统时选择器已显示该语言，
   // 用户再显式选一次的意图是"钉住它"，必须落盘，否则日后仍会跟着系统变。
+  const previous = locale.value
   locale.value = next
+
+  savePending = savePending.catch(() => {}).then(() => saveConfig({ language: next }))
   try {
-    await saveConfig({ language: next })
+    await savePending
   } catch (error) {
+    // 存不下就退回原值：否则界面显示的语言与重启后的语言不一致，且用户毫不知情。
+    // 只在自己仍是最新选择时回退，避免踩掉后一次切换。
+    if (locale.value === next) locale.value = previous
     logger.error(`保存语言设置失败: ${error instanceof Error ? error.message : error}`)
+    message.error(t('common.languageSaveFailed'))
   }
 }
 

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { DEFAULT_LOCALE, SUPPORTED_LOCALES, normalizeLocale } from './index'
+import { SUPPORTED_LOCALES, UNRECOGNIZED_LOCALE, normalizeLocale } from './index'
 
 describe('normalizeLocale', () => {
   it('把各种中文标记归一到 zh-CN', () => {
@@ -15,9 +15,11 @@ describe('normalizeLocale', () => {
     }
   })
 
-  it('空值与无法识别的语言回退到默认语言', () => {
+  it('空值与无法识别的语言回退到英文而不是中文', () => {
+    // 系统语言既非中文也非英文的人更可能看不懂中文，给英文更接近「看得懂」
+    expect(UNRECOGNIZED_LOCALE).toBe('en-US')
     for (const raw of [null, undefined, '', 'fr-FR', 'ja-JP', 'de']) {
-      expect(normalizeLocale(raw)).toBe(DEFAULT_LOCALE)
+      expect(normalizeLocale(raw)).toBe('en-US')
     }
   })
 

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, normalizeLocale } from './index'
+
+describe('normalizeLocale', () => {
+  it('把各种中文标记归一到 zh-CN', () => {
+    for (const raw of ['zh', 'zh-CN', 'zh-Hans-CN', 'zh-TW', 'zh-HK', 'ZH-cn']) {
+      expect(normalizeLocale(raw)).toBe('zh-CN')
+    }
+  })
+
+  it('把各种英文标记归一到 en-US', () => {
+    for (const raw of ['en', 'en-US', 'en-GB', 'EN-us']) {
+      expect(normalizeLocale(raw)).toBe('en-US')
+    }
+  })
+
+  it('空值与无法识别的语言回退到默认语言', () => {
+    for (const raw of [null, undefined, '', 'fr-FR', 'ja-JP', 'de']) {
+      expect(normalizeLocale(raw)).toBe(DEFAULT_LOCALE)
+    }
+  })
+
+  it('归一结果始终落在受支持的语言集合内', () => {
+    for (const raw of ['zh-CN', 'en-US', 'fr', '', 'nonsense']) {
+      expect(SUPPORTED_LOCALES).toContain(normalizeLocale(raw))
+    }
+  })
+})

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -8,22 +8,32 @@ import zhCN from './locales/zh-CN'
 
 export type AppLocale = 'zh-CN' | 'en-US'
 
-export const DEFAULT_LOCALE: AppLocale = 'zh-CN'
+/** 词表源语言：英文词表缺 key 时回退到这里。 */
+export const SOURCE_LOCALE: AppLocale = 'zh-CN'
+
+/**
+ * 语言标记无法识别时使用的界面语言。
+ *
+ * 取英文而非中文：系统语言既非中文也非英文的用户，更可能是看不懂中文的人，
+ * 给他们英文比给中文更接近「看得懂」。
+ */
+export const UNRECOGNIZED_LOCALE: AppLocale = 'en-US'
+
 export const SUPPORTED_LOCALES: AppLocale[] = ['zh-CN', 'en-US']
 
-/** 把任意语言标记归一到受支持的语言；无法识别时回退中文。 */
+/** 把任意语言标记归一到受支持的语言。 */
 export function normalizeLocale(raw: string | null | undefined): AppLocale {
-  if (!raw) return DEFAULT_LOCALE
+  if (!raw) return UNRECOGNIZED_LOCALE
   const lower = raw.toLowerCase()
   if (lower.startsWith('zh')) return 'zh-CN'
   if (lower.startsWith('en')) return 'en-US'
-  return DEFAULT_LOCALE
+  return UNRECOGNIZED_LOCALE
 }
 
 export const i18n = createI18n({
   legacy: false,
-  locale: DEFAULT_LOCALE,
-  fallbackLocale: DEFAULT_LOCALE,
+  locale: SOURCE_LOCALE,
+  fallbackLocale: SOURCE_LOCALE,
   // 英文词表是部分覆盖的，缺失 key 回退中文属预期行为，不必告警。
   missingWarn: false,
   fallbackWarn: false,

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,37 @@
+//   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+//   Copyright © 2025-2026 AUTO-MAS Team
+
+import { createI18n } from 'vue-i18n'
+
+import enUS from './locales/en-US'
+import zhCN from './locales/zh-CN'
+
+export type AppLocale = 'zh-CN' | 'en-US'
+
+export const DEFAULT_LOCALE: AppLocale = 'zh-CN'
+export const SUPPORTED_LOCALES: AppLocale[] = ['zh-CN', 'en-US']
+
+/** 把任意语言标记归一到受支持的语言；无法识别时回退中文。 */
+export function normalizeLocale(raw: string | null | undefined): AppLocale {
+  if (!raw) return DEFAULT_LOCALE
+  const lower = raw.toLowerCase()
+  if (lower.startsWith('zh')) return 'zh-CN'
+  if (lower.startsWith('en')) return 'en-US'
+  return DEFAULT_LOCALE
+}
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: DEFAULT_LOCALE,
+  fallbackLocale: DEFAULT_LOCALE,
+  // 英文词表是部分覆盖的，缺失 key 回退中文属预期行为，不必告警。
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    'zh-CN': zhCN,
+    'en-US': enUS,
+  },
+})
+
+/** 在组件外部取译文（composable 之外的工具函数里用）。 */
+export const t = i18n.global.t

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -9,6 +9,7 @@ export default {
   common: {
     language: 'Language',
     languageTip: 'Interface display language',
+    languageSaveFailed: 'Failed to save the language setting; reverted to the previous one.',
   },
   locale: {
     'zh-CN': '简体中文',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1,0 +1,17 @@
+//   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+//   Copyright © 2025-2026 AUTO-MAS Team
+
+/**
+ * English catalog. Partial by design — missing keys fall back to zh-CN.
+ * Keep the key structure identical to zh-CN.ts.
+ */
+export default {
+  common: {
+    language: 'Language',
+    languageTip: 'Interface display language',
+  },
+  locale: {
+    'zh-CN': '简体中文',
+    'en-US': 'English',
+  },
+}

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1,0 +1,19 @@
+//   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+//   Copyright © 2025-2026 AUTO-MAS Team
+
+/**
+ * 中文词表（源语言）。
+ *
+ * 新增条目时按界面区域分组，key 用小驼峰。译文以本文件为准，
+ * en-US.ts 缺失的 key 会自动回退到这里。
+ */
+export default {
+  common: {
+    language: '语言',
+    languageTip: '界面显示语言',
+  },
+  locale: {
+    'zh-CN': '简体中文',
+    'en-US': 'English',
+  },
+}

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -11,6 +11,7 @@ export default {
   common: {
     language: '语言',
     languageTip: '界面显示语言',
+    languageSaveFailed: '语言设置保存失败，已恢复原语言',
   },
   locale: {
     'zh-CN': '简体中文',

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,13 +9,13 @@ import { configureLocalMonaco } from '@/utils/monaco'
 import { getConfig } from '@/utils/config'
 import { configureSentry, recordRendererStartup } from '@/utils/sentry'
 import { getDefaultHttpEndpoint } from '@/utils/backendEndpoint'
+import { i18n } from '@/i18n'
+import { useLocale } from '@/composables/useLocale'
 
 import Antd, { message } from 'ant-design-vue'
 import 'ant-design-vue/dist/reset.css'
 import '@/styles/scrollbar.css'
 import '@/styles/formSection.css'
-import dayjs from 'dayjs'
-import 'dayjs/locale/zh-cn'
 
 const TITLE_BAR_HEIGHT = 32
 const MESSAGE_TOP_GAP = 8
@@ -50,10 +50,6 @@ if (
 import { bootstrapRealtimeResidents } from '@/bootstrap/realtimeResidents'
 import { initializeAppLifecycle } from '@/composables/useAppLifecycle'
 
-// 正常路由：执行完整初始化
-// 配置dayjs中文本地化
-dayjs.locale('zh-cn')
-
 // 应用级常驻订阅与生命周期协调器必须早于首个主 WebSocket 连接注册（幂等）
 bootstrapRealtimeResidents()
 initializeAppLifecycle()
@@ -87,6 +83,7 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(Antd)
 app.use(router)
+app.use(i18n)
 
 // 全局错误处理
 app.config.errorHandler = (err, instance, info) => {
@@ -95,6 +92,9 @@ app.config.errorHandler = (err, instance, info) => {
 }
 
 const bootstrap = async () => {
+  // 语言必须在挂载前定好，否则首帧会闪一次默认语言
+  await useLocale().initLocale()
+
   const frontendConfig = await getConfig()
   configureSentry(app, router, frontendConfig.Function?.IfEnableTelemetry !== false)
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -92,10 +92,10 @@ app.config.errorHandler = (err, instance, info) => {
 }
 
 const bootstrap = async () => {
-  // 语言必须在挂载前定好，否则首帧会闪一次默认语言
-  await useLocale().initLocale()
-
   const frontendConfig = await getConfig()
+
+  // 语言必须在挂载前定好，否则首帧会闪一次默认语言；复用上面已读的配置，避免重复 IPC
+  await useLocale().initLocale(frontendConfig)
   configureSentry(app, router, frontendConfig.Function?.IfEnableTelemetry !== false)
 
   // 挂载应用

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -1,3 +1,4 @@
+import type { AppLocale } from '@/i18n'
 import type { ThemeMode, ThemeColor } from '@/composables/useTheme'
 import type { CursorEffect } from '@/types/cursorEffect'
 import type { HomeLayoutConfig } from '@/types/home'
@@ -10,6 +11,9 @@ export interface FrontendConfig {
   themeColor: ThemeColor
   cursorEffect?: CursorEffect
   lowPerformanceMode?: boolean
+
+  // 界面语言；未设置时跟随系统
+  language?: AppLocale
 
   // 镜像源设置
   selectedGitMirror: string

--- a/frontend/src/views/setting/TabBasic.vue
+++ b/frontend/src/views/setting/TabBasic.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { QuestionCircleOutlined } from '@ant-design/icons-vue'
+import { useI18n } from 'vue-i18n'
+
+import { useLocale } from '@/composables/useLocale'
 import type { ThemeColor, ThemeMode } from '@/composables/useTheme'
+import { SUPPORTED_LOCALES, type AppLocale } from '@/i18n'
 import type { CursorEffect } from '@/types/cursorEffect'
 import type { GlobalConfig } from '@/api'
 import type { SelectValue } from 'ant-design-vue/es/select'
@@ -40,6 +44,13 @@ const {
   handleLowPerformanceModeChange,
   handleSettingChange,
 } = defineProps<TabBasicProps>()
+
+const { t } = useI18n()
+const { locale, setLocale } = useLocale()
+
+const handleLocaleChange = (value: unknown): void => {
+  void setLocale(value as AppLocale)
+}
 </script>
 
 <template>
@@ -103,6 +114,23 @@ const {
                   />
                   {{ option.label }}
                 </div>
+              </a-select-option>
+            </a-select>
+          </div>
+        </a-col>
+      </a-row>
+      <a-row :gutter="24">
+        <a-col :span="12">
+          <div class="form-item-vertical">
+            <div class="form-label-wrapper">
+              <span class="form-label">{{ t('common.language') }}</span>
+              <a-tooltip :title="t('common.languageTip')">
+                <QuestionCircleOutlined class="help-icon" />
+              </a-tooltip>
+            </div>
+            <a-select :value="locale" size="large" style="width: 100%" @change="handleLocaleChange">
+              <a-select-option v-for="item in SUPPORTED_LOCALES" :key="item" :value="item">
+                {{ t(`locale.${item}`) }}
               </a-select-option>
             </a-select>
           </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -967,6 +967,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@intlify/core-base@npm:11.4.10":
+  version: 11.4.10
+  resolution: "@intlify/core-base@npm:11.4.10"
+  dependencies:
+    "@intlify/devtools-types": "npm:11.4.10"
+    "@intlify/message-compiler": "npm:11.4.10"
+    "@intlify/shared": "npm:11.4.10"
+  checksum: 10c0/b5d8eec451cde1740f8c728f1e48885c7295ed0e9ef0df64636185d532326c62c169a8e6af977bf86c7a965fa28e5ff7cdb1696d0bd50e397748330d0fc305a8
+  languageName: node
+  linkType: hard
+
+"@intlify/devtools-types@npm:11.4.10":
+  version: 11.4.10
+  resolution: "@intlify/devtools-types@npm:11.4.10"
+  dependencies:
+    "@intlify/core-base": "npm:11.4.10"
+    "@intlify/shared": "npm:11.4.10"
+  checksum: 10c0/7e38286a02e343d7419dc7cf5d8d49b7a6e73d187c3938a9ce136b6f798da631c1f519430db6603734284c5ccb4ac3dd072f45937ef7b84e64ff6228690da659
+  languageName: node
+  linkType: hard
+
+"@intlify/message-compiler@npm:11.4.10":
+  version: 11.4.10
+  resolution: "@intlify/message-compiler@npm:11.4.10"
+  dependencies:
+    "@intlify/shared": "npm:11.4.10"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/4f8374092d016a3e0e7bf21156d24f37bbf98f9c55c798177a2025c2e265ce92585a5a5410cc3fefa5ee966351ba7adeb8a7452961cc0aee95d5fef29c3551e9
+  languageName: node
+  linkType: hard
+
+"@intlify/shared@npm:11.4.10":
+  version: 11.4.10
+  resolution: "@intlify/shared@npm:11.4.10"
+  checksum: 10c0/6679f0dad71e7cf24b90345830be06f1504e0ef8300d13d25289c4ccd93cf94c81571ddbfcc168955050463010437aa408e6e9f36754e6aea5907d16073aca16
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2694,7 +2732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/devtools-api@npm:^6.6.4":
+"@vue/devtools-api@npm:^6.5.0, @vue/devtools-api@npm:^6.6.4":
   version: 6.6.4
   resolution: "@vue/devtools-api@npm:6.6.4"
   checksum: 10c0/0a993ae23618166e1bee5a7c14cebd8312752b93c143cbdd48fb2d0f7ade070d0e6baf757cd920d4681fef8f9acf29515162160f38cc7410f9a684d2df21b6de
@@ -4944,6 +4982,7 @@ __metadata:
     vitest: "npm:^4.1.9"
     vue: "npm:^3.5.17"
     vue-eslint-parser: "npm:^10.2.0"
+    vue-i18n: "npm:^11.4.10"
     vue-router: "npm:4"
     vue-tsc: "npm:^2.2.12"
     vuedraggable: "npm:^4.1.0"
@@ -7598,7 +7637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
@@ -8377,6 +8416,20 @@ __metadata:
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
   checksum: 10c0/ded1c52dfa6e08c384da43b8369814bd105e2dc3bbb04e95faa8365af0fcba70293ff8b3749824ae3cc98988aeaaa261d5a205febff23e15667176392dcfee4a
+  languageName: node
+  linkType: hard
+
+"vue-i18n@npm:^11.4.10":
+  version: 11.4.10
+  resolution: "vue-i18n@npm:11.4.10"
+  dependencies:
+    "@intlify/core-base": "npm:11.4.10"
+    "@intlify/devtools-types": "npm:11.4.10"
+    "@intlify/shared": "npm:11.4.10"
+    "@vue/devtools-api": "npm:^6.5.0"
+  peerDependencies:
+    vue: ^3.0.0
+  checksum: 10c0/e44434fc0175c6cbd0a67e5a3fef93861cb2e53d85e8b5fac886743f7e41fae4bd33fe34771f18369153c17eef7363dd0c3aade4e83c25076ddb1b18427035c3
   languageName: node
   linkType: hard
 

--- a/res/version.json
+++ b/res/version.json
@@ -5,7 +5,8 @@
             "新增功能": [
                 "日志处理 新增日志处理钩子层并支持成功/失败标志正则匹配 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaFW专项 新增 MaaFW 脚本类型，可直接托管 MaaFramework 项目：编辑页读取项目 interface.json 后选择控制器、资源与任务，支持 ADB 模拟器与 Win32 PC 游戏两条控制链路；运行时由 AUTO-MAS 进程内的 runner 在独立子进程中驱动项目的 MaaFramework，不启动项目自带界面，也不占用项目自身的配置文件；已在 M9A、MaaYYs、Maa_bbb、MaaEnd 五个项目包上真机验证，覆盖项目自带解释器、项目自带二进制、隔离虚拟环境与双 Agent 四类运行环境 by [@qiyinxi](https://github.com/qiyinxi)",
-                "自定义 Webhook 新增 {gamedate} 变量，可在推送模板中引用与历史记录归档一致的游戏日 by [@qiyinxi](https://github.com/qiyinxi)"
+                "自定义 Webhook 新增 {gamedate} 变量，可在推送模板中引用与历史记录归档一致的游戏日 by [@qiyinxi](https://github.com/qiyinxi)",
+                "界面设置 新增语言选项并接入 i18n 框架，首次启动跟随系统语言，英文界面将逐步补全 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "程序优化": [
                 "架构优化 新增 utils/services 平台层，按通用与 Windows 能力拆分底层实现，非 Windows 环境跳过 Windows 专用初始化 by [@HarcoChen](https://github.com/HarcoChen)",


### PR DESCRIPTION
只搭骨架，词表暂时只有语言选择器自身的条目，界面其余部分不变。目标是让英文用户逐步看到一部分英文，中英混杂可以接受，因此**后端零改动**，英文词表缺失的 key 自动回退中文。

语言存在前端配置（Electron 侧），未设置时跟随系统语言。`useLocale` 统一驱动 vue-i18n、dayjs 与 antd 组件文案，顺带移除了 `main.ts` 里写死的 `dayjs.locale('zh-cn')` 和 `App.vue` 里写死的 antd `zhCN`。

前端 Skill 的 Red Lines 补了两条：新文案走词表；**参与判断的中文字面量保持原样**——`tab.status === '运行'` 这类翻了会静默损坏，全仓有 99 处。

前端 lint 0 error、typecheck 0 error、vitest 127 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

使用共享的前端本地化系统，添加持久化语言选择功能，并协调各本地化 UI 库。

新功能：
- 添加前端语言选择器，支持简体中文和英语；用户选择会持久化到 Electron 配置中，并在首次启动时检测系统语言。

增强功能：
- 引入 vue-i18n，提供中文源消息、部分英文覆盖，并对未翻译的键自动回退到中文。
- 在 vue-i18n、dayjs 和 Ant Design 组件之间同步所选语言环境。
- 记录前端本地化规则，包括目录使用方式，以及保留参与逻辑处理的中文字面量。

构建：
- 添加 vue-i18n 作为前端依赖，并更新依赖锁定文件。

维护：
- 更新应用版本元数据。],
- 概览
- 使用共享的前端本地化系统，添加持久化语言选择功能，并协调各本地化 UI 库。
- 测试

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

建立前端本地化基础，并公开持久化的中英文语言设置，同时不改变后端行为。

新功能：
- 添加持久化的前端语言选择器，支持简体中文和英语，并在首次启动时检测系统语言。

增强：
- 引入共享的本地化层，协调 vue-i18n、dayjs 和 Ant Design 的语言环境；当缺少对应键时，英语翻译回退到中文。
- 记录前端本地化规范，包括目录使用方式，以及保留参与逻辑处理的中文字面量。

构建：
- 将 vue-i18n 添加为前端依赖，并更新依赖锁定文件。

测试：
- 添加对支持语言规范化和回退行为的覆盖。

杂项：
- 更新应用版本元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入前端本地化基础设施以及持久化的中英文语言设置，同时保持后端行为不变。

新功能：
- 添加持久化的前端语言选择器，支持简体中文和英语，并在首次启动时检测系统语言。

增强：
- 建立共享的本地化层，包含中文源消息、部分英文翻译，并在缺少翻译时自动回退到中文。
- 在 vue-i18n、dayjs 和 Ant Design 组件之间同步所选语言，同时不改变后端行为。
- 记录前端本地化实践，包括目录使用方式，以及保留驱动应用逻辑的中文文本字面量。

构建：
- 添加 vue-i18n 前端依赖，并更新依赖锁定文件。

测试：
- 增加对支持语言规范化和回退行为的测试覆盖。

杂项：
- 更新应用版本元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在保持后端行为不变的同时，建立共享的前端本地化功能，并持久化保存中英文语言设置。

新功能：
- 添加持久化的前端语言选择器，支持简体中文和英语，并在首次启动时检测系统语言。

增强功能：
- 引入共享的本地化层，包含中文源消息、部分英文翻译，以及英文键缺失时自动回退到中文的机制。
- 在不改变后端行为的情况下，将所选区域设置同步到 vue-i18n、dayjs 和 Ant Design 组件。
- 记录前端本地化规范，包括目录使用方式，以及保留参与应用逻辑的中文字面量。

构建：
- 添加 vue-i18n 作为前端依赖，并更新依赖锁定文件。

测试：
- 增加对受支持语言规范化和回退行为的测试覆盖。

日常维护：
- 更新应用版本元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Establish shared frontend localization and persistent Chinese-English language settings while keeping backend behavior unchanged.

New Features:
- Add a persistent frontend language selector supporting Simplified Chinese and English, with system-language detection on first launch.

Enhancements:
- Introduce a shared localization layer with Chinese source messages, partial English translations, and automatic fallback to Chinese for missing English keys.
- Synchronize the selected locale across vue-i18n, dayjs, and Ant Design components without changing backend behavior.
- Document frontend localization conventions, including catalog usage and preserving Chinese literals that participate in application logic.

Build:
- Add vue-i18n as a frontend dependency and update the dependency lockfile.

Tests:
- Add coverage for supported-language normalization and fallback behavior.

Chores:
- Update application version metadata.

</details>

</details>

</details>

</details>