### PR TITLE
fix(maafw): 中止任务后不再残留 Agent 进程

### DIFF
--- a/app/task/MaaFW/tools/embedded/runner_task.py
+++ b/app/task/MaaFW/tools/embedded/runner_task.py
@@ -1279,6 +1279,11 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
         if process is None or process.returncode is not None:
             return
 
+        # 必须在 terminate 之前把后代记下来：Windows 的 TerminateProcess 是立即
+        # 且不可捕获的，worker 的 shutdown() 没机会跑；而父进程一死，子进程就
+        # 被重新挂到别处，事后再按父子关系已经查不到它们。
+        descendants = await asyncio.to_thread(_snapshot_descendants, process.pid)
+
         try:
             process.terminate()
             await asyncio.wait_for(process.wait(), timeout=5)
@@ -1286,9 +1291,12 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
             process.kill()
             await process.wait()
         except ProcessLookupError:
-            return
+            pass
         except Exception as exc:
             logger.warning(f"MaaFW runner worker 清理失败: {exc}")
+
+        if descendants:
+            await asyncio.to_thread(_terminate_snapshot, descendants)
 
     def _filter_period_once_tasks(self, plan: MaaFWRunPlan) -> MaaFWRunPlan:
         daily_tasks = set(_load_json_list(self.script_config.get("Run", "DailyOnceTasks")))
