### PR TITLE
fix(hsr): 重试耗尽仍失败的用户不再被标记为完成

### DIFF
--- a/app/task/HSR/AutoProxy.py
+++ b/app/task/HSR/AutoProxy.py
@@ -1515,8 +1515,10 @@ class HSRAutoProxyTask(TaskExecuteBase):
             ]
             if _daily_items and len(_daily_failed) < len(_daily_items):
                 self._queue_daily_proxy_completion(uid, user_name)
-            self._finish_current_user_log(status)
+            # 结束当前用户日志会清空用户上下文，每轮只能调用一次；
+            # 用户状态必须在这一次里定好，否则后续补写全部失效。
             if not failed_items:
+                self._finish_current_user_log(status)
                 return
 
             if attempt < retry_limit:
@@ -1529,10 +1531,7 @@ class HSRAutoProxyTask(TaskExecuteBase):
                     f"用户「{user_name}」第 {attempt}/{retry_limit} 次尝试后，"
                     f"仍有 {len(failed_items)} 个失败任务，{retry_action}"
                 )
-                self._finish_current_user_log(
-                    "HSR 用户任务本轮失败，等待补跑",
-                    user_status="运行",
-                )
+                self._finish_current_user_log(status, user_status="运行")
                 current_items = self._build_retry_queue_items(
                     failed_items,
                     user_item=user_item,
@@ -1544,10 +1543,7 @@ class HSRAutoProxyTask(TaskExecuteBase):
                     temp_files=self.temp_files,
                 )
             else:
-                self._finish_current_user_log(
-                    "HSR 用户任务重试失败",
-                    user_status="异常",
-                )
+                self._finish_current_user_log(status, user_status="异常")
                 for failed_item in failed_items:
                     if failed_item.module_key == "StartGame":
                         continue

--- a/res/version.json
+++ b/res/version.json
@@ -46,7 +46,8 @@
                 "OK-WW专项 修复任务报告推送失败的问题 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "游戏签到 修复开启签到通知时执行签到必报 TypeError 的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "修复明日方舟PC工具连接失败后每秒重试并反复弹出错误提示的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "OK-NTE专项 修复日常任务在当日活跃度奖励已领取过（或日常领取子任务被关闭）时被误判为失败并反复重试的问题，已领取时任务报告显示「跳过（当日已领取）」 by [@AthenaHibou](https://github.com/AthenaHibou)"
+                "OK-NTE专项 修复日常任务在当日活跃度奖励已领取过（或日常领取子任务被关闭）时被误判为失败并反复重试的问题，已领取时任务报告显示「跳过（当日已领取）」 by [@AthenaHibou](https://github.com/AthenaHibou)",
+                "HSR专项 修复模块重试耗尽仍失败时用户被误标为「完成」的问题，调度台总览与任务报告不再把失败的代理报成成功"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
`_finish_current_user_log` 会连同当前用户上下文一起清空，而主循环先无条件调一次（`user_status` 默认「完成」），后面「等待补跑」「重试耗尽」两个分支里的补写全是空操作，`on_crash` 的 `_mark_current_user_abnormal` 同理。于是模块真失败、`main_task` 抛错，用户状态仍停在「完成」：统计通知打 √、调度台算出未完成用户数 0，与历史记录里的「部分失败」自相矛盾。

改为每轮只调用一次并当场定好用户状态；日志标记维持本轮结论不变，历史记录页文案与 `hsr_success_results` 成功判定均不受影响。

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

修复 HSR 用户状态处理逻辑，确保重试次数耗尽的用户被记录为失败，而不是已完成。

错误修复：
- 当 HSR 重试仍处于待处理状态或已耗尽时，正确保留运行中和异常的用户状态，防止失败用户被报告为已完成。

增强功能：
- 确保每次 HSR 用户迭代只最终确定其日志一次，同时保留现有的历史记录措辞和成功结果行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix HSR user status handling so exhausted retries are recorded as failures instead of completed users.

Bug Fixes:
- Correctly preserve running and abnormal user statuses when HSR retries remain pending or are exhausted, preventing failed users from being reported as completed.

Enhancements:
- Ensure each HSR user iteration finalizes its log exactly once while retaining existing history wording and success-result behavior.

</details>