### PR TITLE
fix(general): 配置路径为空时在任务开始前拦下

### DIFF
--- a/app/task/general/manager.py
+++ b/app/task/general/manager.py
@@ -89,6 +89,12 @@ class GeneralManager(TaskExecuteBase):
             )
         ):
             return "开启追踪子进程后, 需至少填写一项追踪进程信息！"
+        # 配置路径为空时 Path("") 等价于 Path(".")，后续的快照与清理会落到
+        # 程序自身的工作目录上，必须在任务开始前拦下
+        if not Config.ScriptConfig[uuid.UUID(self.script_info.script_id)].get(
+            "Script", "ConfigPath"
+        ):
+            return "未填写配置路径, 请检查脚本配置中的配置路径设置！"
         if Config.ScriptConfig[uuid.UUID(self.script_info.script_id)].get(
             "Game", "Enabled"
         ):

--- a/res/version.json
+++ b/res/version.json
@@ -25,7 +25,8 @@
                 "前端i18n BetterGI 专项的脚本编辑页、用户编辑页与配置组件接入词表，切换界面语言即时生效 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaEnd专项 清理不再需要的 MFW 资源 by [@HarcoChen](https://github.com/HarcoChen)",
                 "Runtime 接入 开启 AUTO_MAS_RUNTIME_MODE 后，首次初始化、后端监督与后端更新由 auto-mas-runtime.exe 统一完成，界面保留镜像切换、失败处置与旧链路回退 by [@qiyinxi](https://github.com/qiyinxi)",
-                "HSR专项 移除脚本页的「游戏启动参数」，窗口大小统一由「1920×1080 窗口模式」开关临时改写注册表、任务结束后恢复，旧配置中的该项会在下次保存时自动清除 by [@qiyinxi](https://github.com/qiyinxi)"
+                "HSR专项 移除脚本页的「游戏启动参数」，窗口大小统一由「1920×1080 窗口模式」开关临时改写注册表、任务结束后恢复，旧配置中的该项会在下次保存时自动清除 by [@qiyinxi](https://github.com/qiyinxi)",
+                "通用脚本 未填写「配置路径」时改为在任务开始前直接提示，不再跑起来后才报出难懂的错误"
             ],
             "开发流程": [
                 "新增 GitHub Issue 模板，Bug 反馈按脚本专项、MaaFW 专项与通用问题分区，并附需求建议等模板与常见问题、文档站、官方群链接 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
`GeneralConfig.Script_ConfigPath` 默认是空串，`FileValidator` 放行空串，`GeneralManager.check()` 也不校验它。而 `Path("")` 等价于 `Path(".")` 且 `.exists()` 为 True，配置路径留空时 `_snapshot_external_config` / `_remove_script_config`，以及 `AutoProxy.set_general` 和 `ScriptConfig.set_general` 里的 `rmtree`，都会落到程序自身的工作目录上。

- `check()` 里补一次「配置路径不能为空」的校验。AutoProxy 与 ScriptConfig 两个模式都从这里进，一处盖住 `manager.py`、`AutoProxy.py`、`ScriptConfig.py` 三个删除点。

不是行为回退：默认 `ConfigPathMode` 是 `File`，配置路径留空时今天会先在 `prepare()` 的 `shutil.copy(Path("."), ...)` 抛 `PermissionError: [Errno 13] '.'`（已实测），本来就跑不起来；只有改成 `Folder` 才会真的走到删除。

本地验证（Windows / Python 3.12.13）；3 个用例按 `tests/AGENTS.md` 未提交：

| 用例 | 修复前 | 修复后 |
| --- | --- | --- |
| 空配置路径，AutoProxy 模式 | `check()` 返回 `Pass` | 返回「未填写配置路径…」 |
| 空配置路径，ScriptConfig 模式 | `check()` 返回 `Pass` | 返回「未填写配置路径…」 |
| 填了配置路径 | `Pass` | `Pass` |

`ruff format --check` / `ruff check` 干净，`pytest tests --collect-only -q` 退出码 0。

跟进 #563 正文末尾的「顺带记录」，#564 只处理了 `manager.py` 的 rmtree 容错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

在通用任务校验中强制要求配置路径非空。

错误修复：
- 在任务开始前拒绝未填写配置路径，避免空路径被解析为工作目录并触发错误的快照或清理操作。

杂项：
- 更新版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在通用任务校验中强制要求配置路径非空。

Bug Fixes:
- 在任务开始前拒绝未填写配置路径，避免空路径被解析为工作目录并触发错误的快照或清理操作。

Chores:
- 更新版本信息。

</details>