### PR TITLE
refactor: 全仓冗余清理——单源化专项推送核心并删除死代码

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -30,17 +30,12 @@ from .ocr import router as ocr_router
 from .openclaw_qq import router as openclaw_qq_router
 from .openclaw_weixin import router as openclaw_weixin_router
 from .plan import router as plan_router
+from .qr_login import router as qr_login_router
 from .queue import router as queue_router
 from .scripts import router as scripts_router
 from .setting import router as setting_router
 from .tools import router as tools_router
 from .update import router as update_router
-
-# 可选补丁：米游社扫码登录（可安全删除以下 2 行及 app/api/qr_login.py）
-try:
-    from .qr_login import router as qr_login_router
-except ImportError:
-    qr_login_router = None
 
 __all__ = [
     "core_router",

--- a/app/services/openclaw_common.py
+++ b/app/services/openclaw_common.py
@@ -1,0 +1,58 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+
+#   This file is part of AUTO-MAS.
+
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU Affero General Public License for more details.
+
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+
+#   Contact: DLmaster_361@163.com
+
+"""OpenClaw QQ / 微信两个协议适配器的共享纯函数。"""
+
+from __future__ import annotations
+
+
+class RemoteHTTPError(RuntimeError):
+    """远端返回明确 HTTP 状态码的请求错误。"""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def split_text(text: str, limit: int) -> list[str]:
+    """将通知文本按字符上限拆分，并尽量在换行处断开。
+
+    各平台网关对过长文本可能返回业务失败；通知正文不能依赖模型自行分段，
+    因此在协议适配层做确定性拆分。分段上限由调用方按平台网关限制传入。
+    """
+
+    if limit < 1:
+        raise ValueError("文本分段长度必须大于 0")
+    if not text:
+        return [""]
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        boundary = remaining.rfind("\n", 0, limit + 1)
+        if boundary <= 0:
+            boundary = limit
+        chunks.append(remaining[:boundary].rstrip("\n"))
+        remaining = remaining[boundary:].lstrip("\n")
+    if remaining:
+        chunks.append(remaining)
+    return chunks

--- a/app/services/openclaw_qq.py
+++ b/app/services/openclaw_qq.py
@@ -43,6 +43,8 @@ import httpx
 from app.utils import LazyProxy, get_logger
 from app.utils.platform import secret as platform_secret
 
+from .openclaw_common import RemoteHTTPError, split_text
+
 Config = LazyProxy("app.core", "Config")
 logger = get_logger("QQ官方机器人")
 
@@ -80,14 +82,6 @@ class _RuntimeCredentials:
     user_openid: str
 
 
-class RemoteHTTPError(RuntimeError):
-    """远端返回明确 HTTP 状态码的请求错误。"""
-
-    def __init__(self, status_code: int, message: str) -> None:
-        self.status_code = status_code
-        super().__init__(message)
-
-
 @dataclass(frozen=True)
 class QrStartResult:
     """创建二维码后的公开结果。"""
@@ -114,29 +108,6 @@ class QQStatus:
     connected: bool
     state: str
     message: str
-
-
-def split_text(text: str, limit: int = TEXT_CHUNK_LIMIT) -> list[str]:
-    """将通知文本按字符上限拆分，并尽量在换行处断开。"""
-
-    if limit < 1:
-        raise ValueError("文本分段长度必须大于 0")
-    if not text:
-        return [""]
-    if len(text) <= limit:
-        return [text]
-
-    chunks: list[str] = []
-    remaining = text
-    while len(remaining) > limit:
-        boundary = remaining.rfind("\n", 0, limit + 1)
-        if boundary <= 0:
-            boundary = limit
-        chunks.append(remaining[:boundary].rstrip("\n"))
-        remaining = remaining[boundary:].lstrip("\n")
-    if remaining:
-        chunks.append(remaining)
-    return chunks
 
 
 def _as_int(value: Any) -> int | None:

--- a/app/services/openclaw_weixin.py
+++ b/app/services/openclaw_weixin.py
@@ -45,6 +45,8 @@ import httpx
 from app.utils import LazyProxy, get_logger
 from app.utils.platform import secret as platform_secret
 
+from .openclaw_common import RemoteHTTPError, split_text
+
 Config = LazyProxy("app.core", "Config")
 logger = get_logger("微信Claw")
 
@@ -114,42 +116,6 @@ class WeixinStatus:
     connected: bool
     state: str
     message: str
-
-
-class RemoteHTTPError(RuntimeError):
-    """远端返回明确 HTTP 状态码的请求错误。"""
-
-    def __init__(self, status_code: int, message: str) -> None:
-        self.status_code = status_code
-        super().__init__(message)
-
-
-def split_text(text: str, limit: int = TEXT_CHUNK_LIMIT) -> list[str]:
-    """将文本按字符上限拆分，并尽量在换行处断开。
-
-    iLink 的网关对过长文本可能返回业务失败；通知正文不能依赖模型自行分段，
-    因此这里在协议适配层做确定性拆分。
-    """
-
-    if limit < 1:
-        raise ValueError("文本分段长度必须大于 0")
-    if not text:
-        return [""]
-    if len(text) <= limit:
-        return [text]
-
-    chunks: list[str] = []
-    remaining = text
-    while len(remaining) > limit:
-        boundary = remaining.rfind("\n", 0, limit + 1)
-        if boundary <= 0:
-            boundary = limit
-        chunks.append(remaining[:boundary].rstrip("\n"))
-        remaining = remaining[boundary:]
-        remaining = remaining.lstrip("\n")
-    if remaining:
-        chunks.append(remaining)
-    return chunks
 
 
 def _is_valid_https_url(value: str) -> bool:

--- a/app/task/HSR/tools/notify.py
+++ b/app/task/HSR/tools/notify.py
@@ -24,12 +24,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import HSRUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("HSR 通知工具")
@@ -47,40 +45,8 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        message_html = Config.notify_env.get_template("general_result.html").render(
-            message
-        )
-
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=message_html,
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title, message=message, task_info=task_info
         )
 
     if mode == "统计信息":

