### PR TITLE
fix(maafw): 便携版 embeddable Python 不再作运行池 venv 引导

### DIFF
--- a/app/task/MaaFW/embedded_manager.py
+++ b/app/task/MaaFW/embedded_manager.py
@@ -59,9 +59,13 @@ logger = get_logger("MFW 内置运行")
 def describe_unusable_runtime(project_path: Path) -> str | None:
     """运行前自检：这个项目要用的运行池 runtime 还能用吗？
 
-    只在池里已经存在匹配的 runtime 时才探一次（一个子进程，约 100ms——解释器
-    本来就要起）。没建过就不拦：那份环境会在运行时按需准备，失败自有它自己的
-    报错路径。
+    只在池里已经存在这个项目会用到的那份 runtime 时才探一次（一个子进程，约
+    100ms——解释器本来就要起）。没建过就不拦：那份环境会在运行时按需准备，失败
+    自有它自己的报错路径。
+
+    runtime 的选法与 ``prepare_runner_environment`` 一致：同一份依赖选择器加同一个
+    引导解释器。只按 MaaFW 版本去池里挑不行——旧版本用便携包 embeddable Python
+    建出的坏环境和修好后新建的好环境 MaaFW 版本相同，挑错了会把能跑的任务拦下。
 
     拦在 ``check()`` 而不是只靠编辑页的提示：队列与定时任务不经过编辑页，
     绕不过 check()；而且这里拦下来时模拟器和游戏都还没启动。
@@ -69,37 +73,40 @@ def describe_unusable_runtime(project_path: Path) -> str | None:
 
     # 运行池会拉起 uv 与安装器，只在真要用时导入，别让每次 import 都付这份成本。
     from app.task.MaaFW.tools.core.automas_maafw_runner.environment import (
+        build_runner_packages,
         resolve_project_maafw_requirement,
     )
     from app.task.MaaFW.tools.core.automas_maafw_runtime_pool import (
+        MaaFWRuntimePoolError,
         MaaFWRuntimePoolService,
     )
     from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.installer import (
-        probe_python_identity,
+        host_bootstrap_python_request,
     )
 
     try:
         requirement = resolve_project_maafw_requirement(project_path)
+        if not requirement:
+            return None
+        packages = build_runner_packages(project_path, maafw_requirement=requirement)
+        service = MaaFWRuntimePoolService()
+        python_identity = None
+        bootstrap_request = host_bootstrap_python_request()
+        if bootstrap_request is not None:
+            target = service.pool.resolve_python(bootstrap_request, allow_install=False)
+            if target is None:
+                # 托管解释器还没装，runtime 也就不可能存在。
+                return None
+            python_identity = target["identity"]
     except Exception:  # noqa: BLE001 - 自检失败不该反过来挡住运行
-        return None
-    if not requirement:
         return None
 
     try:
-        runtimes = MaaFWRuntimePoolService().list()
+        # 找到 runtime 后 resolve() 会真的起一次解释器核对 ABI，起不来就是坏了。
+        service.resolve(packages, python_identity=python_identity)
+    except MaaFWRuntimePoolError as exc:  # 原文就是给用户看的
+        return f"MFW 运行环境不可用：{exc}"
     except Exception:  # noqa: BLE001
-        return None
-
-    for runtime in runtimes:
-        if str(runtime.get("maafwRequirement") or "").strip() != requirement:
-            continue
-        python_executable = str(runtime.get("pythonExecutable") or "").strip()
-        if not python_executable:
-            continue
-        try:
-            probe_python_identity(Path(python_executable))
-        except Exception as exc:  # noqa: BLE001 - 原文就是给用户看的
-            return f"MFW 运行环境不可用：{exc}"
         return None
     return None
 

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
@@ -24,6 +24,9 @@ from app.task.MaaFW.tools.core.automas_maafw_runtime_pool import (
     canonicalize_requirements,
     install_python_runtime,
 )
+from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.installer import (
+    host_bootstrap_python_request,
+)
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
@@ -253,6 +256,8 @@ def prepare_runner_environment(
         raise RuntimeError(
             "MaaFW Managed Python constraint 必须随完整 selector/runtimeId 注入"
         )
+    bootstrap_python = sys.executable
+    bootstrap_python_identity: dict[str, Any] | None = None
     if explicit_requirements is not None and bound_runtime_id:
         if bound_runtime is None:
             raise RuntimeError(f"MaaFW Managed runtime 不存在: {bound_runtime_id}")
@@ -276,7 +281,34 @@ def prepare_runner_environment(
         # the CP312 host process.
         expected_runtime_id = bound_runtime_id
     else:
-        expected_runtime_id = build_runtime_id(packages)
+        # 宿主是 embeddable 发行版时不能拿它建 venv（见 installer 探针注释），改用
+        # 池内同小版本的托管解释器；identity 也随之取自那份解释器，别再从宿主进程推。
+        bootstrap_request = host_bootstrap_python_request()
+        if bootstrap_request is not None:
+            bootstrap_target = pool.resolve_python(
+                bootstrap_request, allow_install=False
+            )
+            if bootstrap_target is None:
+                _report_environment_progress(
+                    progress,
+                    "installing_python",
+                    "running",
+                    "正在准备 MaaFW Runtime 的 Python 解释器",
+                    percent=10.0,
+                )
+                bootstrap_target = pool.resolve_python(
+                    bootstrap_request, allow_install=True
+                )
+            if bootstrap_target is None:  # pragma: no cover - fail-closed
+                raise RuntimeError(
+                    "MaaFW runtime 宿主 Python 不能作引导，且池内没有可用的托管解释器"
+                )
+            bootstrap_python = str(bootstrap_target["executable"])
+            bootstrap_python_identity = dict(bootstrap_target["identity"])
+        expected_runtime_id = build_runtime_id(
+            packages,
+            python_identity=bootstrap_python_identity,
+        )
     _report_environment_progress(
         progress,
         "runtime_check",
@@ -324,9 +356,10 @@ def prepare_runner_environment(
             requirements,
             identity,
             cwd=project,
-            # Runtime identity is derived from this process' Python ABI, so
-            # the created environment must use the same interpreter family.
-            bootstrap_python=sys.executable,
+            # Runtime identity is derived from the bootstrap interpreter (this
+            # process, or the pool-managed one standing in for an embeddable
+            # host), so the created environment must use that same interpreter.
+            bootstrap_python=bootstrap_python,
             send_log=send_log,
         )
 
@@ -337,6 +370,7 @@ def prepare_runner_environment(
             packages,
             installer=runtime_installer or install,
             metadata={"component": "automas-maafw-runner"},
+            python_identity=bootstrap_python_identity,
         )
     resolved_runtime_id = str(runtime["runtimeId"])
     _report_environment_progress(
@@ -777,7 +811,6 @@ def _declared_project_maafw_requirement(project_path: Path) -> str | None:
     return matches[0] if matches else None
 
 
-
 def resolve_project_maafw_requirement(project_path: Path) -> str | None:
     """普通项目（非 Managed）会用到的 MaaFW requirement。
 
