### PR TITLE
feat(queue): 完成后操作支持按队列设定延时

### DIFF
--- a/app/api/dispatch.py
+++ b/app/api/dispatch.py
@@ -107,7 +107,8 @@ async def stop_task(task: DispatchIn = Body(...)) -> OutBase:
 async def get_power() -> PowerOut:
 
     try:
-        signal = Config.power_sign
+        # 电源任务启动后标志已清空, 等待期间要回报任务实际待执行的操作
+        signal = System.current_power_operation or Config.power_sign
     except Exception as e:
         return PowerOut(
             code=500,
@@ -129,6 +130,11 @@ async def set_power(task: PowerIn = Body(...)) -> OutBase:
 
     try:
         Config.power_sign = task.signal
+        # 手动选择的电源操作不带延时, 同时清掉队列可能残留的延时
+        Config.power_delay = 0
+        # 已在等待的电源任务持有旧操作, 延时期间又没有倒计时窗口提示,
+        # 因此手动改选一律撤销它, 新选择留给下一次任务结束时生效
+        await System.cancel_pending_power_task()
     except Exception as e:
         return OutBase(
             code=500, status="error", message=f"{type(e).__name__}: {str(e)}"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -284,6 +284,8 @@ class AppConfig(GlobalConfig):
             "KillSelf",
             "Logoff",
         ] = "NoAction"
+        # 电源操作前的静默延时秒数, 与 power_sign 一同由队列配置写入
+        self.power_delay: int = 0
         self.temp_task: List[asyncio.Task] = []
         # 正在循环运行的队列，供配置改动前的安全检查使用
         self.running_cycle_queue_ids: set[uuid.UUID] = set()

--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -781,9 +781,12 @@ class Task(TaskExecuteBase):
             and self.task_info.queue_id is not None
         ):
             if Config.power_sign == "NoAction":
-                Config.power_sign = Config.QueueConfig[
-                    uuid.UUID(self.task_info.queue_id)
-                ].get("Info", "AfterAccomplish")
+                queue_config = Config.QueueConfig[uuid.UUID(self.task_info.queue_id)]
+                Config.power_sign = queue_config.get("Info", "AfterAccomplish")
+                # 队列可为完成后操作单独设定延时, 延时期间不弹出倒计时窗口
+                Config.power_delay = (
+                    queue_config.get("Info", "AfterAccomplishDelay") * 60
+                )
                 await Publisher.send(
                     id=protocol.ID_MAIN,
                     type=protocol.POWER_SIGN_UPDATED,
@@ -1145,6 +1148,7 @@ class _TaskManager:
                 self._stopping_all = True
                 # 主动停止全部任务时，禁止触发队列完成后的电源操作
                 Config.power_sign = "NoAction"
+                Config.power_delay = 0
                 try:
                     if System.power_task is not None and not System.power_task.done():
                         await System.cancel_power_task()
@@ -1163,6 +1167,7 @@ class _TaskManager:
                 finally:
                     # final_task 可能重新写入 AfterAccomplish，主动停止全部任务时必须丢弃。
                     Config.power_sign = "NoAction"
+                    Config.power_delay = 0
                     self._stopping_all = False
             await Publisher.send(
                 id=protocol.ID_MAIN,

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -439,6 +439,10 @@ class QueueConfig(ConfigBase):
                 ]
             ),
         )
+        ## 完成后操作的延时时长, 单位分钟, 0 表示队列结束后直接进入倒计时
+        self.Info_AfterAccomplishDelay = ConfigItem(
+            "Info", "AfterAccomplishDelay", 0, RangeValidator(0, 1440)
+        )
 
         ## Data ------------------------------------------------------------
         ## 上次定时启动时间

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -494,6 +494,9 @@ class QueueConfig_Info(BaseModel):
             "Logoff",
         ]
     ] = Field(default=None, description="完成后操作")
+    AfterAccomplishDelay: Optional[int] = Field(
+        default=None, ge=0, le=1440, description="完成后操作的延时时长(分钟)"
+    )
 
 
 class QueueConfig(BaseModel):

