### PR TITLE
fix(maafw): 运行环境坏了要当场知道，别拖到任务中途

### DIFF
--- a/app/task/MaaFW/embedded_manager.py
+++ b/app/task/MaaFW/embedded_manager.py
@@ -29,6 +29,7 @@ MAS 在自己的 worker 子进程内加载项目的 MaaFramework 直接驱动，
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +54,54 @@ if TYPE_CHECKING:  # pragma: no cover - 仅供类型检查，运行期不导入 
     from app.task.MaaFW.tools.embedded.runner_task import MaaFWPluginAutoProxyTask
 
 logger = get_logger("MFW 内置运行")
+
+
+def describe_unusable_runtime(project_path: Path) -> str | None:
+    """运行前自检：这个项目要用的运行池 runtime 还能用吗？
+
+    只在池里已经存在匹配的 runtime 时才探一次（一个子进程，约 100ms——解释器
+    本来就要起）。没建过就不拦：那份环境会在运行时按需准备，失败自有它自己的
+    报错路径。
+
+    拦在 ``check()`` 而不是只靠编辑页的提示：队列与定时任务不经过编辑页，
+    绕不过 check()；而且这里拦下来时模拟器和游戏都还没启动。
+    """
+
+    # 运行池会拉起 uv 与安装器，只在真要用时导入，别让每次 import 都付这份成本。
+    from app.task.MaaFW.tools.core.automas_maafw_runner.environment import (
+        resolve_project_maafw_requirement,
+    )
+    from app.task.MaaFW.tools.core.automas_maafw_runtime_pool import (
+        MaaFWRuntimePoolService,
+    )
+    from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.installer import (
+        probe_python_identity,
+    )
+
+    try:
+        requirement = resolve_project_maafw_requirement(project_path)
+    except Exception:  # noqa: BLE001 - 自检失败不该反过来挡住运行
+        return None
+    if not requirement:
+        return None
+
+    try:
+        runtimes = MaaFWRuntimePoolService().list()
+    except Exception:  # noqa: BLE001
+        return None
+
+    for runtime in runtimes:
+        if str(runtime.get("maafwRequirement") or "").strip() != requirement:
+            continue
+        python_executable = str(runtime.get("pythonExecutable") or "").strip()
+        if not python_executable:
+            continue
+        try:
+            probe_python_identity(Path(python_executable))
+        except Exception as exc:  # noqa: BLE001 - 原文就是给用户看的
+            return f"MFW 运行环境不可用：{exc}"
+        return None
+    return None
 
 
 class MaaFWEmbeddedManager(TaskExecuteBase):
@@ -124,6 +173,13 @@ class MaaFWEmbeddedManager(TaskExecuteBase):
             return "MFW 没有可运行的用户，请在用户管理页添加并启用至少一个用户"
 
         self.emulator_manager = await self._resolve_emulator_manager(script_config)
+
+        environment_problem = await asyncio.to_thread(
+            describe_unusable_runtime, Path(project_value)
+        )
+        if environment_problem:
+            return environment_problem
+
         return "Pass"
 
     @staticmethod

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
@@ -777,6 +777,21 @@ def _declared_project_maafw_requirement(project_path: Path) -> str | None:
     return matches[0] if matches else None
 
 
+
+def resolve_project_maafw_requirement(project_path: Path) -> str | None:
+    """普通项目（非 Managed）会用到的 MaaFW requirement。
+
+    与 ``prepare_runner_environment`` 内的解析顺序一致：项目自带原生库的实测
+    版本优先于 requirements.txt 的声明（实测 46 个发行包里有 3 个声明是陈旧的）。
+
+    供运行前自检复用——它只需要知道「这个项目会用哪个 runtime」，不需要真的去
+    准备环境，因此不联网、不建 venv。
+    """
+
+    project = Path(project_path)
+    return _bundled_project_maafw_requirement(
+        project
+    ) or _declared_project_maafw_requirement(project)
 def _normalize_python_constraint(value: str | None) -> str | None:
     if value is None:
         return None

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
@@ -308,6 +308,7 @@ def install_python_runtime(
         )
         dependency_installer = "pip"
         resolved_requirements = _resolved_requirements(python_executable)
