### PR TITLE
docs(skill): 订正前端 Skill 已过时的 lint/typecheck 基线

### DIFF
--- a/.agents/skills/mas-frontend-standards/SKILL.md
+++ b/.agents/skills/mas-frontend-standards/SKILL.md
@@ -97,28 +97,29 @@ Use the narrowest module boundary first. Promote to shared directories only afte
 
 All commands run from `frontend/`.
 
-**The repo-wide lint and typecheck baseline is not clean.** As of `v5.4.0-beta.8`, untouched `dev` reports roughly 4900 ESLint problems across ~77 hand-written files (overwhelmingly `prettier/prettier` indentation drift) and 92 `vue-tsc` errors across 7 files (~84 of them in the two `OkNte` edit views). Do not treat a non-empty `yarn lint` or `yarn typecheck` output as evidence that you broke something, and do not try to clean the repo as a side effect of an unrelated task.
+**The repo-wide baseline is clean.** On untouched `dev` (verified 2026-08-30), `yarn lint` reports 0 errors and 1 long-standing `vue/no-v-html` warning, `yarn typecheck` reports 0 errors, and `yarn test` is fully green. `weekly-format.yml` re-runs `ruff format`, `yarn lint:fix` and `yarn format` on `dev` every Monday, so formatting drift does not accumulate.
+
+**Therefore any lint or typecheck error you see is almost certainly yours.** Do not dismiss it as pre-existing noise without first checking the same command on an untouched checkout.
 
 | Touched surface | Command | Passing criterion |
 | --- | --- | --- |
-| Any business code | `npx eslint <your changed files>` | clean, exit 0 |
-| Types, props/emits, API usage, generated-client consumption | `yarn typecheck` | no **new** error naming a file you touched |
+| Any business code | `yarn lint` | 0 errors (1 pre-existing `no-v-html` warning is expected) |
+| Types, props/emits, API usage, generated-client consumption | `yarn typecheck` | 0 errors |
 | A module with a sibling `*.test.ts`, or shared logic/styles under test | `yarn test` | fully green |
 | Build, routing, or Electron entry | `yarn build` | succeeds |
 | Documentation only | file existence, headings, sections, `git status --short` | — |
 | UI | also follow `mas-frontend-ui` verification | — |
 
-Rules that follow from the dirty baseline:
+Rules:
 
-1. Scope lint to the files you changed. `npx eslint <paths>` exits 0 on a clean file and nonzero on a dirty one, so it is a real gate; `yarn lint` is not, because it cannot pass.
-2. `yarn typecheck` has no scoping flag, so run it whole and grep the output for your own file paths. Compare against the baseline instead of expecting zero.
-3. Lint and typecheck are orthogonal. `OkNteUserEdit.vue` is lint-clean with 41 type errors; `scheduler-debug.ts` is the reverse. Passing one says nothing about the other.
-4. `yarn test` is the one gate that is green repo-wide. It must stay green — a failure there is always yours.
-5. If you touch a file that is already in the dirty baseline, leave the pre-existing problems alone and say so in your result. Fixing them is a separate, explicitly-requested task.
+1. Run `yarn lint`, `yarn typecheck` and `yarn test` whole. All three can and should pass; there is no baseline to subtract.
+2. Lint and typecheck are still orthogonal — they check different things, so passing one says nothing about the other. Run both.
+3. `yarn lint:fix` resolves `prettier/prettier` findings; use it rather than hand-formatting.
+4. A failure in any of the three is yours until proven otherwise. If you believe it pre-exists, verify on an untouched checkout and say so explicitly in your result.
 
 Prefer `yarn typecheck` over a full `yarn build` for type validation; it is much faster and covers the renderer via `tsconfig.app.json`.
 
-If a command cannot run, state the exact command and the reason. Never claim "complete", "fixed", or "passed" without verification evidence, and never restate a pre-existing baseline failure as a result of your change.
+If a command cannot run, state the exact command and the reason. Never claim "complete", "fixed", or "passed" without verification evidence.
 
 ## Frontend Tests
 
@@ -144,9 +145,9 @@ Pattern 3 is how several `mas-frontend-ui` layout rules are actually enforced. W
 | "Pinia should hold every frontend value." | Keep isolated short-lived state local, and keep persistent authoritative data in its backend or Electron configuration owner. |
 | "I can tweak generated API files." | `src/api` is generated; regenerate through the project command instead. |
 | "This UI-only change can ignore engineering rules." | UI tasks still obey module, state, API, and verification boundaries. |
