### PR TITLE
chore(github): 新增 Issue 模板并挂上文档与社群链接

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-cn-bug-script.yaml
+++ b/.github/ISSUE_TEMPLATE/01-cn-bug-script.yaml
@@ -1,0 +1,124 @@
+name: Bug 反馈 · 脚本专项（使用中文）
+description: MAA、M9A、MaaEnd、HSR、SRC、OK-WW、OK-NTE、BetterGI 与通用脚本的识别错误、任务异常、连接失败等
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 在提问之前...
+      description: |
+        请确认自己完成了下列必选项之后再进行勾选，若未完成必选项或勾选了「我未仔细阅读」选项，将视为自愿接受被直接关闭 Issue
+      options:
+        - label: 我理解 Issue 是用于反馈和解决问题的，而非吐槽评论区，将尽可能提供更多信息帮助问题解决
+          required: true
+        - label: 我未仔细阅读这些内容，只是一键已读所有内容，并相信这不会影响问题的处理
+        - label: 我填写了简短且清晰明确的标题，以便开发者在翻阅 Issue 列表时能快速确定大致问题，而不是「一个建议」「卡住了」等
+          required: true
+        - label: 我使用的是当前的最新版本，并已查看 Release 与 Pull Requests 中尚未发布的更新内容，其中并未提及该 Bug 已被修复
+          required: true
+        - label: 我已检查了常见问题、公告、活跃议题与已关闭议题，确认我的问题未被提及
+          required: true
+
+  - type: dropdown
+    id: script_type
+    attributes:
+      label: 涉及的脚本类型
+      description: MaaFW 脚本请改用「Bug 反馈 · MaaFW 专项」模板；与具体脚本无关的问题请改用「Bug 反馈 · 通用问题」模板
+      options:
+        - MAA
+        - M9A
+        - MaaEnd
+        - HSR
+        - SRC
+        - OK-WW
+        - OK-NTE
+        - BetterGI
+        - 通用脚本
+    validations:
+      required: true
+
+  - type: input
+    id: mas_version
+    attributes:
+      label: AUTO-MAS 版本
+      description: 见 设置 →「关于」
+      placeholder: v5.5.0-beta.3
+    validations:
+      required: true
+
+  - type: input
+    id: script_version
+    attributes:
+      label: 被托管脚本的版本
+      description: 上面所选脚本自身的版本号
+      placeholder: MAA v5.x.x
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: 问题描述
+      description: 描述问题时请尽可能详细，说明你期望的行为与实际发生的行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      description: 请按顺序写明操作步骤，以及该问题是必现还是偶发
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### 日志
+
+        请在提交本 Issue 后，**在评论区补充以下两份日志**：
+
+        1. **AUTO-MAS 本体日志**：设置 →「日志管理」→「导出日志压缩包」
+        2. **脚本日志**：被托管脚本自身的日志。部分专项在 AUTO-MAS 内已有「导出 XX 问题包」按钮，可直接使用
+
+        请上传压缩包原文件，不要解压后只粘贴其中几行文字。
+
+  - type: checkboxes
+    id: logs
+    attributes:
+      label: 日志确认
+      options:
+        - label: 我已了解需要在提交后于评论区补充 AUTO-MAS 本体日志压缩包与脚本日志两份，缺少日志的 Issue 可能无法排查并被关闭
+          required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 运行环境
+      description: |
+        请说明操作系统及版本、模拟器品牌与版本、模拟器分辨率、DPI；
+        若正在使用 MuMu 12 或雷电 9，请说明截图增强是否开启
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 截图或录屏
+      description: |
+        若是识别相关问题，请尽可能提供模拟器自带截图工具截取的无遮挡原图（或通过 adb 截取）；
+        用 QQ、微信等工具截取的图片包含窗口边框且长宽比不固定，不利于排查
+    validations:
+      required: false
+
+  - type: textarea
+    id: others
+    attributes:
+      label: 还有别的吗？
+      description: 任何能让我们对你所遇到的问题有更多了解的东西
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-cn-bug-maafw.yaml
+++ b/.github/ISSUE_TEMPLATE/02-cn-bug-maafw.yaml
@@ -1,0 +1,120 @@
+name: Bug 反馈 · MaaFW 专项（使用中文）
+description: AUTO-MAS 托管 MaaFramework 项目时的识别错误、任务异常、运行环境问题等
+labels: ["bug", "专项: MaaFW"]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 在提问之前...
+      description: |
+        请确认自己完成了下列必选项之后再进行勾选，若未完成必选项或勾选了「我未仔细阅读」选项，将视为自愿接受被直接关闭 Issue
+      options:
+        - label: 我理解 Issue 是用于反馈和解决问题的，而非吐槽评论区，将尽可能提供更多信息帮助问题解决
+          required: true
+        - label: 我未仔细阅读这些内容，只是一键已读所有内容，并相信这不会影响问题的处理
+        - label: 我填写了简短且清晰明确的标题，以便开发者在翻阅 Issue 列表时能快速确定大致问题，而不是「一个建议」「卡住了」等
+          required: true
+        - label: 我使用的是当前的最新版本，并已查看 Release 与 Pull Requests 中尚未发布的更新内容，其中并未提及该 Bug 已被修复
+          required: true
+        - label: 我已检查了常见问题、公告、活跃议题与已关闭议题，确认我的问题未被提及
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        如果问题出在 MaaFramework 项目自身的识别或任务流程上（换用该项目自带的界面也复现），
+        请到该项目的仓库反馈；本模板用于 AUTO-MAS 托管该项目时出现的问题。
+
+  - type: input
+    id: mas_version
+    attributes:
+      label: AUTO-MAS 版本
+      description: 见 设置 →「关于」
+      placeholder: v5.5.0-beta.3
+    validations:
+      required: true
+
+  - type: input
+    id: project
+    attributes:
+      label: MaaFW 项目名与版本
+      description: 你在 AUTO-MAS 里托管的那个 MaaFramework 项目
+      placeholder: M9A v4.6.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: controller
+    attributes:
+      label: 控制链路
+      description: 在 MaaFW 脚本编辑页里选择的控制器类型
+      options:
+        - ADB 模拟器
+        - Win32 PC 游戏
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: 问题描述
+      description: 描述问题时请尽可能详细，说明你期望的行为与实际发生的行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      description: 请按顺序写明操作步骤，以及该问题是必现还是偶发
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### 日志
+
+        请在提交本 Issue 后，**在评论区补充以下两份日志**：
+
+        1. **AUTO-MAS 本体日志**：设置 →「日志管理」→「导出日志压缩包」
+        2. **MaaFW 项目日志**：该项目自身的 `debug` 目录
+
+        请上传压缩包原文件，不要解压后只粘贴其中几行文字。
+
+  - type: checkboxes
+    id: logs
+    attributes:
+      label: 日志确认
+      options:
+        - label: 我已了解需要在提交后于评论区补充 AUTO-MAS 本体日志压缩包与 MaaFW 项目 debug 目录两份，缺少日志的 Issue 可能无法排查并被关闭
+          required: true
+
+  - type: textarea
+    id: interface
+    attributes:
+      label: 项目的 interface.json
+      description: 若问题与控制器、资源或任务列表有关，请附上项目根目录下的 interface.json
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 运行环境
+      description: 请说明操作系统及版本；ADB 链路请补充模拟器品牌与版本、分辨率、DPI
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 截图或录屏
+      description: 可上传屏幕截图或录制以帮助解释你的问题
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-cn-bug-general.yaml
+++ b/.github/ISSUE_TEMPLATE/03-cn-bug-general.yaml
@@ -1,0 +1,108 @@
+name: Bug 反馈 · 通用问题（使用中文）
+description: 与具体脚本无关的问题：界面、调度、队列、通知、更新、游戏签到、启动与退出等
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 在提问之前...
+      description: |
+        请确认自己完成了下列必选项之后再进行勾选，若未完成必选项或勾选了「我未仔细阅读」选项，将视为自愿接受被直接关闭 Issue
+      options:
+        - label: 我理解 Issue 是用于反馈和解决问题的，而非吐槽评论区，将尽可能提供更多信息帮助问题解决
+          required: true
+        - label: 我未仔细阅读这些内容，只是一键已读所有内容，并相信这不会影响问题的处理
+        - label: 我填写了简短且清晰明确的标题，以便开发者在翻阅 Issue 列表时能快速确定大致问题，而不是「一个建议」「卡住了」等
+          required: true
+        - label: 我使用的是当前的最新版本，并已查看 Release 与 Pull Requests 中尚未发布的更新内容，其中并未提及该 Bug 已被修复
+          required: true
+        - label: 我已检查了常见问题、公告、活跃议题与已关闭议题，确认我的问题未被提及
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 出问题的位置
+      description: 若问题出在某个具体脚本的运行过程中，请改用「Bug 反馈 · 脚本专项」模板
+      options:
+        - 首页
+        - 脚本
+        - 计划
+        - 模拟器
+        - 队列
+        - 调度中心
+        - 历史记录
+        - 工具
+        - 游戏签到
+        - 设置
+        - 通知推送
+        - 软件更新
+        - 启动与退出
+        - 其他
+    validations:
+      required: true
+
+  - type: input
+    id: mas_version
+    attributes:
+      label: AUTO-MAS 版本
+      description: 见 设置 →「关于」
+      placeholder: v5.5.0-beta.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: 问题描述
+      description: 描述问题时请尽可能详细，说明你期望的行为与实际发生的行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      description: 请按顺序写明操作步骤，以及该问题是必现还是偶发
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### 日志
+
+        请在提交本 Issue 后，**在评论区补充日志**：
+
+        1. **AUTO-MAS 本体日志**（必须）：设置 →「日志管理」→「导出日志压缩包」
+        2. 若问题涉及某个脚本，请一并附上该脚本自身的日志
+
+        请上传压缩包原文件，不要解压后只粘贴其中几行文字。
+
+  - type: checkboxes
+    id: logs
+    attributes:
+      label: 日志确认
+      options:
+        - label: 我已了解需要在提交后于评论区补充 AUTO-MAS 本体日志压缩包，缺少日志的 Issue 可能无法排查并被关闭
+          required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 运行环境
+      description: 请说明操作系统及版本、屏幕分辨率与缩放比例
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 截图或录屏
+      description: 可上传屏幕截图或录制以帮助解释你的问题
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-cn-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/04-cn-feature-request.yaml
@@ -1,0 +1,45 @@
+name: 需求建议（使用中文）
+description: 新功能、改进建议等
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 在提问之前...
+      options:
+        - label: 我确认这是需求建议，而不是 Bug 反馈
+          required: true
+        - label: 我已搜索过活跃议题与已关闭议题，确认该需求未被提出过
+          required: true
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: 需求描述
+      description: 你希望 AUTO-MAS 增加或改进什么
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 想解决什么问题
+      description: 描述你的使用场景，以及现在是怎么绕过这个问题的
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 你设想的方案
+      description: 若你已有具体想法，可以在这里描述交互方式或实现思路
+    validations:
+      required: false
+
+  - type: textarea
+    id: others
+    attributes:
+      label: 补充
+      description: 参考资料、其他软件的类似实现、示意图等
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05-cn-ai-report.yaml
+++ b/.github/ISSUE_TEMPLATE/05-cn-ai-report.yaml
@@ -1,0 +1,47 @@
+name: AI 提交的 Bug（使用中文）
+description: 由 AI 工具自动生成或直接提交的 Bug 报告
+labels: ["AI", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        本分区用于 **AI 工具自动生成或直接提交** 的 Bug 报告。
+
+        这类 Issue 会被保留和归档，但**不承诺处理时间，也不保证有人认领**。
+        如果你是真人用户，遇到的是实际使用中的问题，请改用其他 Bug 反馈模板，那边会被优先处理。
+
+  - type: input
+    id: tool
+    attributes:
+      label: 提交所用的 AI 工具或模型
+      placeholder: Claude Code / Codex / ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: 问题描述
+      description: 说明这是什么问题，以及在什么条件下会出现
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 证据
+      description: |
+        请给出可核对的依据：涉及的代码位置（文件路径与行号）、日志片段、复现路径。
+        只有推测而没有证据的报告会被直接关闭。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 确认
+      options:
+        - label: 我确认这是 AI 生成的内容，并已自行核对上面给出的代码位置属实
+          required: true
+        - label: 我理解本分区不承诺处理时间，也不保证有人认领
+          required: true

--- a/.github/ISSUE_TEMPLATE/06-cn-others.yaml
+++ b/.github/ISSUE_TEMPLATE/06-cn-others.yaml
@@ -1,0 +1,10 @@
+name: 其他议题（使用中文）
+description: 提出问题，而不是 Bug 反馈或需求建议
+labels: ["question"]
+body:
+  - type: textarea
+    id: describe
+    attributes:
+      label: 说说你遇到的问题？
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/07-en-blank.yaml
+++ b/.github/ISSUE_TEMPLATE/07-en-blank.yaml
@@ -1,0 +1,37 @@
+name: Issue in English
+description: Report a bug, request a feature, or ask a question — in English
+body:
+  - type: markdown
+    attributes:
+      value: |
+        AUTO-MAS is maintained primarily in Chinese. English issues are welcome,
+        but replies may be delayed. If you can write Chinese, the templates above
+        collect more information up front and will usually get a faster answer.
+
+  - type: textarea
+    id: describe
+    attributes:
+      label: Description
+      description: What happened, what you expected to happen, and how to reproduce it.
+    validations:
+      required: true
+
+  - type: input
+    id: mas_version
+    attributes:
+      label: AUTO-MAS version
+      description: See Settings → About
+      placeholder: v5.5.0-beta.3
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Export the AUTO-MAS log archive from Settings → Log Management → Export log archive.
+        If a managed script is involved, attach that script's own logs as well.
+      options:
+        - label: I understand I need to attach the log archive in a comment after submitting this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 常见问题 / FAQ
+    url: https://doc.auto-mas.top/docs/FAQ
+    about: 提交 Issue 前请先查阅常见问题
+  - name: 📚 官方文档站 / Documentation
+    url: https://doc.auto-mas.top
+    about: 安装、配置与使用说明
+  - name: 🐧 AUTO-MAS 官方 QQ 群
+    url: https://qm.qq.com/q/hdV065dcbu
+    about: 使用问题与日常交流


### PR DESCRIPTION
GitHub 只读默认分支下的 .github/ISSUE_TEMPLATE，故直接落 main。文件内容与 #503 字节一致。

## Sourcery 总结

完善 GitHub Issue 模板与社区入口，规范问题反馈和需求收集流程。

新功能：
- 新增中文 Bug、功能建议、AI 报告、其他议题及英文 Issue 提交模板，按问题类型引导收集版本、复现步骤、日志和运行环境等信息。

改进：
- 完善 Issue 提交流程，区分脚本、MaaFW 与通用问题，并通过必填确认项提升报告质量。

文档：
- 为 Issue 页面添加常见问题、官方文档和 QQ 社群入口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

完善 GitHub Issue 模板与社区入口，规范问题反馈和需求收集流程。

New Features:
- 新增中文 Bug、功能建议、AI 报告、其他议题及英文 Issue 提交模板，按问题类型引导收集版本、复现步骤、日志和运行环境等信息。

Enhancements:
- 完善 Issue 提交流程，区分脚本、MaaFW 与通用问题，并通过必填确认项提升报告质量。

Documentation:
- 为 Issue 页面添加常见问题、官方文档和 QQ 社群入口。

</details>