### PR TITLE
fix(electron): 渲染进程崩溃后自动恢复并留下记录

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -32,11 +32,18 @@ import {
   canRequestRendererClose,
   markForceQuitFailed,
 } from './quitCoordinationState'
+import { decideRendererRecovery } from './rendererCrashRecovery'
 
 import { getLogger, initializeLogger } from './services/logger'
 import { createMaaEndIssueReport } from './services/maaEndIssueReportService'
 import { createOkwwIssueReport } from './services/okwwIssueReportService'
-import { configureMainSentry, recordMainStartup, setMainTelemetryEnabled } from './services/sentry'
+import {
+  captureMainRendererCrash,
+  configureMainSentry,
+  recordMainCount,
+  recordMainStartup,
+  setMainTelemetryEnabled,
+} from './services/sentry'
 import { applyInstanceIdentity, resolveStopAllTasksShortcut } from './services/instanceConfig'
 import AdmZip = require('adm-zip')
 
@@ -197,6 +204,7 @@ let relaunchAfterQuit = false
 let quitFallbackTimer: NodeJS.Timeout | null = null
 const RENDERER_QUIT_FALLBACK_MS = 25000
 let saveWindowStateTimeout: NodeJS.Timeout | null = null
+let rendererCrashes: number[] = []
 let isInitialStartup = true // 标记是否为初次启动
 const isAutoStart = process.argv.includes('--auto-start') // 是否由开机自启动任务计划拉起
 
