### PR TITLE
feat(hsr): 用户配置支持任务前后执行自定义脚本

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -1702,6 +1702,20 @@ class HSRUserConfig(ConfigBase):
         self.Info_RemainedDay = ConfigItem(
             "Info", "RemainedDay", -1, RangeValidator(-1, 9999)
         )
+        ## 任务前执行脚本
+        self.Info_IfScriptBeforeTask = ConfigItem(
+            "Info", "IfScriptBeforeTask", False, BoolValidator()
+        )
+        self.Info_ScriptBeforeTask = ConfigItem(
+            "Info", "ScriptBeforeTask", "", FileValidator()
+        )
+        ## 任务后执行脚本
+        self.Info_IfScriptAfterTask = ConfigItem(
+            "Info", "IfScriptAfterTask", False, BoolValidator()
+        )
+        self.Info_ScriptAfterTask = ConfigItem(
+            "Info", "ScriptAfterTask", "", FileValidator()
+        )
         ## 备注
         self.Info_Notes = ConfigItem("Info", "Notes", "无")
         ## 用户标签信息（虚拟字段，供前端显示）

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -1629,6 +1629,14 @@ class HSRUserConfig_Info(BaseModel):
         default=None, description="游戏服务器"
     )
     RemainedDay: Optional[int] = Field(default=None, description="剩余天数")
+    IfScriptBeforeTask: Optional[bool] = Field(
+        default=None, description="是否在任务前执行脚本"
+    )
+    ScriptBeforeTask: Optional[str] = Field(default=None, description="任务前脚本路径")
+    IfScriptAfterTask: Optional[bool] = Field(
+        default=None, description="是否在任务后执行脚本"
+    )
+    ScriptAfterTask: Optional[str] = Field(default=None, description="任务后脚本路径")
     Notes: Optional[str] = Field(default=None, description="备注")
     Tag: Optional[str] = Field(default=None, description="用户标签列表")
 

--- a/app/task/HSR/AutoProxy.py
+++ b/app/task/HSR/AutoProxy.py
@@ -52,6 +52,7 @@ from .tools.account_switch import (
     stop_external_processes,
     user_needs_account_switch,
 )
+from .tools.extra_script import run_script_after_task, run_script_before_task
 from .tools.log_detect import detect_echo_of_war_completion
 from .tools.m7a_control import HSRM7AControl
 from .tools.m7a_runtime import M7ARunner
@@ -1528,6 +1529,9 @@ class HSRAutoProxyTask(TaskExecuteBase):
             self._finish_current_user_log("HSR 本轮无需执行，已跳过")
             return
 
+        # 执行任务前脚本（每用户仅一次，补跑不重复执行）
+        await run_script_before_task(user_cfg)
+
         failed_items: list[HSRRunItem] = []
         current_items = full_queue
         for attempt in range(1, retry_limit + 1):
@@ -1583,6 +1587,8 @@ class HSRAutoProxyTask(TaskExecuteBase):
             # 用户状态必须在这一次里定好，否则后续补写全部失效。
             if not failed_items:
                 self._finish_current_user_log(status)
+                # 执行任务后脚本（每用户仅一次）
+                await run_script_after_task(user_cfg)
                 return
 
             if attempt < retry_limit:
@@ -1620,6 +1626,8 @@ class HSRAutoProxyTask(TaskExecuteBase):
                         status="failed",
                         reason=failed_item.last_error or "重试后仍未完成",
                     )
+                # 执行任务后脚本（每用户仅一次）
+                await run_script_after_task(user_cfg)
                 raise RuntimeError(
                     self._format_queue_failures(failed_items, retry_limit)
                 )

--- a/app/task/HSR/manager.py
+++ b/app/task/HSR/manager.py
@@ -65,6 +65,7 @@ from .tools.external_locks import (
     acquire_external_path_locks,
     resolve_external_lock_paths,
 )