@@ -1682,6 +1690,53 @@ def _resolve_win32_method(
     if interface_method:
         return method_values.get(interface_method, default)
     return default
+
+
+
+def _snapshot_descendants(pid: int) -> list[tuple[int, float]]:
+    """记下某进程当前的全部后代（pid 与创建时间）。
+
+    创建时间与 pid 配对使用，防止 pid 复用导致误杀——这段时间里原进程可能
+    已经退出、pid 被别人占了。
+    """
+
+    snapshot: list[tuple[int, float]] = []
+    try:
+        for child in psutil.Process(pid).children(recursive=True):
+            with suppress(psutil.Error):
+                snapshot.append((child.pid, child.create_time()))
+    except psutil.Error:
+        return []
+    return snapshot
+
+
+def _terminate_snapshot(snapshot: list[tuple[int, float]]) -> None:
+    """结束快照里仍然存活、且身份对得上的进程。
+
+    worker 被强杀后它启动的 agent 会变成孤儿：MaaFW 的 AgentClient 用 IPC 起
+    agent，生命周期本该随 worker，但 TerminateProcess 不给收尾机会。实测残留
+    过二十多个 agent.exe / python.exe，最老的有二十二小时，它们占内存也占文件
+    句柄——曾导致 venv 目录删不掉。
+    """
+
+    victims: list[psutil.Process] = []
+    for pid, create_time in snapshot:
+        try:
+            process = psutil.Process(pid)
+            if abs(process.create_time() - create_time) > 1:
+                continue  # pid 被复用了，不是当初那个进程
+            process.terminate()
+            victims.append(process)
+        except psutil.Error:
+            continue
+    if not victims:
+        return
+    _gone, alive = psutil.wait_procs(victims, timeout=3)
+    for process in alive:
+        with suppress(psutil.Error):
+            process.kill()
+    psutil.wait_procs(alive, timeout=2)
+    logger.info(f"已清理 MaaFW worker 残留的 {len(victims)} 个子进程")
 
 
 def _decode_subprocess_output(data: bytes) -> str:

--- a/res/version.json
+++ b/res/version.json
@@ -49,7 +49,8 @@
                 "MaaFW专项 修复内置运行未加载项目自带的 MaaFramework 而回落到 AUTO-MAS 运行环境中同版本号但二进制不同的一份的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaFW专项 修复内置运行装上与项目自带 MaaFramework 版本不符的 Python 绑定的问题，改为按项目实际发行的运行库版本安装 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaFW专项 修复运行期间界面日志停止更新、点击停止无响应的问题，原因是转发脚本输出时独占事件循环 by [@qiyinxi](https://github.com/qiyinxi)",
-                "MaaFW专项 修复删除脚本或项目升级后，旧的隔离运行环境永久占用磁盘不被清理的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MaaFW专项 修复删除脚本或项目升级后，旧的隔离运行环境永久占用磁盘不被清理的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MaaFW专项 修复中止任务后项目 Agent 进程残留、持续占用内存与文件句柄的问题 by [@qiyinxi](https://github.com/qiyinxi)"
             ]
         },
         "v5.5.0-beta.1": {

--- a/tests/task/test_maafw_orphan_process_cleanup.py
+++ b/tests/task/test_maafw_orphan_process_cleanup.py
@@ -1,0 +1,206 @@
+"""worker 被强杀后，它启动的 agent 不能留成孤儿。
+
+MaaFW 的 AgentClient 以 IPC 模式启动项目 agent，生命周期本该随 worker：
+worker 正常结束时 `MaaFWRunner.shutdown()` 会 terminate 它们，owner 看门狗
+触发时 `_terminate_descendants()` 也会。
+
+漏的是**宿主强杀 worker** 这条：用户中止任务时宿主调 `process.terminate()`，
+Windows 上那是 `TerminateProcess`——立即且不可捕获，worker 的 shutdown()
+根本没机会跑。
+
+实测后果：进程表里残留二十多个 agent.exe / python.exe，最老的二十二小时，
+占内存也占文件句柄——曾导致 venv 目录因 `[WinError 5] Access is denied` 删不掉。
+
+关键是**顺序**：必须在 terminate 之前把后代记下来。父进程一死子进程就被重新
+挂到别处，事后再按父子关系已经查不到它们。
+"""
+
+import ast
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import psutil
+
+import app.core  # noqa: F401  # 初始化宿主配置
+
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "app/task/MaaFW/tools/embedded/runner_task.py"
+)
+SOURCE = SOURCE_PATH.read_text(encoding="utf-8")
+
+
+def load():
+    import importlib
+    import sys
+
+    patcher = mock.patch.dict(
+        sys.modules,
+        {
+            name: mock.MagicMock()
+            for name in (
+                "maa",
+                "maa.agent_client",
+                "maa.context",
+                "maa.controller",
+                "maa.custom_action",
+                "maa.custom_recognition",
+                "maa.define",
+                "maa.event_sink",
+                "maa.job",
+                "maa.library",
+                "maa.notification_handler",
+                "maa.resource",
+                "maa.tasker",
+                "maa.toolkit",
+            )
+        },
+    )
+    patcher.start()
+    return (
+        importlib.import_module("app.task.MaaFW.tools.embedded.runner_task"),
+        patcher,
+    )
+
+
+class SnapshotBeforeTerminateTest(unittest.TestCase):
+    """顺序错了整个机制就失效，所以直接钉住源码里的先后。"""
+
+    def _body(self) -> str:
+        body = SOURCE[SOURCE.index("async def _terminate_runner_process") :]
+        return body[: body.index(chr(10) + "    def ", 10)]
+
+    def test_the_snapshot_is_taken_before_terminating(self) -> None:
+        body = self._body()
+        self.assertLess(
+            body.index("_snapshot_descendants"),
+            body.index("process.terminate()"),
+            "必须先记下后代再 terminate，否则事后查不到它们",
+        )
+
+    def test_survivors_are_cleaned_after_the_worker_exits(self) -> None:
+        body = self._body()
+        self.assertLess(body.index("process.terminate()"), body.index("_terminate_snapshot"))
+
+    def test_cleanup_runs_off_the_event_loop(self) -> None:
+        """psutil 的遍历与等待是阻塞调用，不能占着事件循环。"""
+
+        body = self._body()
+        for call in ("_snapshot_descendants", "_terminate_snapshot"):
+            with self.subTest(call=call):
+                self.assertIn(f"asyncio.to_thread({call}", body)
+
+
+class SnapshotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module, patcher = load()
+        self.addCleanup(patcher.stop)
+
+    def test_snapshot_records_pid_and_create_time(self) -> None:
+        child = mock.Mock(pid=4242)
+        child.create_time.return_value = 1000.0
+        with mock.patch.object(
+            self.module.psutil, "Process", return_value=mock.Mock(
+                children=mock.Mock(return_value=[child])
+            )
+        ):
+            self.assertEqual(self.module._snapshot_descendants(1), [(4242, 1000.0)])
+
+    def test_a_vanished_parent_yields_nothing(self) -> None:
+        with mock.patch.object(
+            self.module.psutil, "Process", side_effect=psutil.NoSuchProcess(1)
+        ):
+            self.assertEqual(self.module._snapshot_descendants(1), [])
+
+
+class TerminateSnapshotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module, patcher = load()
+        self.addCleanup(patcher.stop)
+
+    def _process(self, create_time: float):
+        proc = mock.Mock()
+        proc.create_time.return_value = create_time
+        return proc
+
+    def test_matching_processes_are_terminated(self) -> None:
+        proc = self._process(1000.0)
+        with (
+            mock.patch.object(self.module.psutil, "Process", return_value=proc),
+            mock.patch.object(
+                self.module.psutil, "wait_procs", return_value=([proc], [])
+            ),
+        ):
+            self.module._terminate_snapshot([(4242, 1000.0)])
+        proc.terminate.assert_called_once()
+
+    def test_a_reused_pid_is_left_alone(self) -> None:
+        """pid 可能已被别的进程占用——创建时间对不上就不能碰。"""
+
+        proc = self._process(9999.0)
+        with (
+            mock.patch.object(self.module.psutil, "Process", return_value=proc),
+            mock.patch.object(self.module.psutil, "wait_procs") as wait_procs,
+        ):
+            self.module._terminate_snapshot([(4242, 1000.0)])
+        proc.terminate.assert_not_called()
+        wait_procs.assert_not_called()
+
+    def test_stubborn_processes_are_killed(self) -> None:
+        proc = self._process(1000.0)
+        with (
+            mock.patch.object(self.module.psutil, "Process", return_value=proc),
+            mock.patch.object(
+                self.module.psutil, "wait_procs", return_value=([], [proc])
+            ),
+        ):
+            self.module._terminate_snapshot([(4242, 1000.0)])
+        proc.kill.assert_called_once()
+
+    def test_an_already_gone_process_is_not_an_error(self) -> None:
+        with mock.patch.object(
+            self.module.psutil, "Process", side_effect=psutil.NoSuchProcess(4242)
+        ):
+            self.module._terminate_snapshot([(4242, 1000.0)])  # 不得抛
+
+    def test_an_empty_snapshot_does_nothing(self) -> None:
+        with mock.patch.object(self.module.psutil, "wait_procs") as wait_procs:
+            self.module._terminate_snapshot([])
+        wait_procs.assert_not_called()
+
+
+class ExistingPathsStillCleanUpTest(unittest.TestCase):
+    """另外两条本来就覆盖的路径不能被改坏。"""
+
+    def test_runner_shutdown_still_terminates_agents(self) -> None:
+        runner = (
+            Path(__file__).resolve().parents[2]
+            / "app/task/MaaFW/tools/core/automas_maafw_runner/runner.py"
+        ).read_text(encoding="utf-8")
+        body = runner[runner.index("def shutdown(self)") :]
+        body = body[: body.index(chr(10) + "    def ", 10)]
+        self.assertIn("process.terminate()", body)
+        self.assertIn("agent_client.disconnect()", body)
+
+    def test_owner_watchdog_still_kills_descendants_before_exiting(self) -> None:
+        worker = (
+            Path(__file__).resolve().parents[2]
+            / "app/task/MaaFW/tools/core/automas_maafw_runner/worker.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(worker)
+        watch = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_watch_owner"
+        )
+        calls = [
+            node.func.id
+            for node in ast.walk(watch)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        ]
+        self.assertIn("_terminate_descendants", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
中止任务后，项目的 Agent 进程会残留下来。实测进程表里堆了 21 个 `agent.exe` / `python.exe`，最老的二十二小时——占内存也占文件句柄，#489 的 venv 清理里那次 `[WinError 5] Access is denied` 就是其中一个占着 `DirectML.dll` 导致的。

## 漏在哪

MaaFW 的 AgentClient 以 IPC 模式启动项目 agent，生命周期本该随 worker。两条路径本来是覆盖的：

- worker 正常结束 → `MaaFWRunner.shutdown()` terminate 它们
- owner 看门狗触发 → `_terminate_descendants()`

漏的是**宿主强杀 worker**：用户中止任务时宿主调 `process.terminate()`，Windows 上那是 `TerminateProcess`，立即且不可捕获，worker 的 `shutdown()` 根本没机会跑。

## 改法

关键是顺序——**terminate 之前先把后代快照下来**。父进程一死，子进程就被重新挂到别处，事后再按父子关系已经查不到它们。

快照记 pid 与创建时间，收尾时两者都对上才动手，防 pid 复用误杀。`psutil` 的遍历与等待是阻塞调用，走 `asyncio.to_thread`。

另两条本来就覆盖的路径加了回归钉住，免得以后被改坏。

## 测试

后端 692 passed / 3 skipped / 525 subtests。唯一失败 `test_activity_fight_preserves_native_options` 来自 dev 的 `2dbcab83`，与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

确保强制停止 MaaFW worker 时，同时清理其仍存活的 Agent 后代进程。

Bug 修复：
- 防止 worker 被强制终止后，遗留孤立的 MaaFW Agent 进程。
- 使用 PID 和创建时间检查清理后代进程，避免终止 PID 被重新使用的进程。

增强功能：
- 在不阻塞 asyncio 事件循环的情况下，执行后代进程发现和清理。
- 保留并回归测试现有的 Agent 清理路径，涵盖正常关闭和所有者 watchdog 终止场景。

测试：
- 增加针对快照排序、进程身份验证、进程消失和顽固进程，以及现有清理路径的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure force-stopping a MaaFW worker also cleans up its surviving Agent descendants.

Bug Fixes:
- Prevent orphaned MaaFW Agent processes from remaining after a worker is force-terminated.
- Clean up descendant processes using PID and creation-time checks to avoid terminating reused PIDs.

Enhancements:
- Run descendant discovery and cleanup without blocking the asyncio event loop.
- Preserve and regression-test existing agent cleanup paths for normal shutdown and owner watchdog termination.

Tests:
- Add regression coverage for snapshot ordering, process identity validation, vanished and stubborn processes, and existing cleanup paths.

</details>