### PR TITLE
fix(maa): 修复托管下借战赚信用与访问好友每日去重失效

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -747,6 +747,14 @@ class MaaUserConfig(ConfigBase):
         self.Data_AnnihilationCompletedWeek = ConfigItem(
             "Data", "AnnihilationCompletedWeek", "2000-W01"
         )
+        ## 上次完成借战赚信用（OF-1）的日期（形如 "2026-09-07"）
+        self.Data_LastCreditFightDate = ConfigItem(
+            "Data", "LastCreditFightDate", "2000-01-01", DateTimeValidator("%Y-%m-%d")
+        )
+        ## 上次完成访问好友的日期（形如 "2026-09-07"）
+        self.Data_LastVisitFriendsDate = ConfigItem(
+            "Data", "LastVisitFriendsDate", "2000-01-01", DateTimeValidator("%Y-%m-%d")
+        )
         ## 上次完成绿票商店购买的月份
         self.Data_GreenTicketStoreMonth = ConfigItem(
             "Data", "GreenTicketStoreMonth", "2000-01", DateTimeValidator("%Y-%m")

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -665,6 +665,12 @@ class MaaUserConfig_Data(BaseModel):
     AnnihilationCompletedWeek: Optional[str] = Field(
         default=None, description="剿灭达到周上限时的 ISO 周"
     )
+    LastCreditFightDate: Optional[str] = Field(
+        default=None, description="上次完成借战赚信用（OF-1）的日期"
+    )
+    LastVisitFriendsDate: Optional[str] = Field(
+        default=None, description="上次完成访问好友的日期"
+    )
     GreenTicketStoreMonth: Optional[str] = Field(
         default=None, description="上次完成绿票商店购买的月份"
     )

--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -101,6 +101,33 @@ def _current_month_marker(now: datetime) -> str:
     return now.strftime("%Y-%m")
 
 
+def _is_marked_today(completed_date: str, now: datetime) -> bool:
+    """判断「每天一次」类完成标记是否已落在本游戏日（UTC+4）内。
+
+    MAS 托管会还原 MAA 目录，MAA 自带的每日去重（如借战、访问好友）
+    不跨运行生效，因此由 MAS 在日志中检测完成后自行记录。
+    """
+
+    return completed_date == now.strftime("%Y-%m-%d")
+
+
+# 信用收支的每日子任务：任务参数键 → 完成日志标记 → 用户存档中的日期字段
+_DAILY_MALL_ITEMS = (
+    (
+        "CreditFight",
+        ("完成任务: 借助战打 OF-1 赚信用", "完成任务: 信用作战"),
+        "LastCreditFightDate",
+        "借战赚信用",
+    ),
+    (
+        "VisitFriends",
+        ("完成任务: 访问好友",),
+        "LastVisitFriendsDate",
+        "访问好友",
+    ),
+)
+
+
 def _should_run_annihilation(
     start_weekday: str,
     completed_week: str,
@@ -405,6 +432,7 @@ class AutoProxyTask(TaskExecuteBase):
         self.cur_user_config = self.user_config[self.cur_user_uid]
         self.check_result = "-"
         self._annihilation_weekly_completion_recorded = False
+        self._daily_mall_recorded: set[str] = set()
 
     async def check(self) -> str:
 
@@ -780,6 +808,24 @@ class AutoProxyTask(TaskExecuteBase):
                 source_task=task_set["DepotMaintain"],
             )
 
+        # 信用收支的每日子任务（借战/访问好友）当日已执行过时关闭：
+        # MAS 托管会还原 MAA 目录，MAA 自带的每日去重不跨运行生效，
+        # 避免同一天重复打 OF-1、重复访问好友
+        for item_key, completion_markers, data_key, item_name in _DAILY_MALL_ITEMS:
+            if (
+                self.mode == "Routine"
+                and task_set["Mall"].get(item_key)
+                and _is_marked_today(
+                    self.cur_user_config.get("Data", data_key),
+                    datetime.now(tz=UTC4),
+                )
+            ):
+                task_set["Mall"][item_key] = False
+                logger.info(
+                    f"用户 {self.cur_user_item.name} 本次跳过{item_name}："
+                    f"最近执行={self.cur_user_config.get('Data', data_key)}"
+                )
+
         # 关闭所有定时
         for i in range(1, 9):
             global_set[f"Timer.Timer{i}"] = "False"  # OLD: 即将移除
@@ -1153,6 +1199,20 @@ class AutoProxyTask(TaskExecuteBase):
                 _current_month_marker(datetime.now(tz=UTC4)),
             )
             logger.info(f"用户 {self.cur_user_item.name} 已完成本月绿票商店购买")