--- a/app/task/M9A/tools/notify.py
+++ b/app/task/M9A/tools/notify.py
@@ -27,11 +27,10 @@ from app.core.notify import (
     NotifyPayload,
     dispatch,
     global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import M9AUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("M9A通知工具")
@@ -323,7 +322,13 @@ async def push_notification(
     logger.info(f"开始推送通知，模式: {mode}，标题: {title}")
 
     if mode == "代理结果":
-        return await _push_proxy_result(title, message, task_info)
+        return await push_proxy_result(
+            title=title,
+            message=message,
+            task_info=task_info,
+            logger=logger,
+            skip_debug_message="当前 SendTaskResultTime 配置不满足推送条件，跳过",
+        )
     if mode == "统计信息":
         return await _push_statistics(title, message, user_config)
     return DispatchResult()
@@ -355,46 +360,6 @@ async def push_version_update(title: str, message: dict) -> DispatchResult:
             system_timeout=10,
         ),
         [global_target(include_system=True)],
-    )
-
-
-async def _push_proxy_result(
-    title: str, message: dict, task_info: object | None
-) -> DispatchResult:
-    """推送全局代理结果通知"""
-    if not should_send_result(message):
-        logger.debug("当前 SendTaskResultTime 配置不满足推送条件，跳过")
-        return DispatchResult()
-
-    message_text = (
-        f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-        f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-        f"{message['result']}"
-    )
-
-    template = Config.notify_env.get_template("general_result.html")
-    counts = (
-        f"已完成用户数: {message['completed_count']}, "
-        f"未完成用户数: {message['uncompleted_count']}"
-    )
-    summary_text = (
-        get_task_game_sign_summary(task_info)
-        if task_info is not None and message.get("game_sign_summary")
-        else ""
-    )
-    return await dispatch_task_report(
-        NotifyPayload(
-            title=title,
-            text=message_text,
-            html=template.render(message),
-            system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-            system_message=counts,
-            system_ticker=counts,
-            system_timeout=10,
-        ),
-        [global_target(include_system=True)],
-        task_info,
-        summary_text=summary_text,
     )
 
 

--- a/app/task/MAA/tools/notify.py
+++ b/app/task/MAA/tools/notify.py
@@ -26,12 +26,11 @@ from app.core.notify import (
     NotifyTarget,
     dispatch,
     global_target,
-    should_send_result,
     statistic_targets,
     user_target,
 )
 from app.models.config import MaaUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("MAA 通知工具")
@@ -95,38 +94,12 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        template = Config.notify_env.get_template("MAA_result.html")
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=template.render(message),
-                signature_sep=SIGNATURE_SEP,
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title,
+            message=message,
+            task_info=task_info,
+            result_template="MAA_result.html",
+            signature_sep=SIGNATURE_SEP,
         )
 
     if mode == "统计信息":

--- a/app/task/MaaEnd/tools/notify.py
+++ b/app/task/MaaEnd/tools/notify.py
@@ -25,12 +25,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import MaaEndUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("MaaEnd 通知工具")
@@ -80,37 +78,8 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        template = Config.notify_env.get_template("general_result.html")
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=template.render(message),
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title, message=message, task_info=task_info
         )
 
     if mode == "统计信息":

--- a/app/task/MaaFW/tools/notify/report.py
+++ b/app/task/MaaFW/tools/notify/report.py
@@ -7,11 +7,9 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("MaaFW 通知工具")
@@ -41,50 +39,10 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        return await _push_proxy_result(title, message, task_info)
+        return await push_proxy_result(title=title, message=message, task_info=task_info)
     if mode == "统计信息":
         return await _push_statistics(title, message, user_config)
     return DispatchResult()
-
-
-async def _push_proxy_result(
-    title: str, message: dict, task_info: object | None
-) -> DispatchResult:
-    """推送脚本级「代理结果」报告（全局渠道）。"""
-
-    if not should_send_result(message):
-        return DispatchResult()
-
-    message_text = (
-        f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-        f"已完成数: {message['completed_count']}, "
-        f"未完成数: {message['uncompleted_count']}\n\n"
-        f"{message['result']}"
-    )
-    message_html = Config.notify_env.get_template("general_result.html").render(message)
-    counts = (
-        f"已完成用户数: {message['completed_count']}, "
-        f"未完成用户数: {message['uncompleted_count']}"
-    )
-    summary_text = (
-        get_task_game_sign_summary(task_info)
-        if task_info is not None and message.get("game_sign_summary")
-        else ""
-    )
-    return await dispatch_task_report(
-        NotifyPayload(
-            title=title,
-            text=message_text,
-            html=message_html,
-            system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-            system_message=counts,
-            system_ticker=counts,
-            system_timeout=10,
-        ),
-        [global_target(include_system=True)],
-        task_info,
-        summary_text=summary_text,
-    )
 
 
 async def _push_statistics(

--- a/app/task/OkNte/tools/notify.py
+++ b/app/task/OkNte/tools/notify.py
@@ -21,12 +21,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import OkNteUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("OK-NTE 通知工具")
@@ -44,37 +42,8 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        template = Config.notify_env.get_template("general_result.html")
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=template.render(message),
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title, message=message, task_info=task_info
         )
 
     if mode == "统计信息":

