### PR TITLE
fix(hsr): 脚本直控隔离目录清理改为尽力而为

### DIFF
--- a/app/task/HSR/tools/native_control.py
+++ b/app/task/HSR/tools/native_control.py
@@ -157,11 +157,24 @@ def get_user_direct_config(user_config: Any, engine: HSREngine) -> str:
     return str(value or "")
 
 
+def _discard_isolated_root(isolated_root: Path | None) -> None:
+    """尽力删除隔离启动目录。
+
+    外部脚本被中止后可能仍占用目录内的文件句柄，删除隔离目录只是收尾动作，
+    失败时把目录留给系统临时目录回收，不应让整个用户任务失败。
+    """
+
+    if isolated_root is not None:
+        shutil.rmtree(isolated_root, ignore_errors=True)
+
+
 class SRADirectControlSession:
-    def __init__(self, executable: Path, config_path: Path, temporary, log) -> None:
+    def __init__(
+        self, executable: Path, config_path: Path, isolated_root: Path, log
+    ) -> None:
         self._executable = executable
         self._config_path = config_path
-        self._temporary = temporary
+        self._isolated_root: Path | None = isolated_root
         self._log = log
         self._process_registry = SRAProcessRegistry()
         self._closed = False
@@ -188,9 +201,8 @@ class SRADirectControlSession:
             return
         await self.cancel()
         await self._process_registry.clear()
-        if self._temporary is not None:
-            self._temporary.cleanup()
-            self._temporary = None
+        _discard_isolated_root(self._isolated_root)
+        self._isolated_root = None
         self._closed = True
 
 
@@ -256,11 +268,11 @@ class SRANativeControlProvider:
         if not isinstance(parsed, dict):
             raise ValueError("SRA 用户快照顶层必须是对象")
         safe_id = re.sub(r"[^A-Za-z0-9_-]+", "-", session_id).strip("-") or "user"
-        temporary = tempfile.TemporaryDirectory(prefix=f"automas-sra-{safe_id[:32]}-")
-        config_path = Path(temporary.name) / "config.json"
+        isolated_root = Path(tempfile.mkdtemp(prefix=f"automas-sra-{safe_id[:32]}-"))
+        config_path = isolated_root / "config.json"
         atomic_write(config_path, config_content.encode("utf-8"))
         log("SRA 将原样执行当前用户导入的隔离配置快照；MAS 只负责外部进程生命周期")
-        return SRADirectControlSession(executable, config_path, temporary, log)
+        return SRADirectControlSession(executable, config_path, isolated_root, log)
 
 
 class M7ADirectControlSession:
@@ -269,7 +281,7 @@ class M7ADirectControlSession:
         self._config_content = config_content
         self._session_id = session_id
         self._log = log
-        self._temporary: tempfile.TemporaryDirectory[str] | None = None
+        self._isolated_root: Path | None = None
         self._runner: M7ARunner | None = None
         self._closed = False
 
@@ -281,10 +293,8 @@ class M7ADirectControlSession:
         if not isinstance(config, dict):
             raise ValueError("三月七助手用户快照顶层必须是对象")
         safe_id = re.sub(r"[^A-Za-z0-9_-]+", "-", self._session_id).strip("-") or "user"
-        self._temporary = tempfile.TemporaryDirectory(
-            prefix=f"automas-m7a-{safe_id[:32]}-"
-        )
-        isolated_root = Path(self._temporary.name)
+        isolated_root = Path(tempfile.mkdtemp(prefix=f"automas-m7a-{safe_id[:32]}-"))
+        self._isolated_root = isolated_root
         try:
             for source in self._source_root.iterdir():
                 if source.name.casefold() == "config.yaml":
@@ -301,8 +311,8 @@ class M7ADirectControlSession:
                 isolated_root / "config.yaml", self._config_content.encode("utf-8")
             )
         except Exception:
-            self._temporary.cleanup()
-            self._temporary = None
+            self._isolated_root = None
+            _discard_isolated_root(isolated_root)
             raise
         return isolated_root
 
@@ -327,9 +337,8 @@ class M7ADirectControlSession:
         if self._closed:
             return
         await self.cancel()
-        if self._temporary is not None:
-            self._temporary.cleanup()
-            self._temporary = None
+        _discard_isolated_root(self._isolated_root)
+        self._isolated_root = None
         self._closed = True
 
 

--- a/res/version.json
+++ b/res/version.json
@@ -48,7 +48,8 @@
                 "修复明日方舟PC工具连接失败后每秒重试并反复弹出错误提示的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "OK-NTE专项 修复日常任务在当日活跃度奖励已领取过（或日常领取子任务被关闭）时被误判为失败并反复重试的问题，已领取时任务报告显示「跳过（当日已领取）」 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "HSR专项 修复模块重试耗尽仍失败时用户被误标为「完成」的问题，调度台总览与任务报告不再把失败的代理报成成功 by [@qiyinxi](https://github.com/qiyinxi)",
-                "MFW专项 修复便携版在装有另一份 Python 3.12 的电脑上运行环境准备成功、任务一启动却报 ctypes 错误的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MFW专项 修复便携版在装有另一份 Python 3.12 的电脑上运行环境准备成功、任务一启动却报 ctypes 错误的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "HSR专项 修复脚本直控的用户在脚本结束后偶发被标记为异常的问题"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
- M7A/SRA 直控会话 `close()` 原先用 `TemporaryDirectory.cleanup()` 删隔离启动目录；脚本被中止后仍占着目录内句柄时它会抛 `PermissionError`，把已经跑完的用户任务标成「异常」。
- 发布版所带的 CPython 3.12.0 在这里更糟：`tempfile` 的 `onexc` 会反复重入 `_rmtree`，一路递归到 `RecursionError`（线上事件里 547 层异常链）。3.12.5+ 才加上 `repeated` 递归闸门。
- 改用 `mkdtemp()` + `shutil.rmtree(..., ignore_errors=True)`，清理隔离目录只当收尾动作，删不掉就留给系统临时目录回收；顺带去掉 `TemporaryDirectory` 在 GC 时会再踩一次同一路径的 finalizer。
- 验证：`pytest tests/task/test_hsr_engine_fallback.py tests/task/test_hsr_account_switch_gate.py` 12 passed；`pytest tests --collect-only` 退出 0；本地脚本占住隔离目录内文件后 `close()` 不再抛异常，句柄释放后目录可正常删除，符号链接指向的源目录未被波及。

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

确保直接控制会话的关闭能够容忍隔离目录清理失败。

错误修复：
- 将直接控制会话隔离目录的清理改为尽力而为，避免锁定的文件导致已完成的用户任务失败。

增强功能：
- 对 SRA 和 M7A 直接控制会话，使用显式的隔离根目录生命周期管理替代托管临时目录清理，防止清理终结器重复尝试删除失败的目录。

杂项：
- 提升项目版本号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure direct-control session shutdown tolerates isolated-directory cleanup failures.

Bug Fixes:
- Make cleanup of isolated direct-control session directories best-effort so locked files cannot turn completed user tasks into failures.

Enhancements:
- Replace managed temporary-directory cleanup with explicit isolated-root lifecycle handling for SRA and M7A direct-control sessions, preventing cleanup finalizers from retrying failed deletion.

Chores:
- Bump the project version.

</details>