### PR TITLE
fix(maafw): 脚本侧强制停止不再被记成任务完成

### DIFF
--- a/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
@@ -91,6 +91,10 @@ MAAFW_DEBUG_LOG_PATH = Path("debug") / "maafw.log"
 # 往下跑——后面每个任务都会在同一个空场景里空转到各自超时，既浪费十几分钟，
 # 又可能把「本轮已做过」的完成态错误写回。直接抛出，交给宿主的重试循环。
 FATAL_CONTROLLER_ACTIONS = frozenset({"start_app"})
+# MaaFramework 在 `Tasker::post_stop` 内部会跑一个同名的伪任务，任何一方调用
+# post_stop 都会产生它。脚本侧（如 MaaEnd 的分辨率闸门）用自定义动作强停时，
+# 我们只能从这里知道「这一轮不是自己结束的」。
+MAAFW_POST_STOP_ENTRY = "MaaTaskerPostStop"
 TASK_CONFIG_LOG_VALUE_LIMIT = 1200
 # 整行上限。留足余量低于宿主 _FRAMEWORK_UI_LOG_MAX_CHARS(1200)，
 # 免得任务配置被当成框架错误诊断截断。
@@ -541,6 +545,7 @@ class MaaFWRunner:
         self._initialized: bool = False
         self._python_env_checked: dict[str, bool] = {}
         self._stop_requested: threading.Event = threading.Event()
+        self._external_stop_seen: threading.Event = threading.Event()
         self._task_failure_summaries: list[str] = []
         self._failed_controller_actions: set[str] = set()
         self._failed_task_errors: list[tuple[str, str]] = []
@@ -610,6 +615,7 @@ class MaaFWRunner:
 
     def run(self, device_config: MaaFWDeviceConfig) -> MaaFWRunResult:
         self._stop_requested.clear()
+        self._external_stop_seen.clear()
         try:
             self._ensure_initialized(device_config)
             completed_tasks = self._run_tasks()
@@ -1848,6 +1854,7 @@ class MaaFWRunner:
             sink = _MaaFWTaskerLogSink(
                 self.send_log,
                 self._record_task_failure_summary,
+                self._note_tasker_entry,
             )
             if self.tasker.add_sink(sink) is not None:
                 self.event_sinks.append(sink)
@@ -2397,6 +2404,44 @@ class MaaFWRunner:
             self.send_log(f"[Python环境] pip install 异常: {exc}，将由 agent 自举尝试")
         return False
 
+    def _note_tasker_entry(self, entry: str) -> None:
+        """从 tasker 事件流里捕获「被外部强停」。
+
+        MAS 自己发起的停止（cleanup / reset_for_retry / shutdown）同样会产生
+        MaaTaskerPostStop，那条路径已有 `_stop_requested` 负责，不能混进来。
+        """
+
+        if entry != MAAFW_POST_STOP_ENTRY:
+            return
+        if self._stop_requested.is_set():
+            return
+        self._external_stop_seen.set()
+
+    def _external_stop_active(self, tasker: Tasker | None) -> bool:
+        """tasker 是不是被脚本侧强停了。
+
+        主判据是同步查询 `MaaTaskerStopping`，不是上面那个事件标志：事件是异步
+        送达的，实测比 `job.wait()` 返回晚约 19ms，光靠它会漏掉**当前**这个任务，
+        于是它照旧被记成「任务完成」——这正是要修的 bug。
+        post_stop 因果上必然早于 wait() 返回，所以此刻 stopping 一定还是 true。
+        事件标志留作兜底，覆盖两个任务之间到达的强停。
+        """
+
+        if self._stop_requested.is_set():
+            return False
+        if self._external_stop_seen.is_set():
+            return True
+        if tasker is None:
+            return False
+        try:
+            if bool(tasker.stopping):
+                self._external_stop_seen.set()
+                return True
+        except Exception:
+            # 老版本 MaaFW 没有 MaaTaskerStopping，退回只靠事件标志。
+            return False
+        return False
+
     def _run_tasks(self) -> list[str]:
         completed_tasks: list[str] = []
         self._completed_tasks = completed_tasks