-| "`yarn lint` is failing, so I broke the build." | ~4900 problems and 92 type errors pre-exist on clean `dev`. Scope lint to your own files and compare typecheck against the baseline. |
-| "Lint passed, so the types are fine." | The two are orthogonal. Lint-clean files carry dozens of type errors in this repo. |
-| "I'll fix the surrounding lint noise while I'm here." | Baseline cleanup is a separate, explicitly-requested task; it buries your real diff. |
+| "`yarn lint` is failing, but the repo baseline is dirty anyway." | It is not. Clean `dev` passes lint, typecheck and tests. A failure is yours until you verify otherwise on an untouched checkout. |
+| "Lint passed, so the types are fine." | The two are orthogonal and check different things. Run both. |
+| "I'll fix the surrounding lint noise while I'm here." | `weekly-format.yml` already formats `dev` every Monday. Unrelated cleanup buries your real diff. |
 | "I need jsdom to test this component." | Tests run in node with no DOM. Extract logic to a sibling `.ts`, or assert on source text. |
 
 ## Final Response

--- a/.agents/skills/mas-frontend-standards/SKILL.md
+++ b/.agents/skills/mas-frontend-standards/SKILL.md
@@ -103,7 +103,7 @@ All commands run from `frontend/`.
 
 | Touched surface | Command | Passing criterion |
 | --- | --- | --- |
-| Any business code | `yarn lint` | 0 errors (1 pre-existing `no-v-html` warning is expected) |
+| Any business code | `yarn eslint . --max-warnings 1` | exit 0. Warnings count: the budget of 1 is the single pre-existing `vue/no-v-html`, so any new warning fails the gate. `yarn lint` alone only surfaces errors — Yarn does not forward `--max-warnings` to the script, hence the direct `yarn eslint` form. |
 | Types, props/emits, API usage, generated-client consumption | `yarn typecheck` | 0 errors |
 | A module with a sibling `*.test.ts`, or shared logic/styles under test | `yarn test` | fully green |
 | Build, routing, or Electron entry | `yarn build` | succeeds |
@@ -114,7 +114,7 @@ Rules:
 
 1. Run `yarn lint`, `yarn typecheck` and `yarn test` whole. All three can and should pass; there is no baseline to subtract.
 2. Lint and typecheck are still orthogonal — they check different things, so passing one says nothing about the other. Run both.
-3. `yarn lint:fix` resolves `prettier/prettier` findings; use it rather than hand-formatting.
+3. `yarn lint:fix` resolves `prettier/prettier` findings; use it rather than hand-formatting. Warnings are part of the gate — do not leave a new one behind.
 4. A failure in any of the three is yours until proven otherwise. If you believe it pre-exists, verify on an untouched checkout and say so explicitly in your result.
 
 Prefer `yarn typecheck` over a full `yarn build` for type validation; it is much faster and covers the renderer via `tsconfig.app.json`.

--- a/.agents/skills/mas-frontend-standards/SKILL.md
+++ b/.agents/skills/mas-frontend-standards/SKILL.md
@@ -97,13 +97,15 @@ Use the narrowest module boundary first. Promote to shared directories only afte
 
 All commands run from `frontend/`.
 
