### PR TITLE
修复剿灭周完成状态误判

### DIFF
--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -114,6 +114,15 @@ def _parse_annihilation_weekly_progress(log: str) -> tuple[int, int] | None:
     return (current, total) if total > 0 else None
 
 
+def _has_completed_annihilation_week(log: str) -> bool:
+    """判断剿灭日志是否表明本周额度已完成。"""
+
+    progress = _parse_annihilation_weekly_progress(log)
+    return "完成任务: 剿灭作战" in log and (
+        progress is None or progress[0] >= progress[1]
+    )
+
+
 def _has_completed_sanity_task(log_records: list[LogRecord]) -> bool:
     """判断日志记录中是否已经完成过体力任务。"""
 
@@ -1021,8 +1030,7 @@ class AutoProxyTask(TaskExecuteBase):
 
         if self.mode == "Annihilation":
             progress = _parse_annihilation_weekly_progress(log)
-            completed = progress and progress[0] >= progress[1]
-            completed = completed or "完成任务: 剿灭作战" in log
+            completed = _has_completed_annihilation_week(log)
             if completed:
                 self.task_dict["Fight"] = False
                 self.run_book["Annihilation"] = True

--- a/res/version.json
+++ b/res/version.json
@@ -15,6 +15,7 @@
             ],
             "修复BUG": [
                 "渲染进程崩溃后不再永久黑屏：新增 render-process-gone / unresponsive / child-process-gone 监听，崩溃时记录 reason 与 exitCode 并自动重载窗口（5 分钟内最多 3 次，窗口原本在托盘则恢复后保持隐藏）；此前渲染进程一死主进程与后端仍在运行，窗口会一直黑着且日志与 Sentry 里没有任何记录，只能从任务管理器强杀 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MAA专项 修复剿灭任务因体力耗尽结束时被误判为已完成本周额度的问题",
                 "修复 MaaFW 运行池解释器自检不覆盖标准库、导致 Python 运行时损坏时直到任务中途才报出难以理解的错误的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "新增 AUTO_MAS_UV_PYTHON_INSTALL_MIRROR，受限网络下可为 MaaFW 运行池的 Python 解释器下载配置镜像 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 MaaFW 运行环境不可用时仍会按重试次数反复重启模拟器与游戏、白等数分钟的问题 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
- 修复剿灭任务因体力耗尽结束时被误判为已完成本周额度的问题。

## Summary by Sourcery

修正剿灭周任务完成状态判断，确保仅在日志明确表明任务完成且周额度已达标时结束任务。

Bug Fixes:
- 修复剿灭作战因体力耗尽结束时被误判为已完成本周额度的问题。

Chores:
- 更新版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修正剿灭周任务完成状态判断，确保仅在日志明确表明任务完成且周额度已达标时结束任务。

Bug Fixes:
- 修复剿灭作战因体力耗尽结束时被误判为已完成本周额度的问题。

Chores:
- 更新版本信息。

</details>