--- a/app/task/Okww/Update.py
+++ b/app/task/Okww/Update.py
@@ -93,9 +93,6 @@ class WuwaUpdateTask(TaskExecuteBase):
         )
         self.cur_user_item.status = "完成"
 
-    async def final_task(self) -> None:
-        pass
-
     async def on_crash(self, e: Exception) -> None:
         self.cur_user_item.status = "异常"
         logger.opt(exception=True).warning(f"鸣潮更新任务出现异常: {e}")

--- a/app/task/Okww/tools/notify.py
+++ b/app/task/Okww/tools/notify.py
@@ -21,12 +21,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     user_statistic_targets,
 )
 from app.models.config import OkwwUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("OK-WW 通知工具")
@@ -67,36 +65,4 @@ async def push_notification(
     if mode != "代理结果":
         return DispatchResult()
 
-    if not should_send_result(message):
-        return DispatchResult()
-
-    message_text = (
-        f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-        f"已完成数: {message['completed_count']}, "
-        f"未完成数: {message['uncompleted_count']}\n\n"
-        f"{message['result']}"
-    )
-    message_html = Config.notify_env.get_template("general_result.html").render(message)
-    counts = (
-        f"已完成用户数: {message['completed_count']}, "
-        f"未完成用户数: {message['uncompleted_count']}"
-    )
-    summary_text = (
-        get_task_game_sign_summary(task_info)
-        if task_info is not None and message.get("game_sign_summary")
-        else ""
-    )
-    return await dispatch_task_report(
-        NotifyPayload(
-            title=title,
-            text=message_text,
-            html=message_html,
-            system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-            system_message=counts,
-            system_ticker=counts,
-            system_timeout=10,
-        ),
-        [global_target(include_system=True)],
-        task_info,
-        summary_text=summary_text,
-    )
+    return await push_proxy_result(title=title, message=message, task_info=task_info)

--- a/app/task/SRC/tools/notify.py
+++ b/app/task/SRC/tools/notify.py
@@ -24,12 +24,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import SrcUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("SRC通知工具")
@@ -47,37 +45,8 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        template = Config.notify_env.get_template("general_result.html")
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=template.render(message),
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title, message=message, task_info=task_info
         )
 
     if mode == "统计信息":

--- a/app/task/general/tools/notify.py
+++ b/app/task/general/tools/notify.py
@@ -24,12 +24,10 @@ from app.core.notify import (
     DispatchResult,
     NotifyPayload,
     dispatch,
-    global_target,
-    should_send_result,
     statistic_targets,
 )
 from app.models.config import GeneralUserConfig
-from app.tools.game_sign_notify import dispatch_task_report, get_task_game_sign_summary
+from app.task.notify_core import push_proxy_result
 from app.utils import get_logger
 
 logger = get_logger("通用通知工具")
