### PR TITLE
fix(okww): 返回登录等待超时时不再静默处理，显式弹出失败

### DIFF
--- a/app/task/Okww/tools/account_switch.py
+++ b/app/task/Okww/tools/account_switch.py
@@ -508,12 +508,18 @@ def _switch_to_login(hwnd: int, on_log: Callable[[str], None]) -> None:
             round(0.63 * _FRAME_HEIGHT),
             after_sleep=3,
         )
-    _wait_ocr_text(
+    if _wait_ocr_text(
         hwnd,
         _LOGIN_PAGE_TEXTS,
         roi=_LOGIN_ROI,
         timeout=60,
-    )
+    ) is None:
+        # 不能在等待超时后假报「已返回登录界面」：盲点可能误触登录进入游戏，
+        # 此时画面无掩码账号，继续选号必然失败且更难排查，必须显式失败留证。
+        raise RuntimeError(
+            "返回登录流程结束但未识别到登录界面（60s 未出现「其他登录方式」），"
+            "可能误入了游戏内画面，请人工确认后重试"
+        )
     on_log("已返回登录界面")
 
 

--- a/res/version.json
+++ b/res/version.json
@@ -34,7 +34,8 @@
                 "OK-WW专项 修复任务报告推送因漏传通知用户配置参数而失败的问题 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "游戏签到 修复通知返回值改为 DispatchResult 后未同步两处消费方、开启签到通知时执行签到必报 TypeError 的问题（手动签到接口返回 500，慢渠道后台通知路径丢失日志） by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "修复明日方舟PC工具连接失败后每秒重试并反复弹出错误提示的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "OK-WW专项 修复账号切换在游戏启动阶段定位不到窗口、或界面尚未进入可执行登录态就误操作而失败的问题，改为分段进展续延等待：先轮询窗口就绪，再等待界面进入「登录页/已登录主菜单」（游戏内长时间更新/加载时持续顺延，长时间无进展才判失败），兼容低性能设备启动延迟 by [@AthenaHibou](https://github.com/AthenaHibou)"
+                "OK-WW专项 修复账号切换在游戏启动阶段定位不到窗口、或界面尚未进入可执行登录态就误操作而失败的问题，改为分段进展续延等待：先轮询窗口就绪，再等待界面进入「登录页/已登录主菜单」（游戏内长时间更新/加载时持续顺延，长时间无进展才判失败），兼容低性能设备启动延迟 by [@AthenaHibou](https://github.com/AthenaHibou)",
+                "OK-WW专项 账号切换未能回到登录界面时立即报错并说明原因，不再误报已就绪后在错误画面上继续选号失败 by [@AthenaHibou](https://github.com/AthenaHibou)"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
### 改动摘要

- 修复 OK-WW 账号切换在返回登录流程未能真正回到登录界面时，仍误报「已返回登录界面」并继续在错误画面上选号的问题（多用户切换的第二个账号失败且报错难以理解）。
- 处理：返回登录后的等待超时不再被忽略，立即失败并给出明确原因，配合既有的诊断截图便于排查。
- 已知触发场景：上一用户退出后游戏刚重新拉起、界面仍在过渡时，旧逻辑误走游戏内返回流程并误触登录。

## Sourcery 摘要

确保 OK-WW 账号切换只有在确认返回登录界面后才继续，并在超时时明确中止流程。

Bug 修复：
- 修复 OK-WW 账号切换返回登录界面超时后仍被误判成功并继续操作的问题。

功能增强：
- 在未识别到登录界面时立即显式失败并提供明确诊断信息，避免误触登录流程并便于结合截图排查。

维护：
- 更新应用版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 OK-WW 账号切换只有在确认返回登录界面后才继续，并在超时时明确中止流程。

Bug Fixes:
- 修复 OK-WW 账号切换返回登录界面超时后仍被误判成功并继续操作的问题。

Enhancements:
- 在未识别到登录界面时立即显式失败并提供明确诊断信息，避免误触登录流程并便于结合截图排查。

Chores:
- 更新应用版本信息。

</details>