@@ -789,9 +822,14 @@ def resolve_project_maafw_requirement(project_path: Path) -> str | None:
     """
 
     project = Path(project_path)
-    return _bundled_project_maafw_requirement(
+    requirement = _bundled_project_maafw_requirement(
         project
     ) or _declared_project_maafw_requirement(project)
+    if requirement is None:
+        return None
+    return _normalize_maafw_requirement(requirement, allow_unconstrained=True)
+
+
 def _normalize_python_constraint(value: str | None) -> str | None:
     if value is None:
         return None

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
@@ -39,8 +39,16 @@ SUPPORTED_CPYTHON_MINORS = ((3, 12), (3, 13))
 # 照样报得一模一样。真机上就这么漏过去过——探测全绿，worker 起来才在
 # ``maa/library.py`` 第 1 行炸掉，抛出的还是 ctypes 内部的天书。放在同一个子进程
 # 里做，零额外开销。
+#
+# stdlibLandmark：解释器能否靠 ``Lib/os.py`` 这个 landmark 找到自己的标准库。
+# 便携包随附的 embeddable 发行版把标准库装在 python3xx.zip 里、靠 python3xx._pth
+# 定位；uv 复制它建 venv 时不会带上 ._pth，建出的解释器找不到 landmark，就按
+# CPython 在 Windows 上的回退规则读注册表 PythonPath，把本机另一份同小版本 Python
+# 的 Lib/DLLs 混进 sys.path——3.12.10 的 _ctypes.pyd 装进 3.12.0 的 python312.dll，
+# ``import ctypes`` 直接炸，而 base 解释器自己却是好的。没有 landmark 的解释器
+# 因此不能当 venv 的引导，见 ``host_bootstrap_python_request``。
 _IDENTITY_PROBE_SCRIPT = (
-    "import ctypes,json,platform,sys,sysconfig;"
+    "import ctypes,json,os,platform,sys,sysconfig;"
     "print(json.dumps({"
     "'implementation': getattr(sys.implementation, 'name', 'python'),"
     "'cacheTag': getattr(sys.implementation, 'cache_tag', None) or 'unknown',"
@@ -49,8 +57,31 @@ _IDENTITY_PROBE_SCRIPT = (
     "'shortVersion': f'{sys.version_info.major}.{sys.version_info.minor}',"
     "'platform': sysconfig.get_platform() or sys.platform,"
     "'architecture': platform.machine() or 'unknown',"
+    "'stdlibLandmark': os.path.isfile("
+    "os.path.join(sysconfig.get_paths()['stdlib'], 'os.py')),"
     "}))"
 )
+
+
+def host_bootstrap_python_request() -> dict[str, str] | None:
+    """宿主解释器不能作 venv 引导时，给出替代它的 python request。
+
+    便携包的 ``environment/python`` 是 embeddable 发行版，由它建出的 venv 不自
+    包含（见 ``_IDENTITY_PROBE_SCRIPT`` 里 stdlibLandmark 的说明）。这时运行池
+    要改用同小版本的托管解释器，identity 也随之取自那份解释器，不再从宿主进程推。
+
+    Returns:
+        宿主能自己作引导时返回 ``None``；否则返回同小版本的 python request，
+        交给 ``resolve_python_interpreter`` 去找或下载。
+    """
+
+    probe = probe_python_identity(Path(sys.executable))
+    if _python_probe_can_bootstrap(probe):
+        return None
+    return {
+        "implementation": "cpython",
+        "constraint": f"=={sys.version_info.major}.{sys.version_info.minor}.*",
+    }
 
 
 def resolve_python_interpreter(
@@ -62,9 +93,10 @@ def resolve_python_interpreter(
     """Resolve one exact interpreter for an explicit Python constraint.
 
     Resolution never silently crosses ABI boundaries.  The host interpreter
