### PR TITLE
fix(hsr): 管控任务的文本配置框被保存重渲染吞掉输入

### DIFF
--- a/frontend/src/views/EditView/User/HSRUserEdit/DynamicManagedFields.vue
+++ b/frontend/src/views/EditView/User/HSRUserEdit/DynamicManagedFields.vue
@@ -52,17 +52,19 @@
         />
         <a-textarea
           v-else-if="field.type === 'json'"
-          :value="formatJson(field.value)"
+          :value="draftValue(field, formatJson(field.value))"
           :auto-size="{ minRows: 3, maxRows: 10 }"
           :disabled="disabled || field.readonly"
           class="option-control monospace-input"
+          @update:value="setDraft(field, $event)"
           @blur="handleJsonBlur(field, $event)"
         />
         <a-input
           v-else
-          :value="String(field.value ?? '')"
+          :value="draftValue(field, String(field.value ?? ''))"
           :disabled="disabled || field.readonly"
           class="option-control"
+          @update:value="setDraft(field, $event)"
           @blur="handleTextBlur(field, $event)"
         />
       </template>
@@ -71,6 +73,7 @@
 </template>
 
 <script setup lang="ts">
+import { reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { message } from 'ant-design-vue'
 import { QuestionCircleOutlined } from '@ant-design/icons-vue'
@@ -78,7 +81,7 @@ import type { HSRManagedField } from '@/composables/useHSRPluginApi'
 
 const { t } = useI18n()
 
-defineProps<{
+const props = defineProps<{
   fields: HSRManagedField[]
   disabled: boolean
 }>()
@@ -86,6 +89,26 @@ defineProps<{
 const emit = defineEmits<{
   change: [key: string, value: unknown]
 }>()
+
+// 文本与 JSON 输入只在失焦时提交，而父级每次保存都会整体重渲染受控输入。
+// 未提交的内容先留在草稿里，避免重渲染用旧的 field.value 把用户输入冲掉。
+const drafts = reactive<Record<string, string>>({})
+
+const clearDrafts = () => {
+  Object.keys(drafts).forEach(key => delete drafts[key])
+}
+
+watch(() => props.fields, clearDrafts)
+
+const draftValue = (field: HSRManagedField, fallback: string) => drafts[field.key] ?? fallback
+
+const setDraft = (field: HSRManagedField, value: string) => {
+  drafts[field.key] = value
+}
+
+const clearDraft = (field: HSRManagedField) => {
+  delete drafts[field.key]
+}
 
 const emitValue = (field: HSRManagedField, value: unknown) => {
   if (value === null || value === undefined) return
@@ -104,14 +127,18 @@ const numberValue = (value: unknown) => {
 const formatJson = (value: unknown) => JSON.stringify(value ?? null, null, 2)
 
 const handleTextBlur = (field: HSRManagedField, event: FocusEvent) => {
+  clearDraft(field)
   emitValue(field, (event.target as HTMLInputElement).value)
 }
 
 const handleJsonBlur = (field: HSRManagedField, event: FocusEvent) => {
   const raw = (event.target as HTMLTextAreaElement).value
   try {
-    emitValue(field, JSON.parse(raw))
+    const parsed = JSON.parse(raw)
+    clearDraft(field)
+    emitValue(field, parsed)
   } catch {
+    // 保留草稿，让用户在原文上继续修正而不是丢失已输入的内容
     message.error(t('edit.p0NotValidJson', { p0: field.label }))
   }
 }

--- a/res/version.json
+++ b/res/version.json
@@ -18,7 +18,8 @@
                 "MFW 建项向导在运行环境准备完成前不再允许进入下一步，准备失败时可就地重试 by [@qiyinxi](https://github.com/qiyinxi)",
                 "OK-WW与OK-NTE专项 多用户切换时等待上一用户的游戏进程完全退出，避免误复用正在退出的旧游戏窗口导致任务被中止 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "OK-NTE专项 修复任务报告剩余体力计算不准确的问题：体力不足以刷满设定目标时误显「剩余体力: 0」，改为按实际刷本消耗（异象界域双倍/单倍次数、异象追猎实际消耗）精确计算剩余体力 by [@AthenaHibou](https://github.com/AthenaHibou)",
-                "前端类型治理 清理脚本与 Electron 基础边界中的 any，并修复 BetterGI 设置会话无法接收完成和错误事件的问题"
+                "前端类型治理 清理脚本与 Electron 基础边界中的 any，并修复 BetterGI 设置会话无法接收完成和错误事件的问题",
+                "HSR专项 修复 MAS 管控任务的文本与 JSON 配置项在输入过程中被重渲染清空、导致只有数字项能填写的问题（如货币战争的首领/投资重开条件、策略文件、开拓者名称）"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
#505 报的是 HSR 货币战争里「部分条目应当可以填写文字实则只能填写数字」。问题不在 SRA 配置解析，在 `DynamicManagedFields.vue` 的输入框绑定。

## 根因

文本框是受控绑定但只在失焦提交：

```vue
:value="String(field.value ?? '')"   @blur="handleTextBlur(...)"
```

ant-design-vue 4.2.6 的 `vc-input/Input.js` 在 `props.value !== undefined` 时走受控分支，`setValue()` **不更新内部 `stateValue`**，只在 nextTick 里 `$forceUpdate()`。所以只要组件重渲染一次，输入框就刷回旧的 `field.value`。而父级 `HSRUserEdit` 的 `:disabled="saving"` 每保存一次翻转一次——相邻字段一提交，正在打字的文本就没了。

`a-input-number` / `a-select` / `a-checkbox` 绑的是 `@change`，逐次回写父级，不受影响。货币战争那 10 项里只有 `运行次数`、`策略序号` 与两个下拉能填进去，4 个重开条件 + 策略文件 + 开拓者名称全被吞，于是看起来像「只能输入数字」。

按 SRA 2.20.0 的 `Default.json` 跑一遍 `list_sra_managed_modules`，这 6 项返回的确实是 `type='string'`，后端类型判定没问题：

```
'currencyWars.reroll.bossAffixes'  type='string'   value=''
'currencyWars.runtimes'            type='integer'  value=1
'currencyWars.strategy'            type='string'   value='template'
```

## 改了什么

- 文本与 JSON 输入改用组件内 draft：`@update:value` 存草稿、`:value` 优先读草稿、blur 提交后清掉。
- `watch(() => props.fields)` 在切任务/切引擎/重载快照时清空草稿（`selectedForm` 返回的是快照里的稳定对象，改单个 `field.value` 不会误触发）。
- JSON 解析失败时保留草稿，让用户在原文上继续修正而不是丢掉已输入的内容。

同一文件里的 select / number / checkbox 保持原样，它们本来就没这个问题。

## 验证

用仓库自带的 antd UMD 搭最小页面复刻这段绑定实测：

| | 打字后 | 触发一次重渲染 | 提交结果 |
| --- | --- | --- | --- |
| 修复前 `a-input` | `abc` | `""` | 从未提交 |
| 修复前 `a-input-number` | `7` | `7` | 已提交 |
| 修复后 `a-input` | `巨大化` | `巨大化` | blur 后提交成功 |

在 `dev@11e46904` 上：

- `yarn lint` → exit 0
- `yarn typecheck` → exit 0
- `yarn test` → 22 文件 142 用例全过
- `yarn vite build` → 通过

## version.json

在 `v5.5.0-beta.3` 的「修复BUG」下加了一条，署名交给 `append-version-contributor` 合并后自动补。

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

防止 HSR 管理的文本和 JSON 字段输入在保存触发的重新渲染过程中被覆盖。

错误修复：
- 在父级重新渲染期间保留 HSR 管理字段中尚未提交的文本和 JSON 输入，防止用户输入的值在失焦提交前丢失。
- 保留无效的 JSON 草稿以便修正，而不是丢弃已输入的内容。

增强功能：
- 当管理字段发生变化时重置临时输入草稿，例如切换任务、引擎或重新加载快照时。

维护工作：
- 在项目版本变更日志中记录此错误修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent HSR managed text and JSON field input from being overwritten during save-triggered re-renders.

Bug Fixes:
- Preserve unsubmitted text and JSON input in HSR managed fields across parent re-renders, preventing user-entered values from being lost before blur submission.
- Keep invalid JSON drafts available for correction instead of discarding the entered content.

Enhancements:
- Reset temporary input drafts when managed fields change, such as when switching tasks, engines, or reloading snapshots.

Chores:
- Record the bug fix in the project version changelog.

</details>