--- a/app/services/system.py
+++ b/app/services/system.py
@@ -64,7 +64,12 @@ class _SystemHandler:
     def get_power_countdown_snapshot(self) -> PowerCountdownSnapshot:
         """返回当前电源倒计时的 HTTP 初始快照。"""
 
-        active = bool(self.power_task is not None and not self.power_task.done())
+        # 延时阶段 remaining 为 0, 此时只是在等待, 不该被当作倒计时推给前端
+        active = bool(
+            self.power_task is not None
+            and not self.power_task.done()
+            and self.current_power_remaining > 0
+        )
         return PowerCountdownSnapshot(
             active=active,
             operation=self.current_power_operation if active else None,
@@ -170,11 +175,15 @@ class _SystemHandler:
             "KillSelf",
             "Logoff",
         ],
+        delay: int = 0,
     ) -> None:
-        """电源任务：逐秒推送倒计时状态，归零后执行电源操作"""
+        """电源任务：先静默等待队列设定的延时，再逐秒推送倒计时状态，归零后执行电源操作"""
 
         self.current_power_operation = power_sign
         try:
+            if delay > 0:
+                # 延时阶段保持静默：不推送倒计时，调度中心的电源标志仍显示待执行操作
+                await asyncio.sleep(delay)
             for remaining in range(self.countdown, 0, -1):
                 self.current_power_remaining = remaining
                 await Publisher.send(
@@ -201,11 +210,15 @@ class _SystemHandler:
 
         if self.power_task is None or self.power_task.done():
             power_sign = Config.power_sign
+            delay = Config.power_delay
             self._power_cancelled_event_task = None
-            power_task = asyncio.create_task(self._power_task(power_sign))
+            power_task = asyncio.create_task(self._power_task(power_sign, delay))
             self.power_task = power_task
-            logger.info(f"电源任务已启动, {self.countdown}秒后执行: {power_sign}")
+            logger.info(
+                f"电源任务已启动, {delay + self.countdown}秒后执行: {power_sign}"
+            )
             Config.power_sign = "NoAction"
+            Config.power_delay = 0
         else:
             logger.warning("已有电源任务在运行, 请勿重复启动")
 
@@ -220,6 +233,12 @@ class _SystemHandler:
         await Publisher.send(
             id=protocol.ID_MAIN, type=protocol.POWER_COUNTDOWN_CANCELLED
         )
+
+    async def cancel_pending_power_task(self) -> None:
+        """存在待执行的电源任务时取消它，没有则跳过。"""
+
+        if self.power_task is not None and not self.power_task.done():
+            await self.cancel_power_task()
 
     async def cancel_power_task(self):
         """取消电源任务"""

--- a/frontend/src/api/models/QueueConfig_Info.ts
+++ b/frontend/src/api/models/QueueConfig_Info.ts
@@ -23,5 +23,9 @@ export type QueueConfig_Info = {
      * 完成后操作
      */
     AfterAccomplish?: ('NoAction' | 'Shutdown' | 'ShutdownForce' | 'Reboot' | 'Hibernate' | 'Sleep' | 'KillSelf' | 'Logoff' | null);
+    /**
+     * 完成后操作的延时时长(分钟)
+     */
+    AfterAccomplishDelay?: (number | null);
 };
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2232,6 +2232,10 @@ export default {
     no: 'No',
     afterDone: 'When finished',
     afterDoneTip: 'What to do after the queue completes',
+    afterDoneDelay: 'Delay',
+    afterDoneDelayTip:
+      'Wait this long after the queue completes before running the action; 0 means no wait. The 60-second countdown still runs before it, so you can still cancel.',
+    afterDoneDelayUnit: 'min',
     actionPlaceholder: 'Select an action',
     action: {
       NoAction: 'Do nothing',

--- a/frontend/src/i18n/locales/ja-JP.ts
+++ b/frontend/src/i18n/locales/ja-JP.ts
@@ -2230,6 +2230,10 @@ export default {
     no: 'いいえ',
     afterDone: '完了後の動作',
     afterDoneTip: 'キュー完了後に実行する動作',
+    afterDoneDelay: '遅延実行',
+    afterDoneDelayTip:
+      'キュー完了後、この時間だけ待ってから動作を実行します。0 は待機なし。実行前の 60 秒カウントダウンでキャンセルできます。',
+    afterDoneDelayUnit: '分',
     actionPlaceholder: '動作を選択してください',
     action: {
       NoAction: '何もしない',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2140,6 +2140,10 @@ export default {
     no: '否',
     afterDone: '完成后操作',
     afterDoneTip: '队列完成后执行的操作',
+    afterDoneDelay: '延时执行',
+    afterDoneDelayTip:
+      '队列完成后先等待这段时间再执行完成后操作，0 表示不等待；执行前仍有 60 秒倒计时可取消',
+    afterDoneDelayUnit: '分钟',
     actionPlaceholder: '请选择操作',
     action: {
       NoAction: '无操作',

--- a/frontend/src/views/queue/index.vue
+++ b/frontend/src/views/queue/index.vue
@@ -111,7 +111,7 @@
 
         <!-- 队列开关配置 -->
         <div class="config-section">
-          <a-row :gutter="24">
+          <a-row :gutter="[24, 24]">
             <a-col :span="6">
               <div class="form-item-vertical">
                 <div class="form-label-wrapper">
@@ -189,6 +189,27 @@
                   :placeholder="t('queue.actionPlaceholder')"
                   size="large"
                   @change="(value: any) => handleConfigChange('AfterAccomplish', value)"
+                />
+              </div>
+            </a-col>
+            <a-col :span="6">
+              <div class="form-item-vertical">
+                <div class="form-label-wrapper">
+                  <span class="form-label">{{ t('queue.afterDoneDelay') }}</span>
+                  <a-tooltip :title="t('queue.afterDoneDelayTip')">
+                    <QuestionCircleOutlined class="help-icon" />
+                  </a-tooltip>
+                </div>
+                <a-input-number
+                  v-model:value="currentAfterAccomplishDelay"
+                  :min="0"
+                  :max="1440"
+                  :precision="0"
+                  :disabled="currentAfterAccomplish === 'NoAction'"
+                  :addon-after="t('queue.afterDoneDelayUnit')"
+                  size="large"
+                  style="width: 100%"
+                  @blur="handleAfterAccomplishDelayBlur"
                 />
               </div>
             </a-col>
@@ -272,6 +293,7 @@ const cycleRunning = computed(() =>
 )
 // 新增：完成后操作状态
 const currentAfterAccomplish = ref<string>('NoAction')
+const currentAfterAccomplishDelay = ref<number>(0)
 // 队列名称编辑状态
 const isEditingQueueName = ref<boolean>(false)
 
@@ -386,6 +408,7 @@ const loadQueueData = async (queueId: string) => {
       currentCycleEnabled.value = queueData.Info?.CycleEnabled ?? false
       // 更新完成后操作状态 - 从API响应中获取
       currentAfterAccomplish.value = queueData.Info?.AfterAccomplish ?? 'NoAction'
+      currentAfterAccomplishDelay.value = queueData.Info?.AfterAccomplishDelay ?? 0
       await new Promise(resolve => setTimeout(resolve, 50))
       if (!isMounted) return
 
@@ -572,6 +595,13 @@ const handleConfigChange = async (key: string, value: any) => {
   await handleSaveChange(key, value)
 }
 
+// 延时输入框失焦时保存，清空输入得到的 null 按 0 处理
+const handleAfterAccomplishDelayBlur = async () => {
+  const delay = currentAfterAccomplishDelay.value ?? 0
+  currentAfterAccomplishDelay.value = delay
+  await handleConfigChange('AfterAccomplishDelay', delay)
+}
+
 // 添加队列
 const handleAddQueue = async () => {
   try {
@@ -682,6 +712,7 @@ const refreshQueueConfig = async () => {
         currentStartUpMode.value = queueData.Info.StartUpMode ?? 'Never'
         currentTimeEnabled.value = queueData.Info.TimeEnabled ?? false
         currentAfterAccomplish.value = queueData.Info.AfterAccomplish ?? 'NoAction'
+        currentAfterAccomplishDelay.value = queueData.Info.AfterAccomplishDelay ?? 0
 
         // 更新队列列表中的名称
         const currentQueue = queueList.value.find(queue => queue.id === activeQueueId.value)

--- a/res/version.json
+++ b/res/version.json
@@ -9,7 +9,8 @@
                 "OK-NTE专项 支持启动后按用户手机号后 4 位强制切换登录账号，并支持由 MAS 经启动器拉起异环游戏、自动点击开始游戏（替代直启客户端避免卡界面，兼容旧客户端路径与启动器更新流程），失败均留存诊断截图，并新增问题包一键导出便于反馈登录失败 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "调度队列 新增循环队列：队列里的每个任务可单独设定固定时间或间隔重复运行，并显示接下来要运行的任务与时间 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW 项目更新可自行选择下载源（Mirror 酱 / GitHub）与更新通道（稳定版 / 测试版） by [@qiyinxi](https://github.com/qiyinxi)",
-                "调度中心 选中脚本后可再指定一个用户单独运行，只代理该用户而不跑该脚本下的其他用户 by [@qiyinxi](https://github.com/qiyinxi)"
+                "调度中心 选中脚本后可再指定一个用户单独运行，只代理该用户而不跑该脚本下的其他用户 by [@qiyinxi](https://github.com/qiyinxi)",
+                "调度队列 完成后操作可单独设定延时，关机、休眠等操作会在队列结束后先静默等待设定的时长，再照常弹出 60 秒倒计时"
             ],
             "程序优化": [
                 "配置来源 MAA、SRC、MaaEnd 与 OK-NTE 用户页的「简洁/详细」配置模式更名为「脚本/用户」，含义不变，旧配置自动迁移 by [@1w1w11w1](https://github.com/1w1w11w1)",


### PR DESCRIPTION
- 队列的「完成后操作」新增延时设置（0-1440 分钟），队列结束后先静默等待设定时长，期间不弹倒计时窗口、界面照常可用，随后照常进入原有的 60 秒倒计时并执行。
- 延时期间 `/get/power` 回报电源任务实际待执行的操作，调度中心的电源下拉框因此能显示挂起的操作（此前启动电源任务后标志即被清空，下拉框显示的是陈旧值）。
- 在电源下拉框手动改选会撤销挂起的电源任务，新的选择留给下一次任务结束时生效；此前改选只写标志，已在等待的操作仍会照旧执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

支持为队列完成后的电源操作配置静默延迟，同时保持待处理操作状态和取消行为的一致性。

新功能：
- 在队列完成后的电源操作前增加可配置的 0–1440 分钟延迟，随后执行现有的可取消倒计时。
- 在队列配置中提供完成操作延迟设置，并添加本地化界面标签和使用说明。

错误修复：
- 在延迟期间保持待处理的电源操作可见，并在手动更改电源选择时取消待处理操作。
- 在所有任务被明确停止后，清除延迟中的电源操作。

增强功能：
- 确保在静默延迟期间电源倒计时状态保持非活动，同时保留待处理操作以便状态报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable silent delays for queue completion power actions while keeping pending-operation status and cancellation behavior consistent.

New Features:
- Add a configurable 0–1440 minute delay before queue completion power actions, followed by the existing cancellable countdown.
- Expose the completion-action delay in queue configuration with localized UI labels and guidance.

Bug Fixes:
- Keep the pending power operation visible while delayed and cancel pending operations when the power selection is manually changed.
- Clear delayed power actions when all tasks are explicitly stopped.

Enhancements:
- Ensure power countdown state remains inactive during the silent delay while retaining the pending operation for status reporting.

</details>

<details>
<summary>Original summary in English</summary>



</details>