@@ -2433,6 +2478,12 @@ class MaaFWRunner:
                         f"游戏未能启动（{actions} 失败），本轮剩余任务已跳过: "
                         f"{display_name}: {message}"
                     ) from exc
+                if self._external_stop_active(tasker):
+                    self.send_log(
+                        f"任务被脚本侧强制停止，本轮剩余任务已跳过: "
+                        f"{display_name}: {message}"
+                    )
+                    break
                 # 这条现在会实时出现在任务日志里，措辞不能对最后一个
                 # 任务说「将继续后续任务」。
                 if index + 1 < total_tasks:
@@ -2445,6 +2496,17 @@ class MaaFWRunner:
                 continue
             if self._stop_requested.is_set():
                 raise RuntimeError("MaaFW 任务已停止")
+            # MaaFW 会把「被 post_stop 打断」的入口回报成 Task.Succeeded——强停是
+            # 由 pipeline 里的动作节点触发的，那个节点本身返回成功。只看
+            # `job.failed` 会把一件没做的事记成「任务完成」，整轮还可能被报成
+            # 全部成功。这里必须独立判一次。
+            if self._external_stop_active(tasker):
+                message = "任务被脚本侧强制停止（MaaTaskerPostStop）"
+                self._failed_task_errors.append((task.name, message))
+                self.send_log(
+                    f"任务未完成，本轮剩余任务已跳过: {display_name}: {message}"
+                )
+                break
             completed_tasks.append(task.name)
             self.send_log(f"任务完成: {display_name}")
             time.sleep(0.1)
@@ -2654,10 +2716,12 @@ class _MaaFWTaskerLogSink(TaskerEventSink):
         self,
         send_log: Callable[[str], None],
         record_failure: Callable[[str, dict[str, Any]], None],
+        note_entry: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__()
         self.send_log = send_log
         self.record_failure = record_failure