-**The repo-wide baseline is clean.** On untouched `dev` (verified 2026-08-30), `yarn lint` reports 0 errors and 1 long-standing `vue/no-v-html` warning, `yarn typecheck` reports 0 errors, and `yarn test` is fully green. `weekly-format.yml` re-runs `ruff format`, `yarn lint:fix` and `yarn format` on `dev` every Monday, so formatting drift does not accumulate.
+**The repo-wide baseline is clean.** On untouched `dev` (verified 2026-08-30), `yarn lint` reports 0 errors and exactly 1 warning (`vue/no-v-html` in `LogPatternDocsModal.vue`, which arrived with #399 on 2026-08-27), `yarn typecheck` reports 0 errors, and `yarn test` is fully green. `weekly-format.yml` re-runs `ruff format`, `yarn lint:fix` and `yarn format` on `dev` every Monday, so formatting drift does not accumulate.
 
-**Therefore any lint or typecheck error you see is almost certainly yours.** Do not dismiss it as pre-existing noise without first checking the same command on an untouched checkout.
+**Therefore any lint or typecheck error you see is almost certainly yours.** Do not dismiss it as pre-existing noise without first checking the same command on an untouched checkout — the repository runs no lint, typecheck or test CI, so this baseline is held by convention alone and can drift.
+
+Maintenance note: the warning budget of 1 exists only because that single `vue/no-v-html` is unfixed. Once it is suppressed or resolved, tighten the gate to `--max-warnings 0`; leaving the budget at 1 silently permits one arbitrary new warning.
 
 | Touched surface | Command | Passing criterion |
 | --- | --- | --- |
-| Any business code | `yarn eslint . --max-warnings 1` | exit 0. Warnings count: the budget of 1 is the single pre-existing `vue/no-v-html`, so any new warning fails the gate. `yarn lint` alone only surfaces errors — Yarn does not forward `--max-warnings` to the script, hence the direct `yarn eslint` form. |
+| Any business code | `yarn lint --max-warnings 1` | exit 0. The budget of 1 covers the single known warning (`vue/no-v-html`, introduced with #399), so any additional warning fails the gate. Plain `yarn lint` prints warnings but does not fail on them. |
 | Types, props/emits, API usage, generated-client consumption | `yarn typecheck` | 0 errors |
 | A module with a sibling `*.test.ts`, or shared logic/styles under test | `yarn test` | fully green |
 | Build, routing, or Electron entry | `yarn build` | succeeds |
@@ -112,7 +114,7 @@ All commands run from `frontend/`.
 
 Rules:
 
-1. Run `yarn lint`, `yarn typecheck` and `yarn test` whole. All three can and should pass; there is no baseline to subtract.
+1. Run all three gates whole — `yarn lint --max-warnings 1`, `yarn typecheck`, `yarn test`. They can and should pass; there is no baseline to subtract. Use the `--max-warnings` form, not plain `yarn lint`, or new warnings slip through.
 2. Lint and typecheck are still orthogonal — they check different things, so passing one says nothing about the other. Run both.
 3. `yarn lint:fix` resolves `prettier/prettier` findings; use it rather than hand-formatting. Warnings are part of the gate — do not leave a new one behind.
 4. A failure in any of the three is yours until proven otherwise. If you believe it pre-exists, verify on an untouched checkout and say so explicitly in your result.

--- a/res/version.json
+++ b/res/version.json
@@ -19,6 +19,7 @@
             "开发流程": [
                 "开发环境改用独立的后端端口与 userData 目录，可与已安装的正式版同时运行 by [@qiyinxi](https://github.com/qiyinxi)",
                 "添加pyproject和ruff配置 by [@HarcoChen](https://github.com/HarcoChen)",
+                "订正前端 Skill 中已过时的 lint / typecheck 基线描述，避免把自己引入的错误当成既有噪音 by [@qiyinxi](https://github.com/qiyinxi)",
                 "清理两处后端测试缺陷：SRC 配置测试不再向系统临时目录写入固定名目录，并移除已不在目标内的 headless 导入守卫测试 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "修复BUG": [


### PR DESCRIPTION
`mas-frontend-standards/SKILL.md` 的 Verification Gate 写于 `v5.4.0-beta.8`，称干净 `dev` 上有约 4900 条 ESLint 问题和 92 个 `vue-tsc` 错误，并据此要求「不要期望为零」「保留既有问题不要动」。

#426 清理之后这个前提已经不成立。2026-08-30 在干净 `dev` 实测：

```
yarn lint       0 errors（1 条长期存在的 vue/no-v-html warning）
yarn typecheck  0 errors
yarn test       127 passed
```

旧描述的问题不只是数字不准——它会让 agent 把自己引入的回归当成基线噪音放过去。本 PR 把该节改成「基线是干净的，报错基本就是你自己的」，并同步订正 Red Lines 里对应的三行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

使前端技能指南与代码仓库当前的干净质量基线保持一致，确保代理能够可靠地检测回归问题。

改进：
- 更新前端技能的验证指南，以反映干净的 lint、类型检查和测试基线；要求验证整个代码仓库，并在另行确认之前将失败视为回归问题。
- 刷新该技能的红线规则，强化独立的 lint/类型检查，并在格式由自动化工具维护时避免进行无关的清理。

文档：
- 修正过时的前端 lint 和类型检查基线文档及验证标准。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使前端技能指南与仓库当前的干净质量基线保持一致，确保代理能够可靠地检测回归问题。

增强功能：
- 更新前端技能的验证指南，以反映整个仓库在 lint、类型检查和测试方面的干净基线；在另行验证之前，将失败视为回归问题。
- 更新前端技能的红线指南，要求独立执行 lint 和类型验证，同时避免无关的格式清理。

文档：
- 更正过时的前端 lint 和类型检查基线文档及验证标准。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使前端技能指南与仓库当前的整洁质量基线保持一致，确保代理能够可靠地检测回归问题。

增强功能：
- 更新前端标准技能，使其反映整个仓库在 lint、类型检查和测试方面的整洁基线，并将失败视为回归问题，除非经过验证确认并非如此。
- 要求独立执行完整仓库的质量门禁，并明确警告处理方式和格式要求。

文档：
- 更正过时的前端验证基线和红线指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the frontend skill guidance with the repository’s current clean quality baseline so agents reliably detect regressions.

Enhancements:
- Update the frontend standards skill to reflect a clean repository-wide lint, typecheck, and test baseline, treating failures as regressions until verified otherwise.
- Require independent full-repository quality gates and clarify warning handling and formatting expectations.

Documentation:
- Correct the outdated frontend verification baseline and red-line guidance.

</details>

</details>

</details>