### PR TITLE
fix(gamesign): 通知返回值改为 DispatchResult 后未同步两处调用方，签到通知必抛 TypeError

### DIFF
--- a/app/api/tools.py
+++ b/app/api/tools.py
@@ -28,6 +28,7 @@ from inspect import isawaitable
 from uuid import UUID
 
 from app.core import Config
+from app.core.notify import DispatchResult
 from app.models.schema import (
     ToolsGetOut,
     ToolsConfig,
@@ -58,15 +59,15 @@ def _track_game_sign_notification(task: asyncio.Task) -> None:
     if task.cancelled():
         return
     try:
-        failed_channels = task.result()
+        result = task.result()
     except Exception as exc:
         logger.warning(f"后台游戏签到通知发送失败: {exc}")
         return
-    if failed_channels:
-        logger.warning(f"后台游戏签到通知部分失败: {'、'.join(failed_channels)}")
+    if result.failed:
+        logger.warning(f"后台游戏签到通知部分失败: {'、'.join(result.failed)}")
 
 
-async def _dispatch_game_sign_notification(results: list[dict]) -> list[str] | None:
+async def _dispatch_game_sign_notification(results: list[dict]) -> DispatchResult | None:
     """发送签到通知；慢渠道转后台，避免阻塞签到完成响应。"""
 
     from app.tools.game_sign_notify import push_game_sign_notification
@@ -81,7 +82,7 @@ async def _dispatch_game_sign_notification(results: list[dict]) -> list[str] | N
         return None
     except Exception as exc:
         logger.warning(f"签到完成，但通知服务异常: {exc}")
-        return ["通知服务"]
+        return DispatchResult(failed=("通知服务",))
 
 
 def _get_game_sign_field(account: object, field: str, default=None):
@@ -185,10 +186,10 @@ async def manual_game_sign() -> OutBase:
         ):
             warning_messages.append("签到未全部完成，请查看签到结果")
         if results and Config.ToolsConfig.get("GameSign", "NotifyEnabled"):
-            failed_channels = await _dispatch_game_sign_notification(results)
-            if failed_channels:
+            notify_result = await _dispatch_game_sign_notification(results)
+            if notify_result and notify_result.failed:
                 warning_messages.append(
-                    f"部分通知发送失败：{'、'.join(failed_channels)}"
+                    f"部分通知发送失败：{'、'.join(notify_result.failed)}"
                 )
         if warning_messages:
             return OutBase(status="warning", message="；".join(warning_messages))

--- a/res/version.json
+++ b/res/version.json
@@ -21,7 +21,8 @@
                 "OK-NTE专项 修复任务报告剩余体力计算不准确的问题：体力不足以刷满设定目标时误显「剩余体力: 0」，改为按实际刷本消耗（异象界域双倍/单倍次数、异象追猎实际消耗）精确计算剩余体力 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "前端类型治理 清理脚本与 Electron 基础边界中的 any，并修复 BetterGI 设置会话无法接收完成和错误事件的问题",
                 "HSR专项 修复 MAS 管控任务的文本与 JSON 配置项在输入过程中被重渲染清空、导致只有数字项能填写的问题（如货币战争的首领/投资重开条件、策略文件、开拓者名称） by [@qiyinxi](https://github.com/qiyinxi)",
-                "OK-WW专项 修复任务报告推送因漏传通知用户配置参数而失败的问题 by [@AthenaHibou](https://github.com/AthenaHibou)"
+                "OK-WW专项 修复任务报告推送因漏传通知用户配置参数而失败的问题 by [@AthenaHibou](https://github.com/AthenaHibou)",
+                "游戏签到 修复通知返回值改为 DispatchResult 后未同步两处消费方、开启签到通知时执行签到必报 TypeError 的问题（手动签到接口返回 500，慢渠道后台通知路径丢失日志） by [@1w1w11w1](https://github.com/1w1w11w1)"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
通知返回值统一迁移到 `DispatchResult` 后，`app/api/tools.py` 两处消费方仍按旧 `list[str]` 使用（`'、'.join(...)`），导致开启签到通知时执行游戏签到必抛 `TypeError`：手动签到接口返回 500，慢渠道后台通知路径丢日志。

- 两处消费方改为取 `DispatchResult.failed`，`_dispatch_game_sign_notification` 返回标注同步为 `DispatchResult | None`，与 `app/core/timer.py` 既有消费方式一致。
- 异常哨兵 `["通知服务"]` 改为 `DispatchResult(failed=("通知服务",))`，保持部分失败提示语义。
- `res/version.json` 增 changelog 记录。

Closes #514

## Summary by Sourcery

修复游戏签到通知迁移至 DispatchResult 后的调用兼容问题，恢复手动签到和后台通知的正常处理。

Bug Fixes:
- 修复游戏签到通知调用方仍按旧列表类型处理通知结果，导致启用通知时手动签到接口报错及后台通知失败日志丢失。

Enhancements:
- 统一游戏签到通知结果的消费与异常提示方式，正确展示失败通知渠道。

Chores:
- 在版本变更记录中补充此次修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复游戏签到通知迁移至 DispatchResult 后的调用兼容问题，恢复手动签到和后台通知的正常处理。

Bug Fixes:
- 修复游戏签到通知调用方仍按旧列表类型处理通知结果，导致启用通知时手动签到接口报错及后台通知失败日志丢失。

Enhancements:
- 统一游戏签到通知结果的消费与异常提示方式，正确展示失败通知渠道。

Chores:
- 在版本变更记录中补充此次修复。

</details>