@@ -702,6 +710,52 @@ function createWindow() {
   mainWindow = win
   lastWindowActivity = null
 
+  // 崩溃时窗口若在托盘里，恢复后保持隐藏，不要自己弹出来打断用户。
+  let keepHiddenAfterRecovery = false
+
+  // 渲染进程崩溃恢复。Electron 不会自动重建崩掉的渲染进程：BrowserWindow 还在，
+  // 托盘和显示/隐藏都正常，但里面的 frame 已经没了，用户看到的是一个永远黑着的
+  // 窗口，只能从任务管理器强杀。没有这个监听时日志里也不会留下任何记录。
+  win.webContents.on('render-process-gone', (_event, details) => {
+    const decision = decideRendererRecovery({
+      reason: details.reason,
+      exitCode: details.exitCode,
+      isQuitting: coordinatedQuit || forceQuitInProgress || quitRequestInFlight,
+      isWindowDestroyed: win.isDestroyed(),
+      now: Date.now(),
+      previousCrashes: rendererCrashes,
+    })
+    rendererCrashes = decision.crashes
+
+    if (decision.action === 'ignore') {
+      logger.info(decision.detail)
+      return
+    }
+
+    logger.error(decision.detail)
+    captureMainRendererCrash({
+      reason: details.reason,
+      exitCode: details.exitCode,
+      crashCount: decision.crashCount,
+      action: decision.action,
+      detail: decision.detail,
+    })
+
+    if (decision.action === 'give-up') return
+
+    keepHiddenAfterRecovery = !win.isVisible()
+    win.webContents.reload()
+  })
+
+  win.on('unresponsive', () => {
+    logger.warn('渲染进程无响应（主线程卡住），等待其自行恢复')
+    recordMainCount('auto_mas.app.renderer.unresponsive', { component: 'electron-main' })
+  })
+
+  win.on('responsive', () => {
+    logger.info('渲染进程已恢复响应')
+  })
+
   // Electron 在最大化窗口最小化后会让 isMaximized() 返回 false，单独记住恢复目标状态。
   let restoreToMaximized = Boolean(config.UI.maximized)
   win.on('maximize', () => {
@@ -719,6 +773,14 @@ function createWindow() {
 
   // 页面加载完成后再显示窗口，避免白屏闪烁
   win.webContents.on('did-finish-load', () => {
+    // 崩溃前窗口就在托盘里，恢复后保持隐藏，不要打断用户。
+    if (keepHiddenAfterRecovery) {
+      keepHiddenAfterRecovery = false
+      notifyWindowActivity('background')
+      logger.info('渲染进程已恢复，窗口保持托盘隐藏状态')
+      return
+    }
+
     // 仅开机自启动且开启"启动后直接最小化"时才隐藏窗口，手动双击启动始终显示
     if (!(isAutoStart && config.Start.IfMinimizeDirectly)) {
       win.show()
@@ -1773,6 +1835,14 @@ app.on('second-instance', () => {
     mainWindow.show()
     mainWindow.focus()
   }
+})
+
+// GPU 进程崩溃同样会让窗口变黑，此前同样不会在日志里留下任何痕迹。
+app.on('child-process-gone', (_event, details) => {
+  if (details.reason === 'clean-exit') return
+  logger.error(
+    `子进程异常退出: type=${details.type}, reason=${details.reason}, exitCode=${details.exitCode}`
+  )
 })
 
 app.on('will-quit', () => {

--- a/frontend/electron/rendererCrashRecovery.test.ts
+++ b/frontend/electron/rendererCrashRecovery.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CRASH_WINDOW_MS,
+  MAX_RELOAD_ATTEMPTS,
+  decideRendererRecovery,
+  type RendererCrashInput,
+} from './rendererCrashRecovery'
+
+const baseInput = (overrides: Partial<RendererCrashInput> = {}): RendererCrashInput => ({
+  reason: 'crashed',
+  exitCode: 5,
+  isQuitting: false,
+  isWindowDestroyed: false,
+  now: 1_000_000,
+  previousCrashes: [],
+  ...overrides,
+})
+
+describe('decideRendererRecovery', () => {
+  it('重载首次崩溃并记录时间戳', () => {
+    const decision = decideRendererRecovery(baseInput())
+
+    expect(decision.action).toBe('reload')
+    expect(decision.crashCount).toBe(1)
+    expect(decision.crashes).toEqual([1_000_000])
+    expect(decision.detail).toContain('crashed')
+  })
+
+  it('正常退出不重载也不计入崩溃统计', () => {
+    const decision = decideRendererRecovery(
+      baseInput({ reason: 'clean-exit', exitCode: 0, previousCrashes: [999_000] })
+    )
+
+    expect(decision.action).toBe('ignore')
+    expect(decision.crashes).toEqual([999_000])
+    expect(decision.crashCount).toBe(1)
+  })
+
+  it('应用退出过程中的渲染进程消失不做恢复', () => {
+    const decision = decideRendererRecovery(baseInput({ isQuitting: true }))
+
+    expect(decision.action).toBe('ignore')
+  })
+
+  it('窗口已销毁时放弃重载', () => {
+    const decision = decideRendererRecovery(baseInput({ isWindowDestroyed: true }))
+
+    expect(decision.action).toBe('give-up')
+  })
+
+  it('统计窗口内超过上限后停止重载', () => {
+    const previousCrashes = Array.from({ length: MAX_RELOAD_ATTEMPTS }, (_, i) => 999_000 + i)
+    const decision = decideRendererRecovery(baseInput({ previousCrashes }))
+
+    expect(decision.action).toBe('give-up')
+    expect(decision.crashCount).toBe(MAX_RELOAD_ATTEMPTS + 1)
+    expect(decision.detail).toContain(`${MAX_RELOAD_ATTEMPTS} 次自动重载上限`)
+  })
+
+  it('窗口期外的旧崩溃被剔除，重新允许重载', () => {
+    const now = CRASH_WINDOW_MS * 2
+    const stale = Array.from({ length: MAX_RELOAD_ATTEMPTS }, (_, i) => i)
+    const decision = decideRendererRecovery(baseInput({ now, previousCrashes: stale }))
+
+    expect(decision.action).toBe('reload')
+    expect(decision.crashCount).toBe(1)
+    expect(decision.crashes).toEqual([now])
+  })
+
+  it('oom 与 launch-failed 同样触发重载', () => {
+    for (const reason of ['oom', 'launch-failed', 'abnormal-exit', 'killed']) {
+      expect(decideRendererRecovery(baseInput({ reason })).action).toBe('reload')
+    }
+  })
+})

--- a/frontend/electron/rendererCrashRecovery.ts
+++ b/frontend/electron/rendererCrashRecovery.ts
@@ -1,0 +1,96 @@
+/**
+ * 渲染进程崩溃恢复决策。
+ *
+ * Electron 不会自动重建崩掉的渲染进程：`render-process-gone` 之后 BrowserWindow
+ * 还在（托盘、显示/隐藏都正常），但里面的 frame 已经没了，用户看到的就是一个
+ * 永远黑着的窗口，只能从任务管理器强杀。这里把「要不要重载」的判断抽成纯函数，
+ * 副作用留在 main.ts。
+ */
+
+export interface RendererCrashInput {
+  /** `render-process-gone` 事件的 details.reason。 */
+  reason: string
+  /** `render-process-gone` 事件的 details.exitCode。 */
+  exitCode: number
+  /** 应用正在退出时渲染进程消失属于正常拆卸，不做恢复。 */
+  isQuitting: boolean
+  /** 窗口已销毁时没有可重载的目标。 */
+  isWindowDestroyed: boolean
+  now: number
+  /** 此前若干次崩溃的时间戳（毫秒）。 */
+  previousCrashes: readonly number[]
+}
+
+export type RendererRecoveryAction = 'ignore' | 'reload' | 'give-up'
+
+export interface RendererCrashDecision {
+  action: RendererRecoveryAction
+  /** 决策说明，直接写进日志与上报。 */
+  detail: string
+  /** 保留在统计窗口内的崩溃时间戳，供下一次决策使用。 */
+  crashes: number[]
+  /** 本次崩溃在统计窗口内是第几次。 */
+  crashCount: number
+}
+
+/** 连续崩溃统计窗口：只有窗口期内的崩溃才算「反复崩溃」。 */
+export const CRASH_WINDOW_MS = 5 * 60 * 1000
+
+/** 统计窗口内最多自动重载几次，超出就停手，避免崩溃—重载死循环烧 CPU。 */
+export const MAX_RELOAD_ATTEMPTS = 3
+
+export function decideRendererRecovery(input: RendererCrashInput): RendererCrashDecision {
+  const kept = input.previousCrashes.filter(at => input.now - at < CRASH_WINDOW_MS)
+
+  // 正常退出不计入崩溃统计，否则退出流程会污染下一次启动的判断。
+  if (input.reason === 'clean-exit') {
+    return {
+      action: 'ignore',
+      detail: '渲染进程正常退出（clean-exit）',
+      crashes: kept,
+      crashCount: kept.length,
+    }
+  }
+
+  const crashes = [...kept, input.now]
+  const crashCount = crashes.length
+
+  if (input.isQuitting) {
+    return {
+      action: 'ignore',
+      detail: `应用正在退出，忽略渲染进程退出（reason=${input.reason}）`,
+      crashes,
+      crashCount,
+    }
+  }
+
+  if (input.isWindowDestroyed) {
+    return {
+      action: 'give-up',
+      detail: `窗口已销毁，无法重载（reason=${input.reason}）`,
+      crashes,
+      crashCount,
+    }
+  }
+
+  if (crashCount > MAX_RELOAD_ATTEMPTS) {
+    return {
+      action: 'give-up',
+      detail:
+        `渲染进程 ${CRASH_WINDOW_MS / 1000}s 内第 ${crashCount} 次崩溃` +
+        `（reason=${input.reason}, exitCode=${input.exitCode}），` +
+        `超过 ${MAX_RELOAD_ATTEMPTS} 次自动重载上限，停止重载`,
+      crashes,
+      crashCount,
+    }
+  }
+
+  return {
+    action: 'reload',
+    detail:
+      `渲染进程异常退出（reason=${input.reason}, exitCode=${input.exitCode}），` +
+      `第 ${crashCount}/${MAX_RELOAD_ATTEMPTS} 次自动重载`,
+    crashes,
+    crashCount,
+  }
+}

--- a/frontend/electron/services/sentry.ts
+++ b/frontend/electron/services/sentry.ts
@@ -104,3 +104,38 @@ export const recordMainStartup = () => {
     component: 'electron-main',
   })
 }
+
+/**
+ * 上报渲染进程崩溃。
+ *
+ * Minidump 集成在上面被整体过滤掉了（Windows minidump 含完整命令行与环境变量块，
+ * 且附件拼进 envelope 的时机在 beforeSend 之后，脱敏钩子够不到），所以渲染进程
+ * 崩溃不会自动进 Sentry。这里补一条只带 reason/exitCode 的结构化事件。
+ */
+export const captureMainRendererCrash = (details: {
+  reason: string
+  exitCode: number
+  crashCount: number
+  action: string
+  detail: string
+}) => {
+  if (!isSentryEnabled()) return
+
+  try {
+    Sentry.captureMessage(`渲染进程退出: ${details.reason}`, {
+      level: 'fatal',
+      tags: {
+        component: 'electron-main',
+        renderer_gone_reason: details.reason,
+        renderer_recovery_action: details.action,
+      },
+      extra: {
+        exitCode: details.exitCode,
+        crashCount: details.crashCount,
+        detail: details.detail,
+      },
+    })
+  } catch {
+    // 遥测失败不能影响恢复流程。
+  }
+}

--- a/frontend/tsconfig.electron.json
+++ b/frontend/tsconfig.electron.json
@@ -16,5 +16,6 @@
     },
     "verbatimModuleSyntax": false
   },
-  "include": ["electron/**/*.ts"]
+  "include": ["electron/**/*.ts"],
+  "exclude": ["electron/**/*.test.ts"]
 }

--- a/res/version.json
+++ b/res/version.json
@@ -12,6 +12,7 @@
                 "BetterGI专项 清理：移除未达提交规范的测试文件，修复其格式与静态检查问题，并移除 .yarnrc.yml 中误提交的 npm 镜像源 by [@1w1w11w1](https://github.com/1w1w11w1)"
             ],
             "修复BUG": [
+                "渲染进程崩溃后不再永久黑屏：新增 render-process-gone / unresponsive / child-process-gone 监听，崩溃时记录 reason 与 exitCode 并自动重载窗口（5 分钟内最多 3 次，窗口原本在托盘则恢复后保持隐藏）；此前渲染进程一死主进程与后端仍在运行，窗口会一直黑着且日志与 Sentry 里没有任何记录，只能从任务管理器强杀",
                 "修复 MaaFW 运行池解释器自检不覆盖标准库、导致 Python 运行时损坏时直到任务中途才报出难以理解的错误的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "新增 AUTO_MAS_UV_PYTHON_INSTALL_MIRROR，受限网络下可为 MaaFW 运行池的 Python 解释器下载配置镜像 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 MaaFW 运行环境不可用时仍会按重试次数反复重启模拟器与游戏、白等数分钟的问题 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
## 问题

Electron 不会自动重建崩掉的渲染进程。`render-process-gone` 之后 BrowserWindow 还在（托盘、显示/隐藏都正常），但里面的 frame 已经没了 —— 用户看到的是一个永远黑着的窗口，主进程和后端仍在跑，只能从任务管理器强杀。

`main.ts` 里此前没有任何崩溃监听，日志里不会留痕；Sentry 也收不到 —— minidump 集成因 PII 被整体 filter 掉了。

一份 v5.4.0 用户日志里 4 天崩了 3 次，每次黑屏 12~16 小时直到手动重启：

```
2026-09-01 16:53:10 | ERROR | 控制台 | Error sending from webFrameMain:
  Error: Render frame was disposed before WebFrameMain could be accessed
    at notifyWindowActivity (...\dist-electron\main.js:373:28)
```

同期后端毫发无损（M9A 跑完 Success、MAA 正常启动），只是对着不存在的前端打了 20 万条 `WebSocket 未连接`。

## 改动

- 新增 `rendererCrashRecovery`：把「要不要重载」抽成纯函数。`clean-exit` 与退出流程中的渲染进程消失不做恢复；5 分钟内最多自动重载 3 次，超出即停手，避免崩溃—重载死循环
- `main.ts` 挂上 `render-process-gone` / `unresponsive` / `responsive` 与 app 级 `child-process-gone`（GPU 进程崩溃同样黑屏、同样无记录），记录 reason 与 exitCode
- 崩溃时窗口若在托盘里，恢复后保持隐藏，不打断用户
- `sentry.ts` 新增 `captureMainRendererCrash`，只上报 reason/exitCode/次数，不碰 minidump
- `tsconfig.electron.json` 排除 `*.test.ts` —— `include` 是 `electron/**/*.ts` 且 `files` 含 `dist-electron/**`，不排会把测试打进 asar

## 验证

`build:main` / `typecheck` / `lint` / `oxfmt --check` / `vitest`（143 passed，含新增 7 例）全过。

另外临时加钩子强制崩溃实跑了一遍，验证后已撤除：

```
渲染进程异常退出（reason=crashed, exitCode=2），第 1/3 次自动重载
页面加载完成，窗口已显示                                      ← 170ms 恢复
渲染进程 300s 内第 4 次崩溃，超过 3 次自动重载上限，停止重载    ← 上限生效
```

托盘隐藏路径单独验过：

```
渲染进程异常退出（reason=crashed, exitCode=2），第 1/3 次自动重载
渲染进程已恢复，窗口保持托盘隐藏状态                           ← 不弹窗
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

自动恢复失败的 Electron 渲染进程，同时记录崩溃诊断信息，并防止重复的恢复循环。

新功能：
- 在渲染进程意外退出后，通过重新加载窗口自动恢复，同时保留托盘隐藏状态。

错误修复：
- 防止渲染进程或相关子进程崩溃后 Electron 窗口永久黑屏。
- 通过限制滚动五分钟时间窗口内的自动恢复尝试次数，避免无限崩溃-重新加载循环。

增强功能：
- 为渲染进程崩溃、无响应状态和子进程异常退出添加结构化日志记录和 Sentry 报告。
- 在恢复决策中忽略正常的渲染进程退出以及与关机相关的进程终止。

构建：
- 从 Electron TypeScript 构建输出中排除 Electron 测试文件。

测试：
- 增加对渲染进程恢复决策、关机处理、崩溃次数限制、过期崩溃记录和受支持退出原因的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically recover failed Electron renderer processes while recording crash diagnostics and preventing repeated recovery loops.

New Features:
- Automatically recover renderer processes by reloading the window after unexpected exits, while preserving tray-hidden state.

Bug Fixes:
- Prevent permanently black Electron windows after renderer or related child-process crashes.
- Avoid infinite crash-reload loops by limiting automatic recovery attempts within a rolling five-minute window.

Enhancements:
- Add structured logging and Sentry reporting for renderer crashes, unresponsive states, and abnormal child-process exits.
- Ignore clean renderer exits and shutdown-related process termination during recovery decisions.

Build:
- Exclude Electron test files from the Electron TypeScript build output.

Tests:
- Add coverage for renderer recovery decisions, shutdown handling, crash limits, stale crash records, and supported exit reasons.

</details>