### PR TITLE
fix(i18n): 转义说明文案里的字面量 |，并加上全表守卫

### DIFF
--- a/frontend/src/i18n/locales.test.ts
+++ b/frontend/src/i18n/locales.test.ts
@@ -38,8 +38,35 @@ describe('词表', () => {
     }
   })
 
-  // vue-i18n 把 | 当复数分隔符、{x} 当占位符、@: 当链接消息。
-  // 字面量必须写成 {'|'} 这种字面插值，否则渲染时会静默丢内容。
+  // 复数消息，| 是有意的分隔符；其余词条里的 | 都必须转义
+  const PLURAL_KEYS = new Set([
+    'home.endfield.ongoing',
+    'plan.count',
+    'queue.count',
+    'scripts.userCount',
+  ])
+
+  // 这一条兜住整张词表：漏转义时 t() 会静默截断（| 后面全丢），
+  // 页面上看不出报错，只是文案短了一截。
+  it('除复数消息外，没有未转义的 | { } @', () => {
+    const literal = /\{'[^']*'\}/g
+    const param = /\{[A-Za-z_]\w*\}/g
+    const offenders: string[] = []
+    for (const [locale, entries] of [
+      ['zh-CN', zhEntries],
+      ['en-US', enEntries],
+    ] as const) {
+      for (const [key, value] of entries) {
+        if (PLURAL_KEYS.has(key)) continue
+        const rest = value.replace(literal, '').replace(param, '')
+        if (/[|{}]/.test(rest) || /@[:.]/.test(rest)) {
+          offenders.push(`${locale} ${key}: ${value}`)
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
   it('字面量里的 | { } @ 都做了转义', () => {
     expect(t('edit.enterInstanceInfoAs')).toBe('请输入实例信息，格式：启动附加命令 | ADB地址')
     expect(t('edit.exampleTaskDoneSuccess')).toBe('例如：任务完成|成功|失败')

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -481,7 +481,7 @@ export default {
       'This currently works on CN servers only, and only at an unscaled 1280x720 resolution',
     accountEmailPhoneNumber: 'account / email / phone number.',
     accountEmailPhoneNumber2:
-      'account / email / phone number, separated by "|". Signing in with a password prefers the B',
+      "account / email / phone number, separated by '{'|'}'. Signing in with a password prefers the B",
     firstMaaSessionAnnihilation: 'First MAA session: annihilation',
     world3: 'World 3',
     secondMaaSessionDaily: 'Second MAA session: daily run',
@@ -1015,7 +1015,7 @@ export default {
     requiredEmptyValueDisables:
       'Required; an empty value disables the rule. A line matching this pattern opens the window (inclusive)',
     requiredEmptyValueDisables2:
-      'Required; an empty value disables the rule. Separate keywords with " | " — any match passes',
+      "Required; an empty value disables the rule. Separate keywords with ' {'|'} ' — any match passes",
     requiredEmptyValueDisables3:
       'Required; an empty value disables the rule. Matched against the whole log line as a Python regex',
     requiredEmptyValueDisables4:

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -469,7 +469,7 @@ export default {
     thisCurrentlyWorksCn: '目前该功能仅支持官服，且仅支持 1280×720 实际未缩放分辨率',
     accountEmailPhoneNumber: '站账号/邮箱号/手机号。',
     accountEmailPhoneNumber2:
-      '站账号/邮箱号/手机号，中间使用「|」分隔，通过账号密码登录时将优先使用 B',
+      "站账号/邮箱号/手机号，中间使用「{'|'}」分隔，通过账号密码登录时将优先使用 B",
     firstMaaSessionAnnihilation: '第一次启动 MAA：剿灭流程',
     world3: '第三世界',
     secondMaaSessionDaily: '第二次启动 MAA：日常流程',
@@ -960,7 +960,7 @@ export default {
     logDebug: '待调试日志',
     requiredEmptyValueDisables: '必填，留空则该规则不生效；匹配到此正则的行作为窗口起始（含该行）',
     requiredEmptyValueDisables2:
-      '必填，留空则该规则不生效；多个关键字以「 | 」分隔，任一命中即通过',
+      "必填，留空则该规则不生效；多个关键字以「 {'|'} 」分隔，任一命中即通过",
     requiredEmptyValueDisables3: '必填，留空则该规则不生效；按 Python 正则匹配整行日志',
     requiredEmptyValueDisables4: '必填，留空则该规则不生效；用于过滤行的正则表达式',
     iLaunchGameMyself: '我自己启动游戏',

--- a/res/version.json
+++ b/res/version.json
@@ -30,6 +30,7 @@
                 "清理 MaaFW 从未发布的外部运行代码路径（启动项目自带 UI 外壳）与随之失效的配置项，内置运行成为唯一实现 by [@qiyinxi](https://github.com/qiyinxi)"
             ],
             "修复BUG": [
+                "前端i18n 修复两条含「|」的说明文案在界面上被截断的问题——vue-i18n 把 | 当复数分隔符，字面量需要转义 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 Mirror 酱一次性下载地址被版本检查缓存复用导致更新包下载失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 HSR 托管任务列表中点击任务开关导致界面报错的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复系统通知标题或内容过长时推送失败的问题 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
vue-i18n 把 `|` 当复数分隔符，词表里作为字面量出现必须写成 `{'|'}`。有两条说明文案漏了转义，渲染时 `|` 后面被静默截断：

```
edit.accountEmailPhoneNumber2    站账号/邮箱号/手机号，中间使用「   ← 后半截没了
edit.requiredEmptyValueDisables2 必填，留空则该规则不生效；多个关键字以「
```

中英文都一样。页面上看不出报错，只是文案短了一截，所以 #487 手测时没发现。当时的转义脚本按单行正则匹配，这两条被 oxfmt 折了行，正好漏网。

`locales.test.ts` 顺手从「逐条断言三个 key」改成扫全表：除四条有意写成复数消息的（`queue.count` 这类）之外，任何词条里出现未转义的 `|` `{` `}` `@:` 都判红。这样同类问题不用再靠人眼发现。

前端 oxlint 0、typecheck 0、vitest 141 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

通过转义字面量管道符并验证完整的 locale 表中是否存在未转义语法，防止 i18n 消息被截断。

Bug 修复：
- 转义受影响的中文和英文 locale 消息中的字面量管道符，使 vue-i18n 不再截断其渲染文本。

增强功能：
- 添加整表 locale 守卫，用于检测显式支持的复数消息之外未转义的 vue-i18n 语法。

测试：
- 将 locale 验证从针对少数关键项的断言扩展为覆盖两个 locale 表，同时保留对代表性消息的渲染检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent i18n message truncation by escaping literal pipes and validating the complete locale tables for unescaped syntax.

Bug Fixes:
- Escape literal pipe characters in the affected Chinese and English locale messages so vue-i18n no longer truncates their rendered text.

Enhancements:
- Add a whole-table locale guard that detects unescaped vue-i18n syntax outside the explicitly supported plural messages.

Tests:
- Expand locale validation from a few key-specific assertions to coverage of both locale tables, while retaining rendering checks for representative messages.

</details>