-    is reused when it satisfies the request.  Otherwise an explicitly
-    configured interpreter or a uv-managed interpreter under ``pool/python``
-    is used.  Only ``allow_install=True`` may download a missing interpreter.
+    is reused when it satisfies the request and can bootstrap a self-contained
+    venv (an embeddable host cannot).  Otherwise an explicitly configured
+    interpreter or a uv-managed interpreter under ``pool/python`` is used.
+    Only ``allow_install=True`` may download a missing interpreter.
     """
 
     implementation = (
@@ -82,7 +114,9 @@ def resolve_python_interpreter(
         )
 
     host_probe = probe_python_identity(Path(sys.executable))
-    if _python_probe_satisfies(host_probe, implementation, specifier):
+    if _python_probe_satisfies(
+        host_probe, implementation, specifier
+    ) and _python_probe_can_bootstrap(host_probe):
         return {
             "executable": str(Path(sys.executable).resolve()),
             "identity": host_probe,
@@ -111,6 +145,11 @@ def resolve_python_interpreter(
                 "configured MaaFW runtime Python does not satisfy the request: "
                 f"path={configured}, constraint={constraint}, "
                 f"actual={probe.get('implementation')} {probe.get('version')}"
+            )
+        if not _python_probe_can_bootstrap(probe):
+            raise RuntimeError(
+                "configured MaaFW runtime Python cannot bootstrap a self-contained "
+                f"venv (embeddable distribution without a stdlib landmark): {configured}"
             )
         return {
             "executable": str(configured.resolve()),
@@ -256,13 +295,22 @@ def install_python_runtime(
     is available, package downloads and unpacked wheels are shared through a
     cache located beside the pool's ``runtimes``/``.staging`` directories, and
     uv hardlinks cached package files into each venv.  A complete Python may
-    fall back to stdlib ``venv`` + pip when uv is unavailable; an embeddable
-    Python without ``venv``/``ensurepip`` cannot.
+    fall back to stdlib ``venv`` + pip when uv is unavailable.  An embeddable
+    Python is rejected outright: even uv can only copy it into a venv that has
+    to borrow a stdlib from the Windows registry.
     """
 
     log = send_log or (lambda _: None)
     bootstrap = str(bootstrap_python or sys.executable)