+
+        # MAA 完成每日子任务时输出完成日志，据此记录执行日期（幂等）
+        if self.mode == "Routine":
+            for _item_key, completion_markers, data_key, item_name in _DAILY_MALL_ITEMS:
+                if data_key not in self._daily_mall_recorded and any(
+                    marker in log for marker in completion_markers
+                ):
+                    self._daily_mall_recorded.add(data_key)
+                    await self.cur_user_config.set(
+                        "Data",
+                        data_key,
+                        datetime.now(tz=UTC4).strftime("%Y-%m-%d"),
+                    )
+                    logger.info(f"用户 {self.cur_user_item.name} 已完成{item_name}")
 
         if "未选择任务" in log:
             self.cur_user_log.status = "MAA 未选择任何任务"

--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -104,11 +104,13 @@ def _current_month_marker(now: datetime) -> str:
 def _is_marked_today(completed_date: str, now: datetime) -> bool:
     """判断「每天一次」类完成标记是否已落在本游戏日（UTC+4）内。
 
-    MAS 托管会还原 MAA 目录，MAA 自带的每日去重（如借战、访问好友）
-    不跨运行生效，因此由 MAS 在日志中检测完成后自行记录。
+    completed_date 为按游戏日记录的标记（形如 "2026-09-07"）；now 接受
+    任意时区，内部归一到 UTC+4 后比较。MAS 托管会还原 MAA 目录，MAA
+    自带的每日去重（如借战、访问好友）不跨运行生效，因此由 MAS 在
+    日志中检测完成后自行记录。
     """
 
-    return completed_date == now.strftime("%Y-%m-%d")
+    return completed_date == now.astimezone(UTC4).strftime("%Y-%m-%d")
 
 
 # 信用收支的每日子任务：任务参数键 → 完成日志标记 → 用户存档中的日期字段