+from .tools.extra_script import run_script_after_task, run_script_before_task
 from .tools.m7a_config import load_m7a_native_config
 from .tools.managed_config import list_managed_modules
 from .tools.native_control import (
@@ -815,6 +816,9 @@ class HSRManager(TaskExecuteBase):
         user_item.status = "运行"
         log_start = len(self._log_lines)
 
+        # 执行任务前脚本（每用户仅一次）
+        await run_script_before_task(user_config)
+
         switcher = HSRAccountSwitcher(
             script_config=self.script_config,
             runtime=self._runtime,
@@ -866,11 +870,15 @@ class HSRManager(TaskExecuteBase):
             user_item.status = "异常"
             log_item.status = "HSR 脚本直控异常"
             log_item.content.extend(f"{line}\n" for line in self._log_lines[log_start:])
+            # 执行任务后脚本（每用户仅一次）
+            await run_script_after_task(user_config)
             raise
 
         user_item.status = "完成"
         log_item.status = "HSR 脚本直控完成"
         log_item.content.extend(f"{line}\n" for line in self._log_lines[log_start:])
+        # 执行任务后脚本（每用户仅一次）
+        await run_script_after_task(user_config)
         return len(control.engines)
 
     async def _persist_user_logs(self) -> None:

--- a/app/task/HSR/tools/extra_script.py
+++ b/app/task/HSR/tools/extra_script.py
@@ -1,0 +1,60 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+#
+#   This file is part of AUTO-MAS.
+#
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+#   the GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+#
+#   Contact: DLmaster_361@163.com
+
+
+from pathlib import Path
+
+from app.models.config import HSRUserConfig
+from app.task.general.tools import execute_script_task
+
+
+async def run_script_before_task(user_config: HSRUserConfig) -> None:
+    """执行用户配置的任务前脚本，未开启时直接返回。
+
+    HSR 的托管与直控两条路径都要用，所以抽成函数；其余专项在 AutoProxy 里
+    内联同样的两行。
+
+    Args:
+        user_config (HSRUserConfig): 当前用户配置。
+    """
+
+    if not user_config.get("Info", "IfScriptBeforeTask"):
+        return
+
+    await execute_script_task(
+        Path(user_config.get("Info", "ScriptBeforeTask")),
+        "脚本前任务",
+    )
+
+
+async def run_script_after_task(user_config: HSRUserConfig) -> None:
+    """执行用户配置的任务后脚本，未开启时直接返回。
+
+    Args:
+        user_config (HSRUserConfig): 当前用户配置。
+    """
+
+    if not user_config.get("Info", "IfScriptAfterTask"):
+        return
+
+    await execute_script_task(
+        Path(user_config.get("Info", "ScriptAfterTask")),
+        "脚本后任务",
+    )

--- a/frontend/src/api/models/HSRUserConfig_Info.ts
+++ b/frontend/src/api/models/HSRUserConfig_Info.ts
@@ -28,6 +28,22 @@ export type HSRUserConfig_Info = {
      */
     RemainedDay?: (number | null);
     /**
+     * 是否在任务前执行脚本
+     */
+    IfScriptBeforeTask?: (boolean | null);
+    /**
+     * 任务前脚本路径
+     */
+    ScriptBeforeTask?: (string | null);
+    /**
+     * 是否在任务后执行脚本
+     */
+    IfScriptAfterTask?: (boolean | null);
+    /**
+     * 任务后脚本路径
+     */
+    ScriptAfterTask?: (string | null);
+    /**
      * 备注
      */
     Notes?: (string | null);

--- a/frontend/src/views/EditView/User/HSRUserEdit.vue
+++ b/frontend/src/views/EditView/User/HSRUserEdit.vue
@@ -284,6 +284,9 @@
             </a-row>
           </div>
 
+          <!-- 额外脚本组件 -->
+          <ExtraScriptSection :form-data="formData" :loading="isSaving" @save="handleFieldSave" />
+
           <UserNotifyConfig
             v-model="formData.Notify"
             :loading="isSaving"
@@ -306,6 +309,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons-vue'
 import hsrLogo from '@/assets/hsr.png'
 import UserEditHeader from '@/components/UserEditHeader.vue'
 import UserNotifyConfig from '@/components/UserNotifyConfig.vue'
+import ExtraScriptSection from '@/components/ExtraScriptSection.vue'
 import { useUserApi } from '@/composables/useUserApi'
 import { useScriptApi } from '@/composables/useScriptApi'
 import {
@@ -365,6 +369,10 @@ const formData = reactive<HSRUserConfigData>({
     Password: '',
     Server: 'CN-Official',
     RemainedDay: -1,
+    IfScriptBeforeTask: false,
+    ScriptBeforeTask: '',
+    IfScriptAfterTask: false,
+    ScriptAfterTask: '',
     Notes: '',
   },
   Stage: {

--- a/frontend/src/views/EditView/User/HSRUserEdit.vue
+++ b/frontend/src/views/EditView/User/HSRUserEdit.vue
@@ -285,7 +285,11 @@
           </div>
 
           <!-- 额外脚本组件 -->
-          <ExtraScriptSection :form-data="formData" :loading="isSaving" @save="handleFieldSave" />
+          <ExtraScriptSection
+            v-model:form-data="formData"
+            :loading="isSaving"
+            @save="handleFieldSave"
+          />
 
           <UserNotifyConfig
             v-model="formData.Notify"

--- a/res/version.json
+++ b/res/version.json
@@ -11,7 +11,8 @@
                 "MFW 项目更新可自行选择下载源（Mirror 酱 / GitHub）与更新通道（稳定版 / 测试版） by [@qiyinxi](https://github.com/qiyinxi)",
                 "调度中心 选中脚本后可再指定一个用户单独运行，只代理该用户而不跑该脚本下的其他用户 by [@qiyinxi](https://github.com/qiyinxi)",
                 "调度队列 完成后操作可单独设定延时，关机、休眠等操作会在队列结束后先静默等待设定的时长，再照常弹出 60 秒倒计时 by [@qiyinxi](https://github.com/qiyinxi)",
-                "通知系统 支持扫码绑定微信 Claw 和 QQ 官方机器人并接收任务通知，绑定与启用状态保持独立，绑定失效或推送失败时会明确提示 by [@HarcoChen](https://github.com/HarcoChen)"
+                "通知系统 支持扫码绑定微信 Claw 和 QQ 官方机器人并接收任务通知，绑定与启用状态保持独立，绑定失效或推送失败时会明确提示 by [@HarcoChen](https://github.com/HarcoChen)",
+                "HSR专项 用户配置页新增「额外脚本」，可在该用户任务开始前与结束后各执行一个自定义脚本（exe / bat / cmd / py 等），MAS 管控与脚本直控两种模式均生效"
             ],
             "程序优化": [
                 "后端更新自动在后台下载并于下次启动生效，启动失败时可修复依赖后重试 by [@ClozyA](https://github.com/ClozyA)",


### PR DESCRIPTION
Closes #567

HSR 是唯一没有「额外脚本」的专项，按 MAA / SRC 等专项的既有口径补齐：`HSRUserConfig` 增加四个配置项，用户页复用现成的 `ExtraScriptSection` 组件，托管与脚本直控两条执行路径都挂上。

执行时机：脚本前任务在整轮队列开始前执行一次，脚本后任务在整轮结束（成功或重试用尽失败）后执行一次，补跑不重复；用户手动中止时不执行，避免停止操作被自定义脚本拖住。

`frontend/src/api/models/HSRUserConfig_Info.ts` 是本地起后端跑 `yarn openapi` 重新生成的。

<details>
<summary>本地验证</summary>

工作树 `feat/hsr-extra-script-20260906`，解释器 `.venv\Scripts\python.exe`（3.12.13）。

- `python -m pytest tests -q` → 475 passed, 3 skipped, 97 subtests passed
- `python -m pytest tests --collect-only -q` → 482 collected，退出码 0
- `ruff check app/models app/task/HSR` → All checks passed
- `yarn lint` / `yarn typecheck` → 退出码 0
- `yarn test` → 401 passed / 3 failed，失败的 3 条都在 `electron/services/backendService.test.ts` 与 `runtimeInitializationService.test.ts`，与本 PR 无关，在改动前的 dev 上同样失败
- 未提交的本地测试（4 条，按 `tests/AGENTS.md` 不入库）：四个配置项默认值、路径经 `FileValidator` 往返、开关关闭时不执行、开关开启时按配置路径分别以「脚本前任务」「脚本后任务」调用 → 4 passed
- 起后端 + vite 手测：HSR 用户页「额外脚本」区块渲染正常，开关切换后 `/api/scripts/user/get` 读回 `IfScriptBeforeTask: true`

未做真机跑任务验证（需要 SRA / 三月七助手与游戏环境）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

添加用户可配置的脚本，以便在 HSR 任务执行前后运行。

新功能：
- 在 HSR 用户设置中添加可配置的任务前置脚本和后置脚本。
- 在用户编辑界面中公开 HSR 额外脚本配置部分。
- 在托管模式和直接控制模式的 HSR 任务执行路径中运行已配置的脚本。

改进：
- 确保脚本在每个用户任务周期中仅运行一次，包括重试次数耗尽后，同时避免在手动取消后执行脚本。

维护：
- 重新生成 HSR 用户配置前端模型并更新项目版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加可由用户配置的脚本，在 HSR 任务执行前后运行。

新功能：
- 在 HSR 用户设置中添加可配置的任务前置脚本和后置脚本。
- 在用户编辑器中公开 HSR 额外脚本设置，并在托管任务流和直接控制任务流中执行这些脚本。

改进：
- 每个用户任务周期运行一次已配置的脚本，包括任务成功完成或重试次数耗尽之后。确保手动取消后不运行任务后置脚本。

杂项：
- 重新生成 HSR 用户配置前端模型并更新项目版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user-configurable scripts that run before and after HSR task execution.

New Features:
- Add configurable pre-task and post-task scripts to HSR user settings.
- Expose HSR extra-script settings in the user editor and execute them across managed and direct-control task flows.

Enhancements:
- Run configured scripts once per user task cycle, including after successful completion or exhausted retries. Ensure post-task scripts are not run after manual cancellation.

Chores:
- Regenerate the HSR user configuration frontend model and update the project version.

</details>

</details>