-    _verify_runtime_identity(Path(bootstrap), identity)
+    bootstrap_probe = _verify_runtime_identity(Path(bootstrap), identity)
+    if not _python_probe_can_bootstrap(bootstrap_probe):
+        # 调用方应先经 host_bootstrap_python_request() 换成托管解释器；走到这里
+        # 说明有路径漏了，宁可失败也别建出一份靠注册表凑标准库的环境。
+        raise RuntimeError(
+            "MaaFW runtime 安装失败：引导 Python 找不到自己的标准库"
+            "（便携版常见 embeddable 发行版），由它建出的环境不自包含，"
+            f"会从注册表混入本机其它 Python 的标准库：{bootstrap}"
+        )
     resolved_cwd = Path(cwd).resolve() if cwd is not None else Path.cwd()
     pool_root = _runtime_pool_root(environment_path)
     uv_cache_dir = (pool_root / UV_CACHE_RELATIVE_PATH).resolve()
@@ -362,7 +410,9 @@ def _create_environment(
 
     绿色免安装包随附的 environment/python 是 embeddable 发行版
     （python3xx._pth，不含 Lib/venv），`python.exe -m venv` 会直接报
-    "No module named venv"。必须先探测，不合格再走 uv 兜底。
+    "No module named venv"——它在 ``install_python_runtime`` 里就被拒了，
+    根本到不了这里。这里的 uv 兜底只服务完整但没带 venv/ensurepip 模块的
+    解释器（部分发行版把它们拆成了单独的包）。
     """
 
     if _python_supports_venv(bootstrap):
@@ -516,6 +566,12 @@ def _python_probe_satisfies(
     except InvalidVersion:
         return False
     return specifier.contains(version, prereleases=True)
+
+
+def _python_probe_can_bootstrap(probe: Mapping[str, Any]) -> bool:
+    """探针报告了 stdlibLandmark 才能建自包含的 venv；缺字段按不能处理。"""
+
+    return str(probe.get("stdlibLandmark") or "").strip().casefold() == "true"
 
 
 def _configured_python_executable(target_version: str) -> Path | None:
@@ -915,7 +971,9 @@ def _probe_python_identity(python_executable: Path) -> dict[str, str]:
                 "MaaFW runtime Python 自检失败：标准库 ctypes 不可用。"
                 "MaaFW 绑定完全依赖 ctypes，这通常意味着这份 Python 的标准库与"
                 "扩展模块来自不同构建——例如运行时被升级或替换过，而已有的运行池"
-                f"仍指向它。请修复或重装该 Python 运行时。原始错误：{detail[-400:]}"
+                "仍指向它；或者这个环境是早期版本用便携包的 embeddable Python 建的，"
+                "从注册表混入了本机另一份 Python 的扩展模块。前者请修复或重装该 "
+                f"Python 运行时，后者删除该运行环境后重新准备即可。原始错误：{detail[-400:]}"
             )
         raise RuntimeError(
             f"MaaFW runtime ABI 探测失败 (exit={result.returncode}): {detail[:400]}"

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/service.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/service.py
@@ -10,7 +10,7 @@ from packaging.version import InvalidVersion, Version
 
 from .cache import prune_uv_cache
 from .identity import build_runtime_id, canonicalize_requirements
-from .installer import install_python_runtime
+from .installer import host_bootstrap_python_request, install_python_runtime
 from .pool import (
     MaaFWRuntimePool,
     MaaFWRuntimePoolError,
@@ -116,6 +116,9 @@ class MaaFWRuntimePoolService:
                 return resolved
         requirements, _, touch, python_request = _normalize_runtime_request(request)
         if python_request is None:
+            # 宿主是 embeddable 时不能拿它建 venv，改按同小版本走池内托管解释器。
+            python_request = host_bootstrap_python_request()
+        if python_request is None:
             return self.resolve(requirements, touch=touch)
         target = self.pool.resolve_python(python_request, allow_install=False)
         if target is None:
@@ -163,6 +166,8 @@ class MaaFWRuntimePoolService:
                         "cannot ensure an unknown runtimeId without requirements"
                     )
         requirements, metadata, _, python_request = _normalize_runtime_request(request)
+        if python_request is None:
+            python_request = host_bootstrap_python_request()
         if python_request is None:
             python_identity = None
             bootstrap_python = None

--- a/frontend/src/services/websocket/types.ts
+++ b/frontend/src/services/websocket/types.ts
@@ -142,7 +142,7 @@ export interface WSPowerSignData {
 
 /** MFW 运行环境准备进度 (id=<scriptId>, type=maafw.env-prepare.progress) */
 export interface WSMaaFWEnvPrepareProgressData {
-  /** resolving / creating_runtime / installing_runtime / runtime_ready / reused / log / ready / failed */
+  /** resolving / installing_python / creating_runtime / installing_runtime / runtime_ready / reused / log / ready / failed */
   stage: string
   /** running / success / failed */
   status: string

--- a/res/version.json
+++ b/res/version.json
@@ -47,7 +47,8 @@
                 "游戏签到 修复开启签到通知时执行签到必报 TypeError 的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "修复明日方舟PC工具连接失败后每秒重试并反复弹出错误提示的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "OK-NTE专项 修复日常任务在当日活跃度奖励已领取过（或日常领取子任务被关闭）时被误判为失败并反复重试的问题，已领取时任务报告显示「跳过（当日已领取）」 by [@AthenaHibou](https://github.com/AthenaHibou)",
-                "HSR专项 修复模块重试耗尽仍失败时用户被误标为「完成」的问题，调度台总览与任务报告不再把失败的代理报成成功 by [@qiyinxi](https://github.com/qiyinxi)"
+                "HSR专项 修复模块重试耗尽仍失败时用户被误标为「完成」的问题，调度台总览与任务报告不再把失败的代理报成成功 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MFW专项 修复便携版在装有另一份 Python 3.12 的电脑上运行环境准备成功、任务一启动却报 ctypes 错误的问题"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
便携版在装有另一份 Python 3.12 的电脑上，MFW 运行环境准备成功、任务一启动就报：

```
File ".../environment/Lib/site-packages/maa/library.py", line 1, in <module>
    import ctypes
File "ctypes/__init__.py", line 157, in <module>
AttributeError: class must define a '_type_' attribute
```

## 根因

便携包随附的 `environment/python` 是 embeddable 发行版。运行池拿它当 venv 引导时，uv 把整套 embeddable 复制进 venv 的 `Scripts\`，**但不带 `python312._pth`**。这个 python 找不到 `Lib\os.py` 这个标准库 landmark，CPython 的 `getpath.py` 就按 Windows 回退规则读注册表 `HKCU\Software\Python\PythonCore\3.12\PythonPath`，把本机系统 Python 3.12.10 的 `Lib;DLLs` 排在 venv `Scripts` 之前——3.12.10 的 `_ctypes.pyd` 装进 3.12.0 的 python312.dll。base 解释器自己 `import ctypes` 是好的，所以 #500 的探针只在 venv 上才会红；没装系统 Python 的机器完全不触发，测试端也就没暴露。

## 改动

- 探针新增 `stdlibLandmark`；没有 landmark 的解释器不再作引导（宿主跳过、configured 报错、`install_python_runtime` fail-closed）
- 无显式 python 约束时改按宿主小版本走池内托管解释器，identity 随之取自它；完整 Python 宿主下 runtime id 逐字节不变
- 运行前自检改按项目实际会用的那份 runtime 探测，不再按 MaaFW 版本随便挑（否则旧坏环境会把新好环境拦下）

## 验证

- `pytest tests/task/test_maafw_*.py`：157 passed；`pytest tests --collect-only` 退出 0；ruff format 通过
- scratch 池端到端：模拟 embeddable 宿主 → 下载托管 CPython 3.12.13 → 建 venv → `sys.path` 无注册表条目、`import maa` 通过；embeddable 引导被拒
- 真机 D:\AUTO-MAS（beta.2 热补同样改动）：M9A 的 `prepare_runner_environment` 建出新 runtime，venv 内 `import maa` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

确保便携式 MaaFW 环境使用自包含且兼容的 Python 运行时，并可靠地拒绝或修复使用可嵌入式解释器创建的环境。

Bug 修复：
- 防止使用可嵌入式 Python 发行版引导 MaaFW 虚拟环境，避免在 Windows 上混用不兼容的标准库和扩展模块。
- 为便携式主机使用兼容的受管理 Python 运行时；当没有可用的自包含引导解释器时，安全地终止操作。
- 使运行前的运行时验证与项目实际使用的运行时保持一致，从而允许修复环境，同时检测不可用的环境。

增强功能：
- 对于完整的 Python 主机，保留其运行时标识；当便携式主机需要运行时时，则从受管理的引导解释器派生运行时标识。
- 在运行时准备期间，为受管理 Python 的安装提供进度报告。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保便携式 MaaFW 环境使用自包含且兼容的 Python 运行时，并可靠地拒绝或替换由可嵌入式解释器创建的环境。

错误修复：
- 防止可嵌入式 Python 发行版引导 MaaFW 虚拟环境，避免在 Windows 上混用不兼容的标准库和扩展模块。
- 对便携式主机使用由池管理的兼容 Python 运行时；当没有可用的自包含引导解释器时，安全地终止操作。
- 在执行前验证项目实际选择的运行时，从而允许修复损坏的环境，而不会因无关的运行时而阻塞。

增强功能：
- 为完整的 Python 主机保留运行时标识；对于便携式主机，则根据受管理的引导解释器生成标识。
- 在准备受管理的 Python 解释器时报告进度。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保便携式 MaaFW 环境使用自包含且兼容的 Python 运行时，并可靠地拒绝或替换由可嵌入解释器创建的环境。

错误修复：
- 防止可嵌入 Python 发行版在缺少自包含标准库的情况下引导 MaaFW 虚拟环境。
- 对便携式主机使用由池管理的兼容 Python 运行时；当没有有效的引导解释器可用时，安全地终止操作。
- 在执行前验证项目实际选择的运行时，使过时的环境能够得到修复，而不会因无关的运行时而受阻。

增强功能：
- 保留完整 Python 主机的运行时标识，并根据选定的受管理解释器派生便携式主机的标识。
- 安装受管理的 Python 解释器时报告进度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure portable MaaFW environments use a self-contained compatible Python runtime and reliably reject or replace environments created from embeddable interpreters.

Bug Fixes:
- Prevent embeddable Python distributions from bootstrapping MaaFW virtual environments without a self-contained standard library.
- Use a compatible pool-managed Python runtime for portable hosts and fail closed when no valid bootstrap interpreter is available.
- Validate the runtime actually selected for the project before execution, allowing stale environments to be repaired without blocking on unrelated runtimes.

Enhancements:
- Preserve runtime identities for complete Python hosts and derive portable-host identities from the selected managed interpreter.
- Report progress while installing a managed Python interpreter.

</details>

</details>

</details>