### PR TITLE
feat(i18n): 状态标签跟随界面语言显示

### DIFF
--- a/frontend/src/components/TaskTree.vue
+++ b/frontend/src/components/TaskTree.vue
@@ -21,7 +21,7 @@
               </span>
             </div>
             <a-tag :color="getStatusColor(script.status)" size="small" class="status-tag">
-              {{ script.status }}
+              {{ statusLabel(script.status) }}
             </a-tag>
           </div>
         </div>
@@ -42,7 +42,7 @@
             <div class="user-content">
               <span class="user-name">{{ user.name }}</span>
               <a-tag :color="getStatusColor(user.status)" size="small" class="status-tag">
-                {{ user.status }}
+                {{ statusLabel(user.status) }}
               </a-tag>
             </div>
           </div>
@@ -56,7 +56,11 @@
 import { CaretDownOutlined, CaretRightOutlined } from '@ant-design/icons-vue'
 import { ref, watch } from 'vue'
 
+import { useStatusLabel } from '@/i18n/status'
+
 const logger = window.electronAPI.getLogger('任务树组件')
+
+const statusLabel = useStatusLabel()
 
 interface User {
   user_id: string

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -11,6 +11,14 @@ export default {
     languageTip: 'Interface display language',
     languageSaveFailed: 'Failed to save the language setting; reverted to the previous one.',
   },
+  status: {
+    waiting: 'Waiting',
+    running: 'Running',
+    done: 'Done',
+    error: 'Error',
+    idle: 'Idle',
+    finished: 'Finished',
+  },
   locale: {
     'zh-CN': '简体中文',
     'en-US': 'English',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -13,6 +13,14 @@ export default {
     languageTip: '界面显示语言',
     languageSaveFailed: '语言设置保存失败，已恢复原语言',
   },
+  status: {
+    waiting: '等待',
+    running: '运行',
+    done: '完成',
+    error: '异常',
+    idle: '空闲',
+    finished: '结束',
+  },
   locale: {
     'zh-CN': '简体中文',
     'en-US': 'English',

--- a/frontend/src/i18n/status.test.ts
+++ b/frontend/src/i18n/status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import enUS from './locales/en-US'
+import zhCN from './locales/zh-CN'
+
+// useStatusLabel 依赖 Vue 组件上下文（useI18n），这里直接校验它依赖的词表契约：
+// 每个状态值都要能在两套词表里找到对应条目，否则渲染时会退回显示原始中文。
+const STATUS_VALUES = ['等待', '运行', '完成', '异常', '空闲', '结束'] as const
+const STATUS_KEYS = ['waiting', 'running', 'done', 'error', 'idle', 'finished'] as const
+
+describe('状态词表', () => {
+  it('中文词表里每个 key 的译文就是后端/调度台实际使用的值', () => {
+    // 这一条同时保证：切到中文时界面显示与改造前逐字一致
+    const zh = zhCN.status as Record<string, string>
+    expect(STATUS_KEYS.map(k => zh[k])).toEqual([...STATUS_VALUES])
+  })
+
+  it('英文词表覆盖了全部状态 key，没有漏项', () => {
+    const en = enUS.status as Record<string, string>
+    for (const key of STATUS_KEYS) {
+      expect(en[key], `en-US 缺少 status.${key}`).toBeTruthy()
+    }
+  })
+
+  it('两套词表的 status key 集合一致', () => {
+    expect(Object.keys(enUS.status).sort()).toEqual(Object.keys(zhCN.status).sort())
+  })
+})

--- a/frontend/src/i18n/status.ts
+++ b/frontend/src/i18n/status.ts
@@ -1,0 +1,39 @@
+//   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+//   Copyright © 2025-2026 AUTO-MAS Team
+
+import { useI18n } from 'vue-i18n'
+
+/**
+ * 状态值 → 词表 key 的映射。
+ *
+ * 这些中文**同时也是程序的判定依据**（后端 `app/models/task.py` 的
+ * `UserItem/ScriptItem.status`，以及前端 `SchedulerStatus`），全仓有近百处
+ * `=== '运行'` 这类比较。所以值本身一个字都不能改，只在渲染的那一刻换成
+ * 当前语言的标签；比较逻辑继续比中文，行为完全不变。
+ *
+ * 两套词汇的取值不重叠，因此共用一张表：
+ * - 等待 / 运行 / 完成 / 异常：后端任务状态
+ * - 空闲 / 运行 / 结束 / 异常：调度台标签状态
+ */
+const STATUS_KEY: Record<string, string> = {
+  等待: 'waiting',
+  运行: 'running',
+  完成: 'done',
+  异常: 'error',
+  空闲: 'idle',
+  结束: 'finished',
+}
+
+/**
+ * 取状态值对应的显示标签。
+ *
+ * 表里没有的值原样返回——后端将来新增状态时宁可显示原文，也不要显示空白。
+ */
+export function useStatusLabel(): (raw: string | null | undefined) => string {
+  const { t } = useI18n()
+  return (raw: string | null | undefined): string => {
+    if (!raw) return ''
+    const key = STATUS_KEY[raw]
+    return key ? t(`status.${key}`) : raw
+  }
+}

--- a/frontend/src/views/scheduler/index.vue
+++ b/frontend/src/views/scheduler/index.vue
@@ -69,7 +69,7 @@
             <div class="tab-content">
               <span class="tab-title">{{ tab.title }}</span>
               <a-tag :color="TAB_STATUS_COLOR[tab.status]" size="small" class="tab-status">
-                {{ tab.status }}
+                {{ statusLabel(tab.status) }}
               </a-tag>
             </div>
           </template>
@@ -143,12 +143,15 @@ import SchedulerTaskControl from './SchedulerTaskControl.vue'
 import SchedulerLogPanel from './SchedulerLogPanel.vue'
 import TaskOverviewPanel from './TaskOverviewPanel.vue'
 import OverlayRainMask from '@/components/OverlayRainMask.vue'
+import { useStatusLabel } from '@/i18n/status'
 import type { SchedulerTab } from './schedulerConstants'
 
 // 用于 keep-alive 识别
 defineOptions({ name: 'SchedulerPage' })
 
 const logger = window.electronAPI.getLogger('调度中心')
+
+const statusLabel = useStatusLabel()
 
 // 使用业务逻辑层
 const {

--- a/res/version.json
+++ b/res/version.json
@@ -6,7 +6,8 @@
                 "日志处理 新增日志处理钩子层并支持成功/失败标志正则匹配 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaFW专项 新增 MaaFW 脚本类型，可直接托管 MaaFramework 项目：编辑页读取项目 interface.json 后选择控制器、资源与任务，支持 ADB 模拟器与 Win32 PC 游戏两条控制链路；运行时由 AUTO-MAS 进程内的 runner 在独立子进程中驱动项目的 MaaFramework，不启动项目自带界面，也不占用项目自身的配置文件；已在 M9A、MaaYYs、Maa_bbb、MaaEnd 五个项目包上真机验证，覆盖项目自带解释器、项目自带二进制、隔离虚拟环境与双 Agent 四类运行环境 by [@qiyinxi](https://github.com/qiyinxi)",
                 "自定义 Webhook 新增 {gamedate} 变量，可在推送模板中引用与历史记录归档一致的游戏日 by [@qiyinxi](https://github.com/qiyinxi)",
-                "界面设置 新增语言选项并接入 i18n 框架，首次启动跟随系统语言，英文界面将逐步补全 by [@qiyinxi](https://github.com/qiyinxi)"
+                "界面设置 新增语言选项并接入 i18n 框架，首次启动跟随系统语言，英文界面将逐步补全 by [@qiyinxi](https://github.com/qiyinxi)",
+                "界面显示 任务与调度台的状态标签跟随界面语言显示，判定逻辑不变 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "程序优化": [
                 "架构优化 新增 utils/services 平台层，按通用与 Windows 能力拆分底层实现，非 Windows 环境跳过 Windows 专用初始化 by [@HarcoChen](https://github.com/HarcoChen)",


### PR DESCRIPTION
任务树与调度台标签直接把状态值印在界面上，所以英文界面下这几处仍然显示「运行」「等待」。

但这些中文同时是程序的判定依据——后端 `UserItem/ScriptItem.status` 与前端 `SchedulerStatus`，全仓有近百处 `=== '运行'` 这类比较——值一个字都不能改。所以只在渲染的那一刻换成当前语言的标签，取值、颜色映射和全部比较逻辑保持原样。

改了三个渲染点：`TaskTree.vue` 的脚本与用户状态、`scheduler/index.vue` 的标签页状态。表里没有的值原样返回，后端将来新增状态时不会显示空白。

中文界面下显示与改造前逐字一致，有测试锁定这一点。

前端 oxlint 0、typecheck 0、vitest 134 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

在不改变底层状态值或比较逻辑的情况下，使用所选界面语言显示任务和调度器状态标签。

新功能：
- 根据当前界面语言本地化任务树和调度器状态标签，同时保留现有的状态值和行为。

改进：
- 添加共享的状态标签映射，并对未知状态值提供平滑回退。
- 保持中文状态标签与之前的 UI 完全一致，并确保中文和英文翻译目录完整且一致。

测试：
- 增加测试覆盖，验证状态翻译的完整性、目录一致性以及中文标签未发生变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display task and scheduler status labels in the selected interface language without changing the underlying status values or comparison logic.

New Features:
- Localize task tree and scheduler status labels according to the active interface language while preserving the existing status values and behavior.

Enhancements:
- Add shared status-label mapping with graceful fallback for unknown status values.
- Keep Chinese status labels identical to the previous UI and ensure Chinese and English translation catalogs remain complete and consistent.

Tests:
- Add coverage validating status translation completeness, catalog consistency, and unchanged Chinese labels.

</details>