+        self.note_entry = note_entry
 
     def on_tasker_task(
         self,
@@ -2668,6 +2732,8 @@ class _MaaFWTaskerLogSink(TaskerEventSink):
         self.send_log(
             f"[MaaFW Tasker] {_notification_label(noti_type)}: {detail.entry}"
         )
+        if self.note_entry is not None:
+            self.note_entry(detail.entry)
 
     def on_raw_notification(
         self,

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
@@ -546,6 +546,8 @@ class MaaFWRunner:
         self._python_env_checked: dict[str, bool] = {}
         self._stop_requested: threading.Event = threading.Event()
         self._external_stop_seen: threading.Event = threading.Event()
+        self._self_stop_lock: threading.Lock = threading.Lock()
+        self._pending_self_stops: int = 0
         self._task_failure_summaries: list[str] = []
         self._failed_controller_actions: set[str] = set()
         self._failed_task_errors: list[tuple[str, str]] = []
@@ -673,7 +675,7 @@ class MaaFWRunner:
             try:
                 _ensure_maafw_client_library_mode()
                 if self.tasker.running:
-                    self.tasker.post_stop().wait()
+                    self._post_self_stop()
             except Exception as exc:
                 self.send_log(f"停止 MaaFW tasker 失败: {exc}")
 
@@ -683,7 +685,7 @@ class MaaFWRunner:
             try:
                 _ensure_maafw_client_library_mode()
                 if self.tasker.running:
-                    self.tasker.post_stop().wait()
+                    self._post_self_stop()
             except Exception as exc:
                 self.send_log(f"停止 MaaFW tasker 准备重试失败: {exc}")
 
@@ -2404,15 +2406,35 @@ class MaaFWRunner:
             self.send_log(f"[Python环境] pip install 异常: {exc}，将由 agent 自举尝试")
         return False
 
-    def _note_tasker_entry(self, entry: str) -> None:
-        """从 tasker 事件流里捕获「被外部强停」。
+    def _post_self_stop(self) -> None:
+        """MAS 自己发起停止，并给随之而来的 MaaTaskerPostStop 通知记账。
 
-        MAS 自己发起的停止（cleanup / reset_for_retry / shutdown）同样会产生
-        MaaTaskerPostStop，那条路径已有 `_stop_requested` 负责，不能混进来。
+        通知是异步送达的，可能晚到下一轮 `run()` 清完标志之后才到；不记账就会被
+        `_note_tasker_entry` 当成脚本侧强停，把重试的第一个任务判成失败、后面的
+        全部跳过。`post_stop()` 返回即代表停止任务已入队、通知必然会来；它抛异常
+        时没有入队，所以计数必须放在调用返回之后。
         """
+
+        if self.tasker is None:
+            return
+        job = self.tasker.post_stop()
+        with self._self_stop_lock:
+            self._pending_self_stops += 1
+        job.wait()
+
+    def _note_tasker_entry(self, noti_type: NotificationType, entry: str) -> None:
+        """从 tasker 事件流里捕获「被外部强停」。"""
 
         if entry != MAAFW_POST_STOP_ENTRY:
             return
+        # 一次 post_stop 会先后发出 Starting 和 Succeeded 两条通知。只认第一条，
+        # 记账才能和 `_post_self_stop` 的调用一一对应。
+        if noti_type != NotificationType.Starting:
+            return
+        with self._self_stop_lock:
+            if self._pending_self_stops > 0:
+                self._pending_self_stops -= 1
+                return
         if self._stop_requested.is_set():
             return
         self._external_stop_seen.set()
@@ -2716,7 +2738,7 @@ class _MaaFWTaskerLogSink(TaskerEventSink):
         self,
         send_log: Callable[[str], None],
         record_failure: Callable[[str, dict[str, Any]], None],
-        note_entry: Callable[[str], None] | None = None,
+        note_entry: Callable[[NotificationType, str], None] | None = None,
     ) -> None:
         super().__init__()
         self.send_log = send_log
@@ -2733,7 +2755,7 @@ class _MaaFWTaskerLogSink(TaskerEventSink):
             f"[MaaFW Tasker] {_notification_label(noti_type)}: {detail.entry}"
         )
         if self.note_entry is not None:
-            self.note_entry(detail.entry)
+            self.note_entry(noti_type, detail.entry)
 
     def on_raw_notification(
         self,

--- a/res/version.json
+++ b/res/version.json
@@ -103,7 +103,8 @@
                 "HSR专项与SRC专项 修复英文与日文界面的术语错误：「历战余响」在英文下被显示为「差分宇宙」（两者在同一页面上是不同玩法），「体力配置」沿用了明日方舟的「理智」译法，「侵蚀隧洞」英文名复数有误 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 修复项目 interface 的同一个预设里重复写了同一个任务（例如 MXU 的随机启动标记）时整份项目读不出来、建项向导卡在第一步的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 从新链路回退到旧链路后准备项目运行环境时，改为直接复用 Runtime 已经装好的 uv，不再要求用户自己再准备一份 by [@qiyinxi](https://github.com/qiyinxi)",
-                "MFW专项 准备运行环境确实找不到 uv 时改为给出可照做的中文提示，写明 uv.exe 该放的完整路径，以及本机已有完整 Python 3.12 时可改设环境变量跳过下载 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MFW专项 准备运行环境确实找不到 uv 时改为给出可照做的中文提示，写明 uv.exe 该放的完整路径，以及本机已有完整 Python 3.12 时可改设环境变量跳过下载 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MFW专项 修复脚本侧强制停止任务（如 MaaEnd 分辨率不达标时的强停）被记成「任务完成」的问题：现在被强停的任务按失败记录，本轮剩余任务不再投递，不会再出现整轮一件事没做却报成全部成功"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
## 问题

脚本侧的守卫（如 MaaEnd 分辨率不达标时的强停）会调 `PostStop` 停掉整个 tasker。强停是由 pipeline 里的动作节点触发的，那个节点自身返回成功，MaaFW 于是把入口回报成 `Tasker.Task.Succeeded`；runner 只看 `job.failed`，把一件没做的事记成「任务完成」，还继续投递剩余任务，每个重复一遍。

实际现场（2026-09-07 04:00，MaaEnd 12 个任务）：11 个被记成完成，只因为其中一次投递恰好撞上 tasker 正在 stopping、报了 `task_id=0` 才暴露。**否则整轮会被报成全部成功。**

## 判据为什么不用事件

第一版想监听 `MaaTaskerPostStop` 事件，但它比 `job.wait()` 返回晚约 19ms：

```
[04:00:31.772] 任务完成: 🤝拜访好友
[04:00:31.791] [MaaFW Tasker] 开始: MaaTaskerPostStop
```

光靠事件会漏掉当前这个任务，正好是要修的那个。改用同步查询 `MaaTaskerStopping`——`post_stop` 因果上必然早于 `wait()` 返回，此刻 `stopping` 一定还是 true。事件标志降级为兜底，覆盖两个任务之间到达的强停；`_stop_requested` 排除 MAS 自己发起的停止。

命中后：当前任务按失败记录、不计入 `completedTasks`，剩余任务不再投递。`task_id=0` 那条也一并收编，它本来就是「投递撞上 stopping」的表现。

## 本地验证

在本分支的 `.venv`（Python 3.12）实跑：

| 检查 | 结果 |
| --- | --- |
| `python -m pytest tests` | 484 passed, 3 skipped |
| `python -m pytest tests --collect-only -q` | 487 collected，退出 0 |
| `ruff check` / `ruff format --check` | 通过 |
| 回归测试 7 例（边界测试，按 `tests/AGENTS.md` 未提交） | 7 passed |

回归测试含一条敏感性检查：把新判据短路成恒 `False`，断言旧行为下 3 个任务全被记成「完成」——确认这组用例确实能捕获该 bug，而不是修复前后都绿。

## 残留风险

判据是「tasker 被停 → 当前任务算失败」。如果某个项目把 `PostStop` 当**正常收尾**用，它的末尾任务会从「完成」变成「失败」。MaaEnd 里 `PostStop` 只挂在 `__SceneCheckAbortPipeline` 一个节点上，是纯 abort 用法；其他项目未逐一核查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

防止由脚本触发的 tasker 停止操作被报告为成功任务，并阻止剩余任务继续运行。

Bug 修复：
- 将脚本触发的 MaaFramework 停止操作视为任务失败，而不是成功完成，从而避免将未完成的任务计为成功，或提交后续任务。

增强功能：
- 通过检查 tasker 的停止状态同步检测外部停止操作，并保留事件通知作为后备机制，同时排除由 MAS 自身发起的停止操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止由脚本触发的 tasker 停止被报告为成功任务，并阻止剩余任务队列继续执行。

Bug 修复：
- 将由脚本触发的 MaaFramework tasker 停止视为任务失败，而不是成功完成，从而避免将未完成的工作记录为已完成，或提交后续任务。

改进：
- 通过 tasker 状态同步检测外部触发的停止，并以基于事件的方式进行回退，同时区分由 MAS 发起的停止。

日常维护：
- 更新应用程序版本元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent script-triggered tasker stops from being reported as successful tasks and from allowing the remaining task queue to continue.

Bug Fixes:
- Treats script-triggered MaaFramework tasker stops as task failures instead of successful completions, preventing unfinished work from being recorded as completed or subsequent tasks from being submitted.

Enhancements:
- Detects externally triggered stops synchronously through tasker state with event-based fallback, while distinguishing MAS-initiated stops.

Chores:
- Updates the application version metadata.

</details>

</details>