+    _verify_maafw_importable(python_executable)
     version = _installed_maafw_version(python_executable)
     installer_name = "uv" if uv_executable is not None else "pip"
     installer_metadata = {
@@ -1043,6 +1044,37 @@ def _uv_install_environment(
     env["UV_CACHE_DIR"] = str(cache_dir)
     env["UV_LINK_MODE"] = link_mode
     return env
+
+
+def _verify_maafw_importable(python_executable: Path) -> None:
+    """装完必须真的 import 得动 maa，而不是「元数据里有」。
+
+    ``importlib.metadata.version('maafw')`` 只读包元数据，装了一半、或者解释器
+    自己的标准库坏掉时它照样报得出版本号——真机上就出过这种事：运行池认为环境
+    就绪，worker 起来才在 ``maa/library.py`` 第 1 行的 ``import ctypes`` 处炸掉。
+    这里在写 manifest 之前拦一次，坏环境就不会被记成好的。
+    """
+
+    try:
+        result = subprocess.run(
+            [str(python_executable), "-c", "import maa"],
+            capture_output=True,
+            timeout=60,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=_clean_install_environment(python_executable.parent.parent),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(
+            f"MaaFW runtime 校验失败：无法执行 {python_executable}"
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(
+            "MaaFW runtime 校验失败：依赖已安装但 import maa 不成功，"
+            f"该环境不可用。原始错误：{detail[-400:]}"
+        )
 
 
 def _installed_maafw_version(python_executable: Path) -> str | None:

--- a/frontend/src/views/EditView/Script/MaaFWScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/MaaFWScriptEdit.vue
@@ -71,6 +71,14 @@
             <template v-if="envReady && envAgents.length" #description>
               已就绪的 Agent：{{ envAgents.map(a => a.runtimeKind || '未知').join('、') }}
             </template>
+            <template v-if="envFailed" #description>
+              运行环境没准备好，后面几步配了也跑不起来。请检查网络与项目路径后重试。
+            </template>
+            <template v-if="envFailed" #action>
+              <a-button size="small" :loading="envPreparing" @click="retryAgentEnvPrepare">
+                重试
+              </a-button>
+            </template>
           </a-alert>
         </div>
 
@@ -214,8 +222,13 @@ const stepItems = [
   { title: t('edit.projectUpdate') },
   { title: t('edit.runConfiguration') },
 ]
-// 第一步没读到 interface 就往下走，后面几步全是空的，先拦住
-const canLeaveCurrentStep = computed(() => currentStep.value !== 0 || previewData.value !== null)
+// 第一步没读到 interface 就往下走，后面几步全是空的，先拦住。
+// 运行环境同理：没装完就往下配，配完了也跑不起来——首次要下载 MaaFramework，
+// 失败时（离线、镜像不通、解释器坏）后面每一步都是白填。失败不是死路，
+// 提示条里有「重试」。
+const canLeaveCurrentStep = computed(
+  () => currentStep.value !== 0 || (previewData.value !== null && envReady.value),
+)
 const pageLoading = ref(false)
 const isInitializing = ref(true)
 const isSaving = ref(false)
@@ -498,6 +511,12 @@ const runAgentEnvPrepare = async (targetPath?: string) => {
   } finally {
     envPreparing.value = false
   }
+}
+
+// 重试要清掉「这个路径已经备好过」的记忆，否则 runAgentEnvPrepare 会直接跳过。
+const retryAgentEnvPrepare = async () => {
+  envPreparedPath.value = ''
+  await runAgentEnvPrepare()
 }
 
 const selectMaaFWPath = async () => {

--- a/res/version.json
+++ b/res/version.json
@@ -8,7 +8,9 @@
             "修复BUG": [
                 "修复 MaaFW 运行池解释器自检不覆盖标准库、导致 Python 运行时损坏时直到任务中途才报出难以理解的错误的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "新增 AUTO_MAS_UV_PYTHON_INSTALL_MIRROR，受限网络下可为 MaaFW 运行池的 Python 解释器下载配置镜像 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复 MaaFW 运行环境不可用时仍会按重试次数反复重启模拟器与游戏、白等数分钟的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 MaaFW 运行环境不可用时仍会按重试次数反复重启模拟器与游戏、白等数分钟的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复 MaaFW 运行环境损坏时直到任务中途才暴露的问题，改为安装后立即校验、运行前再自检一次 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MFW 建项向导在运行环境准备完成前不再允许进入下一步，准备失败时可就地重试 by [@qiyinxi](https://github.com/qiyinxi)"
             ]
         },
         "v5.5.0-beta.2": {

--- a/tests/task/test_maafw_environment_gate.py
+++ b/tests/task/test_maafw_environment_gate.py
@@ -1,0 +1,176 @@
+"""运行环境闸门：装完要验真、跑之前要拦一道。
+
+真机现场（2026-08-31）：用户的 Python 运行时标准库损坏，运行池却认为环境就绪，
+直到 worker 起来才在 ``maa/library.py`` 第 1 行的 ``import ctypes`` 处炸掉，抛出
+ctypes 内部的天书；而且模拟器和游戏已经先被拉起来了。
+
+两道闸门：
+
+- **装完即验**（``_verify_maafw_importable``）：``importlib.metadata.version``
+  只读包元数据，装了一半或标准库坏掉时它照样报得出版本号。写 manifest 之前真的
+  ``import maa`` 一次，坏环境就不会被记成好的。
+- **跑前自检**（``describe_unusable_runtime``）：拦在 ``check()`` 里而不是只靠
+  编辑页提示——队列与定时任务不经过编辑页，绕不过 check()，而且此时模拟器和游戏
+  都还没启动。
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import app.core  # noqa: F401  # 初始化宿主配置
+
+from app.task.MaaFW import embedded_manager
+from app.task.MaaFW.tools.core.automas_maafw_runtime_pool import installer
+
+
+def _fake_python(tmp: Path, body: str) -> Path:
+    """造一个只会按 body 行事的假解释器（.cmd 转发到真 Python）。"""
+
+    script = tmp / "fake.py"
+    script.write_text(body, encoding="utf-8")
+    launcher = tmp / "fake.cmd"
+    launcher.write_text(
+        f'@echo off\r\n"{sys.executable}" "{script}" %*\r\n', encoding="utf-8"
+    )
+    return launcher
+
+
+class VerifyImportableTest(unittest.TestCase):
+    """装完必须真的 import 得动 maa。"""
+
+    def test_failure_is_raised_with_the_real_cause(self) -> None:
+        with TemporaryDirectory() as name:
+            tmp = Path(name)
+            fake = _fake_python(
+                tmp,
+                "import sys\n"
+                "sys.stderr.write(\"ModuleNotFoundError: No module named 'maa'\\n\")\n"
+                "sys.exit(1)\n",
+            )
+            with self.assertRaises(RuntimeError) as caught:
+                installer._verify_maafw_importable(fake)
+
+        message = str(caught.exception)
+        self.assertIn("import maa 不成功", message)
+        self.assertIn("ModuleNotFoundError", message, "原始错误要带出去")
+
+    def test_success_is_silent(self) -> None:
+        with TemporaryDirectory() as name:
+            tmp = Path(name)
+            fake = _fake_python(tmp, "pass\n")
+            self.assertIsNone(installer._verify_maafw_importable(fake))
+
+    def test_it_runs_before_the_manifest_is_written(self) -> None:
+        """源码级守卫：校验必须排在取版本号之前，否则坏环境仍会被记下来。"""
+
+        import inspect
+
+        source = inspect.getsource(installer)
+        verify = source.index("_verify_maafw_importable(python_executable)\n    version")
+        self.assertGreater(verify, 0, "校验要紧挨在取版本号之前")
+
+
+class RuntimeGateTest(unittest.TestCase):
+    """跑之前的自检。"""
+
+    def _gate(self, *, requirement, runtimes, probe_error=None):
+        probe = mock.Mock()
+        if probe_error is not None:
+            probe.side_effect = probe_error
+        service = mock.Mock()
+        service.return_value.list.return_value = runtimes
+        with mock.patch.multiple(
+            "app.task.MaaFW.tools.core.automas_maafw_runner.environment",
+            resolve_project_maafw_requirement=mock.Mock(return_value=requirement),
+        ):
+            with mock.patch(
+                "app.task.MaaFW.tools.core.automas_maafw_runtime_pool"
+                ".MaaFWRuntimePoolService",
+                service,
+            ):
+                with mock.patch(
+                    "app.task.MaaFW.tools.core.automas_maafw_runtime_pool.installer"
+                    ".probe_python_identity",
+                    probe,
+                ):
+                    return (
+                        embedded_manager.describe_unusable_runtime(Path("D:/proj")),
+                        probe,
+                    )
+
+    @staticmethod
+    def _runtime(requirement: str, executable: str = "D:/pool/python.exe"):
+        return {"maafwRequirement": requirement, "pythonExecutable": executable}
+
+    def test_broken_runtime_is_reported(self) -> None:
+        problem, probe = self._gate(
+            requirement="maafw==5.13.0b2",
+            runtimes=[self._runtime("maafw==5.13.0b2")],
+            probe_error=RuntimeError("标准库 ctypes 不可用"),
+        )
+        self.assertIsNotNone(problem)
+        self.assertIn("MFW 运行环境不可用", problem)
+        self.assertIn("标准库 ctypes 不可用", problem)
+        probe.assert_called_once()
+
+    def test_healthy_runtime_passes(self) -> None:
+        problem, probe = self._gate(
+            requirement="maafw==5.13.0b2",
+            runtimes=[self._runtime("maafw==5.13.0b2")],
+        )
+        self.assertIsNone(problem)
+        probe.assert_called_once()
+
+    def test_unbuilt_runtime_is_not_blocked(self) -> None:
+        """池里还没有匹配的 runtime 就不拦：那份环境会在运行时按需准备。"""
+
+        problem, probe = self._gate(
+            requirement="maafw==5.13.0b2",
+            runtimes=[self._runtime("maafw==5.9.0")],
+        )
+        self.assertIsNone(problem)
+        probe.assert_not_called()
+
+    def test_unresolvable_requirement_is_not_blocked(self) -> None:
+        problem, probe = self._gate(requirement=None, runtimes=[])
+        self.assertIsNone(problem)
+        probe.assert_not_called()
+
+    def test_only_the_matching_runtime_is_probed(self) -> None:
+        """池里通常有好几份 runtime，不该为了自检把它们全起一遍。"""
+
+        problem, probe = self._gate(
+            requirement="maafw==5.13.0b2",
+            runtimes=[
+                self._runtime("maafw==5.9.0"),
+                self._runtime("maafw==5.13.0b2"),
+                self._runtime("maafw==5.13.0b5"),
+            ],
+        )
+        self.assertIsNone(problem)
+        self.assertEqual(probe.call_count, 1)
+
+    def test_self_check_failure_never_blocks_the_run(self) -> None:
+        """自检自己出问题（池不可读等）不能反过来挡住运行。"""
+
+        service = mock.Mock()
+        service.return_value.list.side_effect = OSError("pool unreadable")
+        with mock.patch.multiple(
+            "app.task.MaaFW.tools.core.automas_maafw_runner.environment",
+            resolve_project_maafw_requirement=mock.Mock(return_value="maafw==5.13.0b2"),
+        ):
+            with mock.patch(
+                "app.task.MaaFW.tools.core.automas_maafw_runtime_pool"
+                ".MaaFWRuntimePoolService",
+                service,
+            ):
+                self.assertIsNone(
+                    embedded_manager.describe_unusable_runtime(Path("D:/proj"))
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
用户机器上的报错：

```
MaaFW 运行异常: MaaFW runner worker exited without result: 1: from .library import Library
  File "...\maafw-runtime-8113c68.../environment\Lib\site-packages\maa\library.py", line 1, in <module>
    import ctypes
  File "ctypes\__init__.py", line 157, in <module>
AttributeError: class must define a '_type_' attribute
```

运行池认为环境就绪，直到 worker 起来才炸——而模拟器和游戏已经先被拉起来了。

## 根因

`ctypes/__init__.py` 157 行是 `class py_object(_SimpleCData):`，**158 行就写着 `_type_ = "O"`**。类体里有而 `_ctypes` 说没有，只有一种可能：ctypes 的两半（纯 Python 部分与 `_ctypes.pyd`）来自不同构建。

原来的 `verify_python` 确实会启动解释器校验，但探针只 import `json/platform/sys/sysconfig`，而 version、soabi、platform **全部来自解释器二进制**——标准库那一半坏了照样报得一模一样。（探针加 ctypes 的改动已随 dev 上的 `01a20888` 合入。）

## 本 PR 补三道

**1. 装完即验** — `installer._verify_maafw_importable`

原来只有 `importlib.metadata.version('maafw')`，读的是包元数据，装了一半或标准库坏掉时照样报得出版本号。写 manifest 之前真的 `import maa` 一次，坏环境就不会被记成好的。

**2. 跑前自检** — `embedded_manager.describe_unusable_runtime`

`check()` 此前只验模式/脚本 ID/项目路径/用户/模拟器，完全不碰环境。现在解析出该项目会用的 MaaFW requirement，在池里找到匹配的 runtime 才探一次；**没建过就不拦**，那份环境会在运行时按需准备。

拦在 `check()` 而不是只靠编辑页：队列与定时任务不经过编辑页，绕不过它；而且此时模拟器和游戏都还没启动。

为此把 requirement 解析抽成 `resolve_project_maafw_requirement`，与 `prepare_runner_environment` 内的顺序一致（项目自带原生库的实测版本优先于 `requirements.txt` 的声明）。实测对 MaaYYs 解析出 `maafw==5.13.0b2`，与真机日志一致。

**3. 向导闸门** — `MaaFWScriptEdit.vue`

环境没准备好不让进下一步——首次要下载 MaaFramework，失败时后面每一步都是白填。失败不是死路：提示条里带「重试」。

自检自身出问题（池不可读等）一律放行，不能反过来挡住运行。

## 验证

- 后端 `830 passed`，2 条失败均与本 PR 无关（`test_activity_fight_preserves_native_options` 是既有的，`test_deleted_script_forces_repo_and_resubscribes` 来自 #410）
- 新增 9 项测试；回退实现后以 `AttributeError: ... has no attribute '_verify_maafw_importable'` 变红
- 前端 `vitest 142 passed`、`vite build` 通过
- 拿 4 个真实池 venv 跑过自检，不误伤

## 未覆盖

向导守卫是 SFC 里的两行 computed，单测要挂载整页，性价比低，**没有前端单测**。真正可执行的闸门是后端那道（有测试）。

## 顺带

`useBettergiGuiSession.ts:88` 的 typecheck error 与 `useScriptApi.ts:1125` 的 `no-dupe-else-if` lint error 都来自 #410，本 PR 未处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

在安装、任务预检和设置向导导航期间，快速失败并阻止使用不可用的 MaaFW 环境。

新功能：
- 添加运行前验证，在任务开始前检测现有但不可用的 MaaFW 运行时。
- 在运行时环境准备就绪前，阻止 MaaFW 设置向导继续进行，并支持重试。

错误修复：
- 在安装期间验证 `import maa` 是否成功，从而拒绝损坏的 MaaFW 环境，避免在运行时未就绪时记录该环境。
- 当匹配的 MaaFW 运行时不可用或无法使用时，避免启动模拟器或游戏。

改进：
- 复用项目的 MaaFW 要求解析逻辑，确保准备和验证期间选择一致的运行时。
- 对于与现有匹配运行时无关的验证失败，允许其保持非阻塞状态，以便仍可按需准备环境。

测试：
- 增加对安装期间导入验证和运行时预检门控场景的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fail fast on unusable MaaFW environments during installation, task pre-flight checks, and setup wizard navigation.

New Features:
- Add pre-run validation that detects unusable existing MaaFW runtimes before tasks start.
- Prevent the MaaFW setup wizard from advancing until the runtime environment is ready, with retry support.

Bug Fixes:
- Reject broken MaaFW environments during installation by verifying that `import maa` succeeds before recording the runtime as ready.
- Avoid starting emulators or games when the matching MaaFW runtime is unavailable or unusable.

Enhancements:
- Reuse project MaaFW requirement resolution for consistent runtime selection during preparation and validation.
- Allow validation failures unrelated to a matching existing runtime to remain non-blocking so environments can still be prepared on demand.

Tests:
- Add coverage for installation-time import validation and runtime pre-flight gating scenarios.

</details>