### PR TITLE
fix(hsr): 培养目标模式下单独执行历战余响

### DIFF
--- a/app/task/HSR/AutoProxy.py
+++ b/app/task/HSR/AutoProxy.py
@@ -476,13 +476,18 @@ class HSRAutoProxyTask(TaskExecuteBase):
         eow_enabled: bool,
         result: object,
         script: Literal["M7A", "SRA"],
+        dedicated_run: bool = False,
     ) -> None:
         """外部脚本确认历战余响完成后，登记完成态。"""
 
         if not eow_enabled:
             return
 
-        completed, reason = detect_echo_of_war_completion(result, script)
+        completed, reason = detect_echo_of_war_completion(
+            result,
+            script,
+            dedicated_run=dedicated_run,
+        )
         if not completed:
             self._record_module_result(
                 user_id=user_id,
@@ -844,6 +849,27 @@ class HSRAutoProxyTask(TaskExecuteBase):
                 )
 
             if assigned == "SRA":
+                # 培养目标模式由 SRA 原生识别决定副本，塞进 tasklist 的周本不一定
+                # 被执行（2.20.0 之前更是完全不读 tasklist），单独跑一次保证周本。
+                if module.key == "Daily" and module_daily_eow_enabled:
+                    cultivation_enabled, _ = self._daily_native_modes(
+                        assigned_script=assigned,
+                        user_cfg=user_cfg,
+                    )
+                    if cultivation_enabled:
+                        items.append(
+                            self._sra_control.create_echo_of_war_item(
+                                user_item=user_item,
+                                user_cfg=user_cfg,
+                                user_name=user_name,
+                                uid=uid,
+                                phase=phase,
+                                sra_exe_path=sra_exe_path,
+                                script_id=script_id,
+                                temp_files=temp_files,
+                            )
+                        )
+                        module_daily_eow_enabled = False
                 item = self._sra_control.create_module_item(
                     user_item=user_item,
                     user_cfg=user_cfg,
@@ -1318,7 +1344,9 @@ class HSRAutoProxyTask(TaskExecuteBase):
                 if bool(getattr(result, "success", True)):
                     if item.on_success is not None:
                         item.on_success(result)
-                    if item.module_key != "StartGame":
+                    # 历战余响独立项的最终结果由 on_success 按日志判定，
+                    # 这里再记一次会把「未完成」覆盖成「完成」。
+                    if item.module_key not in ("StartGame", "EchoOfWar"):
                         self._record_module_result(
                             user_id=item.user_id,
                             user_name=item.user_name,

--- a/app/task/HSR/tools/log_detect.py
+++ b/app/task/HSR/tools/log_detect.py
@@ -43,7 +43,12 @@ HSR_EOW_REMAINING_COUNT_RE = re.compile(
     r"本周[「\"]?历战余响[」\"；:：]?\s*剩余次数[:：]\s*(\d+)\s*/\s*3"
 )
 HSR_EOW_M7A_START_RE = re.compile(r"开始刷历战余响.*?每轮包含\s*(\d+)\s*次")
+# 「将执行 N 次」只在 SRA 体力自动分配路径打印，手动副本任务没有这行。
 HSR_EOW_SRA_PLAN_RE = re.compile(r"任务\s+历战余响.*?将执行\s*(\d+)\s*次")
+HSR_EOW_SRA_DONE_MARKER = "任务完成：历战余响"
+# SRA 打不过或点不中关卡时也会打印「任务完成」，只有战斗失败会单独留痕；
+# 排除同样含该子串的「退出战斗失败」，那只是收尾点击没成功。
+HSR_EOW_SRA_BATTLE_FAILED_RE = re.compile(r"(?<!退出)战斗失败")
 
 HSR_ENGLISH_FAILURE_RE = re.compile(
     r"(Traceback \(most recent call last\):|Failed to execute script|"
@@ -227,8 +232,19 @@ def result_text(result: object) -> str:
     return "\n".join(part for part in (output, error) if part)
 
 
-def detect_echo_of_war_completion(result: object, script: str) -> tuple[bool, str]:
-    """根据 M7A/SRA 输出判断本周历战余响是否已完成。"""
+def detect_echo_of_war_completion(
+    result: object,
+    script: str,
+    dedicated_run: bool = False,
+) -> tuple[bool, str]:
+    """根据 M7A/SRA 输出判断本周历战余响是否已完成。
+
+    Args:
+        result: 外部脚本执行结果。
+        script: 本次执行的引擎。
+        dedicated_run: 本次外部脚本只按 3 连战跑了历战余响一项。SRA 手动副本
+            任务不打印体力分配计划，这时以任务完成日志作为完成依据。
+    """
 
     text = result_text(result)
     if not text:
@@ -272,13 +288,14 @@ def detect_echo_of_war_completion(result: object, script: str) -> tuple[bool, st
         return False, "外部脚本日志显示历战余响未完成或体力不足"
 
     sra_attempts = _parse_max_int(HSR_EOW_SRA_PLAN_RE, text)
-    if (
-        str(script).upper() == "SRA"
-        and sra_attempts is not None
-        and sra_attempts >= HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT
-        and "任务完成：历战余响" in text
-    ):
-        return True, f"SRA 日志显示历战余响已执行 {sra_attempts} 次"
+    if str(script).upper() == "SRA" and HSR_EOW_SRA_DONE_MARKER in text:
+        if (
+            sra_attempts is not None
+            and sra_attempts >= HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT
+        ):
+            return True, f"SRA 日志显示历战余响已执行 {sra_attempts} 次"
+        if dedicated_run and not HSR_EOW_SRA_BATTLE_FAILED_RE.search(text):
+            return True, "SRA 单独执行历战余响完成，本周次数已一次挑战用尽"
 
     return False, "未从外部脚本日志确认历战余响已完成"
 

--- a/app/task/HSR/tools/sra_control.py
+++ b/app/task/HSR/tools/sra_control.py
@@ -24,9 +24,10 @@ from app.models.task import UserItem
 
 from ..task_mapping import HSRTaskModule
 from .account_switch import HSRAccountSwitcher, resolve_sra_start_mode
-from .log_detect import detect_weekly_completion
+from .log_detect import HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT, detect_weekly_completion
 from .run_model import HSRPhase, HSRRunItem
 from .sra_runtime import (
+    build_sra_echo_of_war_config,
     build_sra_module_config,
     build_sra_tasklist_description,
     write_sra_temp_config,
@@ -70,7 +71,7 @@ class HSRSRAControl:
         append_log: Callable[[str], None],
         phase_timeout_seconds: Callable[[HSRPhase], int],
         module_timeout_seconds: Callable[[str], int],
-        queue_eow_completion: Callable[[str, str, bool, object, str], None],
+        queue_eow_completion: Callable[..., None],
         queue_weekly_completion: Callable[[str, str, str], None],
         record_module_result: Callable[..., None],
     ) -> None:
@@ -256,5 +257,67 @@ class HSRSRAControl:
             description=description,
             timeout_seconds=timeout_seconds,
             run=run_sra_module,
+            on_success=on_success,
+        )
+
+    def create_echo_of_war_item(
+        self,
+        *,
+        user_item: UserItem,
+        user_cfg: HSRUserConfig,
+        user_name: str,
+        uid: str,
+        phase: HSRPhase,
+        sra_exe_path: Path,
+        script_id: str,
+        temp_files: list[Path],
+    ) -> HSRRunItem:
+        """创建只跑历战余响的 SRA 队列项，排在体力模块之前先占用周本次数。"""
+
+        timeout_seconds = self._module_timeout_seconds("Daily")
+        cfg = build_sra_echo_of_war_config(self.script_config, user_cfg)
+        temp_path = write_sra_temp_config(cfg, script_id, uid, "EchoOfWar")
+        temp_files.append(temp_path)
+
+        eow_item = cfg["trailblazePower"]["tasklist"][0]
+        level_name = eow_item.get("levelName") or eow_item.get("id")
+        description = (
+            f"SRA TrailblazePowerTask：单独执行历战余响 {level_name} "
+            f"x{HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT}"
+        )
+
+        async def run_sra_echo_of_war():
+            return await self.run_sra_task(
+                sra_exe_path,
+                "TrailblazePowerTask",
+                temp_path,
+                user_name,
+                "历战余响",
+                timeout_seconds=timeout_seconds,
+                module_key="EchoOfWar",
+            )
+
+        def on_success(result, uid=uid, user_name=user_name):
+            self._queue_eow_completion(
+                uid,
+                user_name,
+                True,
+                result,
+                "SRA",
+                dedicated_run=True,
+            )
+
+        return HSRRunItem(
+            user_item=user_item,
+            user_cfg=user_cfg,
+            user_name=user_name,
+            user_id=uid,
+            phase=phase,
+            module_key="EchoOfWar",
+            module_name="历战余响",
+            script="SRA",
+            description=description,
+            timeout_seconds=timeout_seconds,
+            run=run_sra_echo_of_war,
             on_success=on_success,
         )

--- a/app/task/HSR/tools/sra_runtime.py
+++ b/app/task/HSR/tools/sra_runtime.py
@@ -34,6 +34,7 @@ from app.utils import ProcessManager, decode_bytes, get_logger
 from app.utils.io import atomic_write, migrate_legacy_dir, read_file, write_file
 
 from .log_detect import (
+    HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT,
     can_read_stream_live,
     emit_process_output,
     has_failure_output,
@@ -818,6 +819,7 @@ def _native_stage_to_sra_tp_item(
     field: str,
     run_times: int,
     count: int = 1,
+    auto_detect: bool = SRA_TRAILBLAZE_POWER_AUTO_DETECT,
 ) -> dict | None:
     """把 Stage.ScriptStage / ScriptEchoOfWar 转成 SRA tasklist item。"""
 
@@ -839,7 +841,7 @@ def _native_stage_to_sra_tp_item(
         "levelName": label,
         "count": count,
         "runtimes": run_times,
-        "autoDetect": SRA_TRAILBLAZE_POWER_AUTO_DETECT,
+        "autoDetect": auto_detect,
     }
 
 
@@ -859,19 +861,83 @@ def _build_sra_trailblaze_tasklist(
 
     if eow_enabled:
         # SRA autoDetect 路径不读取 RunTimes，这里只保留结构占位。
-        native_eow = _native_stage_to_sra_tp_item(user_config, "ScriptEchoOfWar", 1)
-        if native_eow is None:
-            raise RuntimeError(
-                "本周需要执行历战余响，但 Stage.ScriptEchoOfWar 缺少 SRA 原生"
-                "历战余响字段；请在体力配置中重新选择历战余响"
-            )
-        eow_item = native_eow
+        eow_item = _require_sra_echo_of_war_item(
+            user_config,
+            auto_detect=SRA_TRAILBLAZE_POWER_AUTO_DETECT,
+            count=1,
+        )
 
     if eow_item is not None:
         tasklist.append(eow_item)
     if main_item is not None:
         tasklist.append(main_item)
     return tasklist
+
+
+def _require_sra_echo_of_war_item(
+    user_config,
+    *,
+    auto_detect: bool,
+    count: int,
+) -> dict:
+    """取历战余响的 SRA tasklist item；缺少原生字段时直接报错。"""
+
+    item = _native_stage_to_sra_tp_item(
+        user_config,
+        "ScriptEchoOfWar",
+        1,
+        count=count,
+        auto_detect=auto_detect,
+    )
+    if item is None:
+        raise RuntimeError(
+            "本周需要执行历战余响，但 Stage.ScriptEchoOfWar 缺少 SRA 原生"
+            "历战余响字段；请在体力配置中重新选择历战余响"
+        )
+    return item
+
+
+def build_sra_echo_of_war_config(
+    script_config,
+    user_config,
+    name: str = "_mas_temp_EchoOfWar",
+) -> dict:
+    """构造只跑历战余响的 SRA TrailblazePowerTask 配置。
+
+    培养目标模式下 SRA 由原生识别决定副本，只有培养目标材料正好出自历战余响
+    才会排上周本；2.20.0 之前的 SRA 在该模式下还完全不读 tasklist。周本因此
+    单独跑一次手动副本，不依赖培养目标内容与 SRA 版本。
+
+    Args:
+        script_config: HSR 脚本配置，用于沿用用户的原生体力选项。
+        user_config: HSR 用户配置，提供历战余响关卡。
+        name: 写入 SRA 临时配置的配置名。
+
+    Returns:
+        只启用 trailblazePower、tasklist 仅含历战余响的 SRA TasksConfig。
+
+    Raises:
+        RuntimeError: 用户未配置 SRA 原生历战余响关卡。
+    """
+
+    eow_item = _require_sra_echo_of_war_item(
+        user_config,
+        auto_detect=False,
+        count=HSR_ECHO_OF_WAR_WEEKLY_REWARD_LIMIT,
+    )
+    config = _build_sra_base_config(name)
+    _apply_managed_options(config, "Daily", script_config, user_config)
+    trailblaze = config["trailblazePower"]
+    trailblaze["enabled"] = True
+    # 本次只为周本而跑：关掉培养目标识别与活动检测，避免顺带消耗体力；
+    # 补充体力仍按体力模块的口径统一关闭。
+    trailblaze["useBuildTarget"] = False
+    trailblaze["activity.enabled"] = False
+    trailblaze["replenish.enabled"] = False
+    trailblaze["replenish.way"] = 0
+    trailblaze["replenish.times"] = 0
+    trailblaze["tasklist"] = [eow_item]
+    return config
 
 
 def _resolve_sra_currency_wars_strategy(script_config) -> str:

--- a/res/version.json
+++ b/res/version.json
@@ -45,6 +45,7 @@
                 "OK-NTE专项 修复任务报告剩余体力计算不准确的问题：体力不足以刷满设定目标时误显「剩余体力: 0」，改为按实际刷本消耗（异象界域双倍/单倍次数、异象追猎实际消耗）精确计算剩余体力 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "前端类型治理 清理脚本与 Electron 基础边界中的 any，并修复 BetterGI 设置会话无法接收完成和错误事件的问题",
                 "HSR专项 修复 MAS 管控任务的文本与 JSON 配置项在输入过程中被重渲染清空、导致只有数字项能填写的问题（如货币战争的首领/投资重开条件、策略文件、开拓者名称） by [@qiyinxi](https://github.com/qiyinxi)",
+                "HSR专项 修复 SRA 开启「使用培养目标」后历战余响一直不刷、状态始终停在本周未完成的问题",
                 "OK-WW专项 修复任务报告推送因漏传通知用户配置参数而失败的问题 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "游戏签到 修复通知返回值改为 DispatchResult 后未同步两处消费方、开启签到通知时执行签到必报 TypeError 的问题（手动签到接口返回 500，慢渠道后台通知路径丢失日志） by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "BetterGI专项 修复任务跨过本地午夜后仍监控前一天日志文件、导致后续状态误判的问题 by [@Craun718](https://github.com/Craun718)",


### PR DESCRIPTION
HSR 专项在 SRA 引擎下勾选「使用培养目标」后，历战余响从来不会被执行，模块状态固定停在「本周未完成」，每轮重试也不会好转。

- `useBuildTarget` 为真时 MAS 会清空 `trailblazePower.tasklist`，用户配置的历战余响关卡被丢弃；而 SRA 的培养目标识别只在目标材料恰好出自周本时才会自己排上，且 2.20.0 之前在该模式下完全不读 tasklist。改为在体力模块之前单独跑一次 `TrailblazePowerTask`（`useBuildTarget=false`、tasklist 仅含历战余响、`autoDetect=false` + `count=3`），该形状在 2.16.1 至今的所有 SRA 版本都落到 `manual_tasks` 固定 3 连战，不依赖 SRA 版本与培养目标内容。
- 未勾选培养目标的手动副本模式保持原有行为不变。
- SRA 手动副本任务不打印「将执行 N 次」，完成判定补 `dedicated_run` 分支；由于 `battle()` 在未取胜时同样会打印「任务完成」，额外用「战斗失败」兜底，避免打不过周本时误写本周完成、导致整周不再重试。

本地验证（`.venv` Python 3.12.13）：`ruff check app/task/HSR/` 通过，改动文件 `ruff format --check` 通过；`pytest tests` 456 passed / 3 skipped，`pytest tests --collect-only` 退出码 0。另用临时脚本把生成的配置喂进 SRA v2.19.0 与 v2.21.0 的 `TasksConfig.from_dict`，回放 `run() → init_custom_tasklist() → battle() → battle_start()`，确认落在 `manual_tasks` 且 `single_time=3, run_time=1`；完成判定覆盖体力不足、战斗失败、退出战斗失败、未执行周本、M7A 串味与旧路径行为不变。未做真机实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

确保 SRA 培养目标模式下历战余响能够独立执行并准确记录完成状态。

Bug Fixes:
- 修复 SRA 启用培养目标时历战余响未执行且错误记录为本周完成的问题。
- 修复 SRA 单独执行历战余响时的完成与战斗失败判定，避免失败后停止后续重试。

Enhancements:
- 在培养目标模式下将历战余响作为独立任务优先于体力模块执行，并兼容不同 SRA 版本。
- 保持未启用培养目标的手动副本模式行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 SRA 培养目标模式下历战余响能够独立执行并准确记录完成状态。

Bug Fixes:
- 修复 SRA 启用培养目标时历战余响未执行且错误记录为本周完成的问题。
- 修复 SRA 单独执行历战余响时的完成与战斗失败判定，避免失败后停止后续重试。

Enhancements:
- 在培养目标模式下将历战余响作为独立任务优先于体力模块执行，并兼容不同 SRA 版本。
- 保持未启用培养目标的手动副本模式行为不变。

</details>