@@ -47,38 +45,8 @@ async def push_notification(
     logger.info(f"开始推送通知, 模式: {mode}, 标题: {title}")
 
     if mode == "代理结果":
-        if not should_send_result(message):
-            return DispatchResult()
-
-        message_text = (
-            f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
-            f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
-            f"{message['result']}"
-        )
-        # 生成HTML通知内容
-        template = Config.notify_env.get_template("general_result.html")
-        counts = (
-            f"已完成用户数: {message['completed_count']}, "
-            f"未完成用户数: {message['uncompleted_count']}"
-        )
-        summary_text = (
-            get_task_game_sign_summary(task_info)
-            if task_info is not None and message.get("game_sign_summary")
-            else ""
-        )
-        return await dispatch_task_report(
-            NotifyPayload(
-                title=title,
-                text=message_text,
-                html=template.render(message),
-                system_title=message.get("system_title") or title.replace("报告", "已完成！"),
-                system_message=counts,
-                system_ticker=counts,
-                system_timeout=10,
-            ),
-            [global_target(include_system=True)],
-            task_info,
-            summary_text=summary_text,
+        return await push_proxy_result(
+            title=title, message=message, task_info=task_info
         )
 
     if mode == "统计信息":

--- a/app/task/notify_core.py
+++ b/app/task/notify_core.py
@@ -1,0 +1,100 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+
+#   This file is part of AUTO-MAS.
+
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+#   the GNU Affero General Public License for more details.
+
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+
+#   Contact: DLmaster_361@163.com
+
+"""各专项通知工具共用的「代理结果」推送核心。
+
+SRC / HSR / MaaEnd / OkNte / general / Okww / MAA / M9A / MaaFW 的代理结果
+分支原本逐字重复，仅模板名、签名分隔符与跳过日志存在授权差异，统一收敛到
+本模块。各专项的统计信息分支差异较大，保留在各自 notify 模块内。
+"""
+
+from typing import Any
+
+from app.core import Config
+from app.core.notify import (
+    DispatchResult,
+    NotifyPayload,
+    global_target,
+    should_send_result,
+)
+from app.tools.game_sign_notify import (
+    dispatch_task_report,
+    get_task_game_sign_summary,
+)
+
+
+async def push_proxy_result(
+    *,
+    title: str,
+    message: dict,
+    task_info: object | None = None,
+    result_template: str = "general_result.html",
+    signature_sep: str = "\n\n",
+    logger: Any | None = None,
+    skip_debug_message: str | None = None,
+) -> DispatchResult:
+    """推送全局「代理结果」报告；签到汇总与渠道级重试由 dispatch_task_report 承担。
+
+    Args:
+        title: 通知标题。
+        message: 需含 start_time / end_time / completed_count /
+            uncompleted_count / result 字段。
+        task_info: 任务信息，用于签到汇总的渠道级重试。
+        result_template: 结果 HTML 模板名，MAA 用 MAA_result.html。
+        signature_sep: 签名分隔符，默认与 NotifyPayload 缺省一致；MAA 只空一行。
+        logger: 调用方模块 logger，仅用于可选的跳过 debug 日志。
+        skip_debug_message: SendTaskResultTime 不满足时的 debug 文案，仅 M9A 传入。
+    """
+
+    if not should_send_result(message):
+        if logger is not None and skip_debug_message:
+            logger.debug(skip_debug_message)
+        return DispatchResult()
+
+    message_text = (
+        f"任务开始时间: {message['start_time']}, 结束时间: {message['end_time']}\n"
+        f"已完成数: {message['completed_count']}, 未完成数: {message['uncompleted_count']}\n\n"
+        f"{message['result']}"
+    )
+    template = Config.notify_env.get_template(result_template)
+    counts = (
+        f"已完成用户数: {message['completed_count']}, "
+        f"未完成用户数: {message['uncompleted_count']}"
+    )
+    summary_text = (
+        get_task_game_sign_summary(task_info)
+        if task_info is not None and message.get("game_sign_summary")
+        else ""
+    )
+    return await dispatch_task_report(
+        NotifyPayload(
+            title=title,
+            text=message_text,
+            html=template.render(message),
+            signature_sep=signature_sep,
+            system_title=message.get("system_title") or title.replace("报告", "已完成！"),
+            system_message=counts,
+            system_ticker=counts,
+            system_timeout=10,
+        ),
+        [global_target(include_system=True)],
+        task_info,
+        summary_text=summary_text,
+    )

--- a/app/tools/skland.py
+++ b/app/tools/skland.py
@@ -51,8 +51,6 @@ from app.utils.constants import BROWSER_ENV, DES_RULE, SKLAND_SM_CONFIG, UTC8
 from app.utils.logger import get_logger
 from app.utils.security import format_exception_reason
 
-from .skland_response import is_skland_already_signed
-
 _skland_sign_lock = asyncio.Lock()
 _device_id_lock = asyncio.Lock()
 _cached_device_id: str | None = None
@@ -71,6 +69,14 @@ SKLAND_ENDFIELD_SIGN_URL = "https://zonai.skland.com/web/v1/game/endfield/attend
 SKLAND_SIGN_INTERVAL = 1.0
 
 logger = get_logger("森空岛签到任务")
+
+
+def is_skland_already_signed(response: dict) -> bool:
+    """判断森空岛签到响应是否表示今日已签到。"""
+    message = str(response.get("message", ""))
+    return response.get("code") == 10001 or any(
+        marker in message for marker in ("请勿重复签到", "Please do not sign in again!")
+    )
 
 
 def _get_arknights_game_id(character: dict[str, Any]) -> Any:

--- a/app/tools/skland_response.py
+++ b/app/tools/skland_response.py
@@ -1,6 +1,0 @@
-def is_skland_already_signed(response: dict) -> bool:
-    """判断森空岛签到响应是否表示今日已签到。"""
-    message = str(response.get("message", ""))
-    return response.get("code") == 10001 or any(
-        marker in message for marker in ("请勿重复签到", "Please do not sign in again!")
-    )

--- a/app/tools/taygedo.py
+++ b/app/tools/taygedo.py
@@ -301,7 +301,7 @@ async def _laohu_password_login(
         data=_signed_laohu_data(data),
         timeout=30.0,
     )
-    payload = _read_login_json(response, "塔吉多账号密码登录")
+    payload = _read_json(response, "塔吉多账号密码登录")
     result = payload.get("result")
     user_id = ""
     token = ""
@@ -407,7 +407,7 @@ async def _request_user_center_login(
         },
         timeout=30.0,
     )
-    return response, _read_login_json(response, "塔吉多用户中心登录")
+    return response, _read_json(response, "塔吉多用户中心登录")
 
 
 def _laohu_android_base_params(device_id: str, timestamp: str) -> dict[str, str]:
@@ -453,18 +453,6 @@ def _make_login_ds() -> str:
         )
     ).hexdigest()
     return f"{timestamp},{nonce},{signature}"
-
-
-def _read_login_json(response: httpx.Response, endpoint: str) -> dict[str, Any]:
-    try:
-        data = response.json()
-    except (ValueError, json.JSONDecodeError) as exc:
-        raise ValueError(
-            f"{endpoint}返回了无效 JSON（HTTP {response.status_code}）"
-        ) from exc
-    if not isinstance(data, dict):
-        raise ValueError(f"{endpoint}返回格式无效（HTTP {response.status_code}）")
-    return data
 
 
 def _is_code(value: Any, expected: int) -> bool:

--- a/app/utils/emulator/general.py
+++ b/app/utils/emulator/general.py
@@ -32,7 +32,7 @@ if IS_WINDOWS:
     import win32gui
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
 from app.models.config import EmulatorConfig
 from app.models.emulator import DeviceBase, DeviceInfo, DeviceStatus
@@ -58,7 +58,6 @@ class GeneralDeviceManager(DeviceBase):
         self.config = config
         self.emulator_path = Path(config.get("Info", "Path"))
         self.process_managers: Dict[str, ProcessManager] = {}
-        self.device_info: Dict[str, Dict[str, Any]] = {}
 
     async def open(self, idx: str, package_name: str = "") -> DeviceInfo:
 