--- a/frontend/src/api/models/MaaUserConfig_Data.ts
+++ b/frontend/src/api/models/MaaUserConfig_Data.ts
@@ -8,6 +8,14 @@ export type MaaUserConfig_Data = {
      */
     AnnihilationCompletedWeek?: (string | null);
     /**
+     * 上次完成借战赚信用（OF-1）的日期
+     */
+    LastCreditFightDate?: (string | null);
+    /**
+     * 上次完成访问好友的日期
+     */
+    LastVisitFriendsDate?: (string | null);
+    /**
      * 上次完成绿票商店购买的月份
      */
     GreenTicketStoreMonth?: (string | null);

--- a/res/version.json
+++ b/res/version.json
@@ -50,6 +50,7 @@
                 "开发流程 禁止 AI 助手协助 force push by [@Craun718](https://github.com/Craun718)"
             ],
             "修复BUG": [
+                "MAA专项 修复信用收支的借战赚信用与访问好友在 MAS 托管下每日去重失效、同一天重复执行的问题：现在每个子任务每天最多执行一次，不影响领取信用与信用购物 by [@jinghero](https://github.com/jinghero)",
                 "OK-NTE专项 加固切换账号流程：预防弹窗及屏保等意外情况 by [@AthenaHibou](https://github.com/AthenaHibou)",
                 "修复同时打开两个前端窗口时互相抢占后端连接、每隔几秒断线并反复弹出提示的问题：后开的窗口接管连接，先开的窗口停止重连并只提示一次 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MaaEnd专项 修复 MaaEnd 更新后已完成任务被误判失败并重复重试的问题 by [@HarcoChen](https://github.com/HarcoChen)",

--- a/tests/task/test_maa_credit_fight_dedup.py
+++ b/tests/task/test_maa_credit_fight_dedup.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta, timezone
+
+from app.task.MAA.AutoProxy import _is_marked_today
+
+UTC4 = timezone(timedelta(hours=4))
+
+
+def test_marked_date_not_today_counts_as_pending() -> None:
+    assert not _is_marked_today("2000-01-01", datetime(2026, 9, 7, 12, 0, tzinfo=UTC4))
+
+
+def test_marked_today_suppresses_rerun() -> None:
+    assert _is_marked_today("2026-09-07", datetime(2026, 9, 7, 12, 0, tzinfo=UTC4))
+
+
+def test_marked_date_anchor_is_utc4() -> None:
+    # 东八区 2026-09-08 03:00 仍处于东四区 9 月 7 日，当日标记应继续生效
+    beijing_early_morning = datetime(
+        2026, 9, 8, 3, 0, tzinfo=timezone(timedelta(hours=8))
+    )
+
+    assert _is_marked_today("2026-09-07", beijing_early_morning.astimezone(UTC4))
+    assert not _is_marked_today("2026-09-06", beijing_early_morning.astimezone(UTC4))

--- a/tests/task/test_maa_credit_fight_dedup.py
+++ b/tests/task/test_maa_credit_fight_dedup.py
@@ -21,3 +21,11 @@ def test_marked_date_anchor_is_utc4() -> None:
 
     assert _is_marked_today("2026-09-07", beijing_early_morning.astimezone(UTC4))
     assert not _is_marked_today("2026-09-06", beijing_early_morning.astimezone(UTC4))
+
+
+def test_non_utc4_datetime_is_normalized_internally() -> None:
+    # UTC 时间 2026-09-07 20:00 即东四区的 2026-09-08 00:00：跨入新游戏日的临界时刻
+    utc_boundary = datetime(2026, 9, 7, 20, 0, tzinfo=timezone.utc)
+
+    assert _is_marked_today("2026-09-08", utc_boundary)
+    assert not _is_marked_today("2026-09-07", utc_boundary)


### PR DESCRIPTION
## 摘要

- MAA 的信用收支原生提供「借战赚信用一天仅一次」「访问好友一天仅一次」的去重选项，但其状态保存在 MAA 目录配置中；MAS 每次代理后会还原该目录，导致这两个原生选项在 MAS 托管场景下失效——同一天多次托管会重复执行，单个用户每次多耗时约 4 分钟（借战约 3 分钟、访问好友约 45 秒），且不产生额外收益（OF-1 的每日信用加成仅首次有效）
- 本修复适配该原生功能：改由 MAS 按用户记录执行日期（按游戏换日 UTC+4），当天已执行过则在任务参数中关闭对应子项，去重语义与 MAA 原生选项保持一致
- 领取信用与信用购物不受影响；多用户/多账号各自独立记录；固定关卡与计划表两种配置模式、脚本/用户两种配置来源下行为一致

## 验证

- 真机验证：同日第一次托管正常执行借战与访问好友并记录；第二次托管日志出现「本次跳过借战赚信用/本次跳过访问好友」，MAA 队列不再进入 OF-1 与好友访问
- 单元测试覆盖换日边界（游戏日按 UTC+4 计算）

## Sourcery 摘要

为 MAS 托管场景持久化信用收支每日任务的完成状态，避免重复借战和访问好友。

Bug 修复：
- 在 MAS 托管模式下恢复借战赚信用和访问好友的每日去重，避免同一游戏日重复执行。

改进：
- 按用户和账号独立保存两项任务的最近完成日期，并以 UTC+4 游戏日判断是否跳过任务。

测试：
- 新增覆盖日期去重及 UTC+4 换日边界的单元测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

恢复托管运行期间 MAA 信用收益任务可靠的每日去重功能。

错误修复：
- 恢复 MAS 托管的 MAA 运行中信用作战和访问好友任务的每日去重，防止在同一个游戏日内重复执行。

增强功能：
- 为每个用户和账号分别持久化完成日期，并使用 UTC+4 的游戏日边界来判断是否应跳过每日任务。

测试：
- 添加覆盖每日去重和 UTC+4 日期边界行为的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore reliable daily deduplication for MAA credit income tasks during managed runs.

Bug Fixes:
- Restore daily deduplication for credit-fighting and friend-visit tasks in MAS-managed MAA runs, preventing repeated execution within the same game day.

Enhancements:
- Persist completion dates independently for each user and account, using the UTC+4 game-day boundary to determine whether daily tasks should be skipped.

Tests:
- Add unit tests covering daily deduplication and UTC+4 date-boundary behavior.

</details>

</details>