@@ -205,6 +204,5 @@ class GeneralDeviceManager(DeviceBase):
                 logger.error(f"清理设备{idx}资源失败: {str(e)}")
 
         self.process_managers.clear()
-        self.device_info.clear()
 
         logger.info("设备管理器资源清理完成")

--- a/app/utils/expression/__init__.py
+++ b/app/utils/expression/__init__.py
@@ -23,14 +23,7 @@
 """
 
 from .evaluator import CompiledExpression, compile_expression
-from .functions import (
-    FUNCTIONS,
-    REGISTRY,
-    Process,
-    apply_function,
-    make_process,
-    register_process,
-)
+from .functions import FUNCTIONS, apply_function
 from .parser import ExpressionError, parse
 
 __all__ = [
@@ -39,9 +32,5 @@ __all__ = [
     "ExpressionError",
     "parse",
     "FUNCTIONS",
-    "Process",
-    "REGISTRY",
-    "register_process",
-    "make_process",
     "apply_function",
 ]

--- a/app/utils/expression/evaluator.py
+++ b/app/utils/expression/evaluator.py
@@ -18,7 +18,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional, Pattern
 
-from .functions import FUNCTIONS, REGISTRY, apply_function
+from .functions import FUNCTIONS, apply_function
 from .parser import (
     ExpressionError,
     FunctionCall,
@@ -162,13 +162,12 @@ def compile_expression(expr_str: str) -> CompiledExpression:
     compiled_lines: list[list[_CompiledSegment]] = []
 
     # 校验函数名：未知函数名在编译期即报错，避免运行时静默失效
-    # 可用函数 = 内置 FUNCTIONS ∪ 注入的自定义算子 REGISTRY
-    available = ", ".join(sorted(set(FUNCTIONS) | set(REGISTRY)))
+    available = ", ".join(sorted(FUNCTIONS))
     for line in ast_lines:
         for seg in line:
             if isinstance(seg, RegexSegment):
                 for fn in seg.functions:
-                    if fn.name not in FUNCTIONS and fn.name not in REGISTRY:
+                    if fn.name not in FUNCTIONS:
                         raise ExpressionError(
                             f"未知函数 '{fn.name}'，可用函数: {available}"
                         )

--- a/app/utils/expression/functions.py
+++ b/app/utils/expression/functions.py
@@ -1,10 +1,6 @@
-"""内置函数与自定义算子实现
+"""内置函数实现
 
 内置函数每个接收 (text, args) 并返回处理后的字符串，注册在 FUNCTIONS 字典中。
-
-自定义算子通过 @register_process 注入（如 log_box 的 i18n 翻译），继承
-Process 基类、实现 name 与 run(text, args)，注册在 REGISTRY 字典中。求值时
-先查内置函数、再查注入算子，保证引擎对外仍是统一函数链语义。
 
 内置函数清单：cut / get / sub / cutby / subby / replace / trim / upper / lower
 """
@@ -15,79 +11,6 @@ from typing import Callable, Union
 
 # 函数参数类型
 Arg = Union[str, int]
-
-
-# ==================== 自定义算子 ====================
-
-
-class Process:
-    """自定义文本处理算子基类
-
-    子类通过 @register_process 注入表达式引擎，作为函数链可用的自定义函数。
-    实现 name 类属性与 run(text, args)；构造时接收表达式调用处的静态参数
-    *args，便于子类按调用参数完成实例化配置。
-
-    用法::
-
-        @register_process
-        class Translate(Process):
-            name = "translate"
-
-            def run(self, text, args):
-                return translator.translate(text)
-    """
-
-    name: str = ""
-
-    def __init__(self, *args: Arg) -> None:
-        self.args: list[Arg] = list(args)
-
-    def run(self, text: str, args: list[Arg]) -> str:
-        """处理文本：text 为输入，args 为表达式调用处的参数"""
-        raise NotImplementedError
-
-    def __call__(self, text: str, args: list[Arg]) -> str:
-        """对齐内置函数签名 func(text, args)"""
-        return self.run(text, args)
-
-
-# ==================== 注册表 ====================
-
-# 注入的自定义算子注册表：函数名 → Process 子类
-REGISTRY: dict[str, type[Process]] = {}
-
-
-def register_process(cls: type[Process]) -> type[Process]:
-    """按 cls.name 将自定义算子登记进 REGISTRY
-
-    Args:
-        cls: Process 子类，需定义 name 类属性
-
-    Returns:
-        原类（供装饰器使用）
-
-    Raises:
-        ValueError: 类未定义 name 类属性
-    """
-    name = getattr(cls, "name", "") or ""
-    if not name:
-        raise ValueError(f"自定义算子 {cls.__name__} 必须定义 name 类属性")
-    REGISTRY[name] = cls
-    return cls
-
-
-def make_process(name: str, cls: type[Process], args: list[Arg]) -> Process:
-    """按表达式调用参数实例化自定义算子
-
-    Args:
-        name: 算子名（仅用于构造提示）
-        cls: Process 子类
-        args: 表达式调用处的静态参数
-
-    Returns:
-        Process 实例
-    """
-    return cls(*args)
 
 
 def _find_nth(text: str, marker: str, nth: int, start: int = 0) -> int:
@@ -285,7 +208,7 @@ FUNCTIONS: dict[str, Callable[[str, list[Arg]], str]] = {
 
 
 def apply_function(name: str, args: list[Arg], text: str) -> str:
-    """调用函数（先查内置函数，再查注入的自定义算子）
+    """调用内置函数
 
     Args:
         name: 函数名
@@ -299,9 +222,6 @@ def apply_function(name: str, args: list[Arg], text: str) -> str:
         ValueError: 函数不存在或参数不合法
     """
     func = FUNCTIONS.get(name)
-    if func is not None:
-        return func(text, args)
-    cls = REGISTRY.get(name)
-    if cls is None:
+    if func is None:
         raise ValueError(f"未知函数: {name}")
-    return make_process(name, cls, args)(text, args)
+    return func(text, args)

--- a/app/utils/i18n/translator.py
+++ b/app/utils/i18n/translator.py
@@ -94,10 +94,10 @@ class PoTranslator:
         *,
         base: Optional[PathLike] = None,
     ) -> "PoTranslator":
-        """加载补充翻译文件（.po / .mo），优先于已加载的翻译
+        """加载补充翻译文件（.po / .mo），语义与 load 一致，保留别名给既有调用方
 
-        补充翻译后加载、覆盖同名键，如 AutoMAS 项目自带的补充 .mo 或专项
-        补充的关键节点文案；与 load 一样支持多个文件与相对路径解析。
+        后加载、覆盖同名键，如 AutoMAS 项目自带的补充 .mo 或专项补充的
+        关键节点文案。
 
         Args:
             paths: 补充翻译文件路径（单个或多个）
@@ -106,14 +106,7 @@ class PoTranslator:
         Returns:
             self（支持链式调用）
         """
-        items = [paths] if isinstance(paths, (str, Path)) else list(paths)
-        for item in items:
-            path = Path(item)
-            if not path.is_absolute() and base is not None:
-                path = Path(base) / path
-            self._map.update(self._load_file(path))
-        self._rebuild_sorted_keys()
-        return self
+        return self.load(paths, base=base)
 
     def translate(self, text: str) -> str:
         """逐行翻译：命中的键替换为译文，未命中返回原文

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -22,7 +22,14 @@
 
 import re
 
-from app.utils.platform import secret
+from app.utils.platform.secret import dpapi_decrypt, dpapi_encrypt
+
+__all__ = [
+    "sanitize_log_message",
+    "format_exception_reason",
+    "dpapi_encrypt",
+    "dpapi_decrypt",
+]
 
 
 def sanitize_log_message(message: str) -> str:
@@ -84,45 +91,3 @@ def format_exception_reason(
         else:
             message = "程序内部异常"
     return f"{stage}（{exception_name}）：{message}"
-
-
-def dpapi_encrypt(
-    note: str, description: None | str = None, entropy: None | bytes = None
-) -> str:
-    """
-    使用Windows DPAPI加密数据
-
-    :param note: 数据明文
-    :type note: str
-    :param description: 描述信息
-    :type description: str
-    :param entropy: 随机熵
-    :type entropy: bytes
-    :return: 加密后的数据
-    :rtype: str
-    """
-
-    if note == "":
-        return ""
-    return secret.dpapi_encrypt(
-        note,
-        description,
-        entropy,
-    )
-
-
-def dpapi_decrypt(note: str, entropy: None | bytes = None) -> str:
-    """
-    使用Windows DPAPI解密数据
-
-    :param note: 数据密文
-    :type note: str
-    :param entropy: 随机熵
-    :type entropy: bytes
-    :return: 解密后的明文
-    :rtype: str
-    """
-
-    if note == "":
-        return ""
-    return secret.dpapi_decrypt(note, entropy)

--- a/app/utils/websocket.py
+++ b/app/utils/websocket.py
@@ -168,10 +168,6 @@ class WebSocketClient:
             if asyncio.iscoroutine(result):
                 await result
 
-    async def close(self, code: int = 1000, reason: str = "正常关闭"):
-        """兼容统一的关闭接口。"""
-        await self.disconnect()
-
     async def send(self, message: Dict[str, Any]) -> bool:
         """
         发送 JSON 消息
@@ -192,10 +188,6 @@ class WebSocketClient:
         except Exception as e:
             self.logger.error(f"发送消息失败: {type(e).__name__}: {e}")
             return False
-
-    async def send_json(self, data: Dict[str, Any]) -> bool:
-        """兼容 FastAPI WebSocket 的 send_json 接口。"""
-        return await self.send(data)
 
     async def send_auth(
         self,
@@ -418,15 +410,6 @@ class WebSocketClient:
             self.logger.info("已发送认证消息")
         return success
 
-    def set_auth_token(self, token: Optional[str]):
-        """
-        设置认证令牌（下次连接/重连时生效）
-
-        Args:
-            token: 认证令牌，设为 None 可清除
-        """
-        self._auth_token = token
-
 
 # ============== WebSocket 客户端管理器 ==============
 
@@ -456,18 +439,6 @@ class WSClientManager:
     def get_client(self, name: str) -> Optional[WebSocketClient]:
         """获取客户端实例"""
         return self._clients.get(name)
-
-    def get_session(self, name: str) -> Optional[WebSocketClient]:
-        """兼容旧接口：获取客户端实例。"""
-        return self._clients.get(name)
-
-    def has_client(self, name: str) -> bool:
-        """检查客户端是否存在"""
-        return name in self._clients
-
-    def is_system_client(self, name: str) -> bool:
-        """检查是否为系统客户端"""
-        return name in self._system_clients
 
     def list_clients(self) -> Dict[str, Dict[str, Any]]:
         """列出所有客户端及其状态"""
@@ -718,27 +689,6 @@ class WSClientManager:
         except Exception as e:
             self._logger.error(f"初始化 Koishi 系统客户端失败: {type(e).__name__}: {e}")
             return False
-
-    async def update_system_client_koishi(self) -> bool:
-        """
-        更新 Koishi 系统客户端配置
-
-        当配置变更时调用，会断开旧连接并重新连接
-
-        Returns:
-            bool: 是否成功更新
-        """
-        # 如果客户端存在，先断开
-        if self.has_client(self.KOISHI_CLIENT_NAME):
-            await self.disconnect_client(self.KOISHI_CLIENT_NAME)
-            # 从系统客户端集合中移除以允许删除
-            self._system_clients.discard(self.KOISHI_CLIENT_NAME)
-            # 删除旧客户端
-            if self.KOISHI_CLIENT_NAME in self._clients:
-                del self._clients[self.KOISHI_CLIENT_NAME]
-
-        # 重新初始化
-        return await self.init_system_client_koishi()
 
 
 # 全局管理器实例

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,7 +10,7 @@ import { useAppInitialization } from './composables/useAppInitialization.ts'
 import AppLayout from './components/AppLayout.vue'
 import TitleBar from './components/TitleBar.vue'
 import UpdateModal from './components/UpdateModal.vue'
-import DevDebugPanel from './components/DevDebugPanel.vue'
+import DebugPanel from './components/devtools/index.vue'
 import GlobalPowerCountdown from './components/GlobalPowerCountdown.vue'
 import AppClosingOverlay from './components/AppClosingOverlay.vue'
 import BackendStartupOverlay from './components/BackendStartupOverlay.vue'
@@ -84,7 +84,7 @@ onMounted(async () => {
     </div>
 
     <!-- 开发环境调试面板 - 开发工具始终可用 -->
-    <DevDebugPanel />
+    <DebugPanel />
 
     <!-- 以下组件仅在初始化完成后挂载 -->
     <template v-if="isInitialized">

--- a/frontend/src/components/CursorEffectLayer.vue
+++ b/frontend/src/components/CursorEffectLayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, type Component } from 'vue'
-import FluidCursor from '@/components/inspira/FluidCursor.vue'
+import FluidCursor from '@/components/inspira/FluidCursorOfficial.vue'
 import SleekLineCursor from '@/components/inspira/SleekLineCursor.vue'
 import { useCursorEffectStore } from '@/stores/cursorEffect'
 import { usePerformanceStore } from '@/stores/performance'

--- a/frontend/src/components/DevDebugPanel.vue
+++ b/frontend/src/components/DevDebugPanel.vue
@@ -1,7 +1,0 @@
-<template>
-  <DebugPanel />
-</template>
-
-<script setup lang="ts">
-import DebugPanel from './devtools/index.vue'
-</script>

--- a/frontend/src/components/inspira/FluidCursor.vue
+++ b/frontend/src/components/inspira/FluidCursor.vue
@@ -1,7 +1,0 @@
-<template>
-  <FluidCursorOfficial />
-</template>
-
-<script setup lang="ts">
-import FluidCursorOfficial from './FluidCursorOfficial.vue'
-</script>

--- a/frontend/src/composables/useStatusTag.ts
+++ b/frontend/src/composables/useStatusTag.ts
@@ -151,24 +151,6 @@ export function parseStatusTagList(
 }
 
 /**
- * 序列化状态标签为JSON字符串
- * @param tag - StatusTag对象
- * @returns JSON字符串
- */
-export function serializeStatusTag(tag: StatusTag): string {
-  return JSON.stringify(tag)
-}
-
-/**
- * 序列化状态标签数组为JSON字符串
- * @param tags - StatusTag对象数组
- * @returns JSON字符串
- */
-export function serializeStatusTagList(tags: StatusTag[]): string {
-  return JSON.stringify(tags)
-}
-
-/**
  * 使用状态标签的Composable
  * @param statusGetter - 获取状态字符串的函数
  * @param defaultTag - 默认标签
@@ -179,19 +161,6 @@ export function useStatusTag(
   defaultTag: StatusTag | null = null
 ): ComputedRef<StatusTag | null> {
   return computed(() => parseStatusTag(statusGetter(), defaultTag))
-}
-
-/**
- * 使用状态标签列表的Composable
- * @param statusListGetter - 获取状态字符串数组的函数
- * @param defaultTags - 默认标签数组
- * @returns 计算属性，返回解析后的StatusTag数组
- */
-export function useStatusTagList(
-  statusListGetter: () => string | string[] | null | undefined,
-  defaultTags: StatusTag[] = []
-): ComputedRef<StatusTag[]> {
-  return computed(() => parseStatusTagList(statusListGetter(), defaultTags))
 }
 
 /**

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,7 +2,6 @@ import {
   createRouter,
   createWebHashHistory,
   type LocationQueryRaw,
-  type RouteParamsRawGeneric,
 } from 'vue-router'
 import { useAppInitialization } from '@/composables/useAppInitialization'
 import { getInitializationDecision } from '@/utils/initializationDecision'
@@ -403,23 +402,6 @@ export function navigateTo(
   const { replace = false, query } = options || {}
   if (replace) return router.replace({ path, query })
   return router.push({ path, query })
-}
-
-export function navigateToByName(
-  name: string,
-  options?: { replace?: boolean; query?: LocationQueryRaw; params?: RouteParamsRawGeneric }
-) {
-  const { replace = false, query, params } = options || {}
-  if (replace) return router.replace({ name, query, params })
-  return router.push({ name, query, params })
-}
-
-export function goBack() {
-  return router.back()
-}
-
-export function goForward() {
-  return router.forward()
 }
 
 export default router

--- a/main.py
+++ b/main.py
@@ -432,10 +432,7 @@ def main():
     app.include_router(ocr_router)
     app.include_router(openclaw_qq_router)
     app.include_router(openclaw_weixin_router)
-
-    # 可选补丁：米游社扫码登录
-    if qr_login_router is not None:
-        app.include_router(qr_login_router)
+    app.include_router(qr_login_router)
 
     app.mount(
         "/api/res/materials",

--- a/res/version.json
+++ b/res/version.json
@@ -38,7 +38,8 @@
                 "首页 使用快速启动成功后会自动跳转到调度中心 by [@Craun718](https://github.com/Craun718)",
                 "HSR专项 脚本页新增「SRA 配置档案」下拉，可指定 SRA 多份配置档案中的哪一份供 MAS 管控表单、脚本直控与导入快照使用；默认「自动」保持原有的优先 Default 行为，所选档案被删除时会回退并在脚本页、用户页与运行日志中提示 by [@qiyinxi](https://github.com/qiyinxi)",
                 "HSR专项 用户页仍以中文显示的一批界面文案（页面标题、用户名与剩余天数标签、历战余响与周常的本周完成状态、服务器与体力副本选项、管控任务列表的周常/日常与启用摘要等）接入多语言词表，英文与日文界面不再夹杂中文 by [@qiyinxi](https://github.com/qiyinxi)",
-                "日志清理 自动清理OCR图片 by [@HarcoChen](https://github.com/HarcoChen)"
+                "日志清理 自动清理OCR图片 by [@HarcoChen](https://github.com/HarcoChen)",
+                "代码清理 单源化各脚本专项重复的任务报告推送核心与 QQ/微信通知公共助手，并清理前后端死代码与直通包装组件，行为保持不变 by [@1w1w11w1](https://github.com/1w1w11w1)"
             ],
             "开发流程": [
                 "新增 GitHub Issue 模板，Bug 反馈按脚本专项、MaaFW 专项与通用问题分区，并附需求建议等模板与常见问题、文档站、官方群链接 by [@qiyinxi](https://github.com/qiyinxi)",

--- a/tests/tools/test_skland_response.py
+++ b/tests/tools/test_skland_response.py
@@ -1,6 +1,6 @@
 import unittest
 
-from app.tools.skland_response import is_skland_already_signed
+from app.tools.skland import is_skland_already_signed
 
 
 class SklandResponseTest(unittest.TestCase):


### PR DESCRIPTION
## 概要

- 单源化九个脚本专项（SRC / HSR / MaaEnd / OkNte / general / Okww / MAA / M9A / MaaFW）逐字重复的「代理结果」推送核心至 `app/task/notify_core.py`；各专项差异较大的统计信息分支按平台保留原地
- 合并 QQ / 微信通知适配器逐字节相同的 `RemoteHTTPError` 与 `split_text` 至 `app/services/openclaw_common.py`；删除表达式引擎的空注册算子框架、`WebSocketClient` 七个零调用方法等前后端死代码，并内联两个纯直通组件
- 折叠单函数模块 `app/tools/skland_response.py`、`taygedo.py` 同文件重复的 JSON 解析助手，`security.py` 的 DPAPI 包装改为直接再导出平台实现；米游社扫码登录路由改为无条件导入
- `res/version.json` 已在 v5.5.0-beta.3「程序优化」补充一条记录

以上均为逐字等价级别的合并与死代码删除，不改变任何事实意义上的行为。

## 本地验证结果

- 推送核心行为捕获：对 9 个专项模块 monkeypatch `dispatch`/`dispatch_task_report`/`should_send_result`/`global_target`/`Config`/`logger`，在正常与跳过两条路径下捕获 payload 全字段、targets 与日志行，重构前后 JSON 逐字节一致
- 定向测试 `tests/tools/test_skland_response.py` `tests/services/test_openclaw_qq.py` `tests/services/test_openclaw_weixin.py` `tests/core/test_ws_connection.py` `tests/task/test_okww_push_log.py` `tests/api/test_update_api.py`：29 passed
- 收集门槛 `python -m pytest tests --collect-only -q`：478 collected，退出码 0
- `ruff check` 覆盖全部改动文件通过；前端 `vue-tsc` 全量 3271 文件退出码 0、`oxlint` 0 告警
- 已知与本次无关的环境问题：`tests/task/test_maafw_embedded_prepare_cancel.py` 3 例失败在本仓库干净 HEAD 上同样失败（本地 venv 缺 pytest-asyncio）

## Sourcery 总结

在不改变行为的前提下，整合应用中重复的通知和工具代码，同时移除过时的后端和前端实现。

增强：
- 集中处理九个任务模块中相同的代理结果通知逻辑，同时保留特定平台的报告行为。
- 整合共享的 OpenClaw 通知工具，并简化等效的翻译、安全和响应处理接口。

测试：
- 更新 Skland 响应测试以使用整合后的实现。

维护：
- 移除后端和前端中未使用的表达式引擎注册 API、WebSocket 兼容方法、冗余状态、透传组件以及其他死代码。
- 将 MiYoShe 二维码登录路由改为无条件启用，并在版本元数据中记录此次清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate duplicated notification and utility code across the application while removing obsolete backend and frontend implementations without changing behavior.

Enhancements:
- Centralize identical proxy-result notification handling across nine task modules while preserving platform-specific reporting behavior.
- Consolidate shared OpenClaw notification utilities and simplify equivalent translation, security, and response-processing interfaces.

Tests:
- Update the Skland response test to use the consolidated implementation.

Chores:
- Remove unused expression-engine registration APIs, WebSocket compatibility methods, redundant state, pass-through components, and other dead code across the backend and frontend.
- Make MiYoShe QR-login routing unconditional and record the cleanup in the version metadata.

</details>