### PR TITLE
feat(maafw): Win32 桌面游戏窗口整形与桌面容量检查

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -2474,6 +2474,17 @@ class MaaFWConfig(ConfigBase):
         self.Game_CloseOnFinish = ConfigItem(
             "Game", "CloseOnFinish", True, BoolValidator()
         )
+        ## Win32 controller 下把游戏窗口客户区调整为指定尺寸。
+        ## Win32 controller 截的是客户区，脚本侧的分辨率闸门校验的也是它；显示器
+        ## 断开导致桌面回落到小分辨率时，游戏窗口会被压小并被游戏自己记住，之后
+        ## 每次运行都不达标。默认 Off：MAS 无从知道某个项目要的是什么比例，只在
+        ## 用户明确指定时才动窗口。
+        self.Game_WindowSize = ConfigItem(
+            "Game",
+            "WindowSize",
+            "Off",
+            OptionsValidator(["Off", "Fit", "1280x720", "1600x900", "1920x1080"]),
+        )
 
         ## Update ----------------------------------------------------------
         ## 项目自动更新时机：Off 不更新 / BeforeRun 运行前 / AfterRun 全部用户跑完后。

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -2227,6 +2227,12 @@ class MaaFWConfig_Game(BaseModel):
     CloseOnFinish: Optional[bool] = Field(
         default=None, description="任务结束后是否关闭由 MAS 启动的游戏"
     )
+    WindowSize: Optional[Literal["Off", "Fit", "1280x720", "1600x900", "1920x1080"]] = (
+        Field(
+            default=None,
+            description="Win32 controller 下把游戏窗口客户区调整为指定尺寸；Off 不调整，Fit 取屏幕放得下的最大一档",
+        )
+    )
 
 
 class MaaFWConfig_Update(BaseModel):

--- a/app/task/MaaFW/tools/embedded/runner_task.py
+++ b/app/task/MaaFW/tools/embedded/runner_task.py
@@ -50,7 +50,6 @@ from app.utils import ProcessInfo, ProcessManager, get_logger
 from app.utils.constants import UTC4
 from app.utils.io import migrate_legacy_dir
 from app.utils.platform.display import (
-    can_host_client,
     describe_monitors,
     find_host_monitor,
     monitor_from_window,
@@ -714,8 +713,6 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
                 return resource.name
         return None
 
-
-
     def _check_desktop_capacity(self) -> str | None:
         """开了窗口整形时，先确认桌面上真有一块屏放得下目标客户区。
 
@@ -742,25 +739,31 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
             "使用显示器假负载，或把「游戏窗口尺寸」改小"
         )
 
-    def _win32_window_target(self, monitor) -> tuple[int, int] | None:
-        """按脚本配置解析目标客户区；Off 或放不下时返回 None。
+    def _win32_window_plan(self):
+        """解析「目标客户区 + 该放到哪块屏」。Off、或没有一块屏放得下时返回 None。
 
-        目标只给 16:9 的几档预设，不做任意尺寸：MAS 无从知道某个 MaaFW 项目要的
-        是什么比例，硬凑一个非标尺寸只会把问题从「窗口太小」换成「窗口比例怪」。
+        目标只给 16:9 的几档预设，不做任意尺寸：MAS 无从知道某个 MaaFW 项目要的是什么
+        比例，硬凑一个非标尺寸只会把问题从「窗口太小」换成「窗口比例怪」。
+
+        选屏与判据必须是同一次决策。早先的版本容量检查按「任意显示器」放行、整形却按
+        「窗口当前所在显示器」执行，多屏尺寸不同时两者会对不上：窗口在小屏上时检查通过，
+        整形却降档，或者显式尺寸被夹到小屏工作区外面。
         """
 
         mode = str(self.script_config.get("Game", "WindowSize") or "Off")
         if mode == "Off":
             return None
         if mode in _WIN32_WINDOW_SIZE_PRESETS:
-            return _WIN32_WINDOW_SIZE_PRESETS[mode]
-        if mode != "Fit":
+            candidates = (_WIN32_WINDOW_SIZE_PRESETS[mode],)
+        elif mode == "Fit":
+            candidates = _WIN32_WINDOW_FIT_ORDER
+        else:
             return None
-        if monitor is None:
-            return None
-        for size in _WIN32_WINDOW_FIT_ORDER:
-            if can_host_client(monitor, *size):
-                return size
+
+        for size in candidates:
+            monitor = find_host_monitor(*size)
+            if monitor is not None:
+                return size, monitor
         return None
 
     def _prepare_win32_window(self, hwnd: int) -> None:
@@ -777,8 +780,8 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
         try:
             self._append_log(f"桌面显示器: {describe_monitors()}")
         except Exception as exc:
+            # 读不到显示器信息不能让窗口诊断一起丢掉——恰恰是出问题时最需要它。
             self._append_log(f"读取显示器信息失败: {exc}")
-            return
 
         try:
             monitor = monitor_from_window(hwnd)
@@ -788,17 +791,29 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
                 f"{_format_physical_suffix(hwnd, before)}"
                 f"; 所在显示器: {monitor.describe() if monitor else '未知'}"
             )
+        except Exception as exc:
+            self._append_log(f"读取游戏窗口尺寸失败: {exc}")
+            return
 
-            target = self._win32_window_target(monitor)
-            if target is None:
+        try:
+            plan = self._win32_window_plan()
+            if plan is None:
                 return
-            if before == target:
+            target, host = plan
+            already_ok = (
+                before == target
+                and monitor is not None
+                and monitor.handle == host.handle
+            )
+            if already_ok:
                 self._append_log(
                     f"游戏窗口客户区已是 {target[0]}x{target[1]}，无需调整"
                 )
                 return
+            if monitor is not None and monitor.handle != host.handle:
+                self._append_log(f"游戏窗口将移至 {host.device} 以容纳目标尺寸")
 
-            after = set_client_size(hwnd, *target)
+            after = set_client_size(hwnd, *target, monitor_handle=host.handle)
             if after is None:
                 self._append_log(
                     f"游戏窗口无法调整为 {target[0]}x{target[1]}"

--- a/app/task/MaaFW/tools/embedded/runner_task.py
+++ b/app/task/MaaFW/tools/embedded/runner_task.py
@@ -49,6 +49,13 @@ from app.task.MaaFW.tools.notify import push_notification
 from app.utils import ProcessInfo, ProcessManager, get_logger
 from app.utils.constants import UTC4
 from app.utils.io import migrate_legacy_dir
+from app.utils.platform.display import (
+    can_host_client,
+    describe_monitors,
+    find_host_monitor,
+    monitor_from_window,
+)
+from app.utils.platform.window import get_client_size, set_client_size
 
 from .project_path import release_project_path, try_reserve_project_path
 from .runtime_route import MaaFWManagedExecutionRoute, managed_execution_route
@@ -76,6 +83,17 @@ _ADB_SCREENCAP_EMULATOR_EXTRAS = 1 << 6
 _ADB_INPUT_DEFAULT = -9
 _ADB_INPUT_ALL = -1
 _ADB_INPUT_EMULATOR_EXTRAS = 1 << 3
+# 游戏窗口整形的目标客户区。只给 16:9 的标准档：MAS 无从知道某个 MaaFW 项目要的
+# 是什么比例，任意尺寸只会把「窗口太小」换成「窗口比例怪」。
+_WIN32_WINDOW_SIZE_PRESETS = {
+    "1280x720": (1280, 720),
+    "1600x900": (1600, 900),
+    "1920x1080": (1920, 1080),
+}
+# Fit 模式从大到小挑第一个放得下的。
+_WIN32_WINDOW_FIT_ORDER = ((1920, 1080), (1600, 900), (1280, 720))
+_WIN32_WINDOW_MIN_CLIENT = (1280, 720)
+
 _WIN32_SCREENCAP_METHODS = {
     "GDI": 1,
     "FramePool": 1 << 1,
@@ -394,6 +412,11 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
             elif game_path_error is not None:
                 self.cur_user_item.status = "异常"
                 return game_path_error
+            elif self.run_plan.controllerType == "Win32":
+                desktop_error = await asyncio.to_thread(self._check_desktop_capacity)
+                if desktop_error is not None:
+                    self.cur_user_item.status = "异常"
+                    return desktop_error
 
             keep_reservation = True
             return "Pass"
@@ -691,6 +714,110 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
                 return resource.name
         return None
 
+
+
+    def _check_desktop_capacity(self) -> str | None:
+        """开了窗口整形时，先确认桌面上真有一块屏放得下目标客户区。
+
+        只在用户明确指定尺寸时才拦：没开整形就说明用户自己管窗口，MAS 不该替他
+        决定多大算够。放不下时当场说清楚，而不是让任务跑一轮再被脚本侧的分辨率
+        闸门打掉——那条路径给出的信息量少得多。
+        """
+
+        mode = str(self.script_config.get("Game", "WindowSize") or "Off")
+        if mode == "Off":
+            return None
+        target = _WIN32_WINDOW_SIZE_PRESETS.get(mode, _WIN32_WINDOW_MIN_CLIENT)
+        try:
+            if find_host_monitor(*target) is not None:
+                return None
+            detail = describe_monitors()
+        except Exception:
+            # 查不到显示器信息不足以判定桌面不可用，放行交给后续流程。
+            return None
+        return (
+            f"桌面上没有一块显示器放得下 {target[0]}x{target[1]} 的游戏窗口，"
+            f"当前显示器: {detail}。"
+            "显示器断开或关闭时 Windows 会回落到很小的分辨率，请接回显示器、"
+            "使用显示器假负载，或把「游戏窗口尺寸」改小"
+        )
+
+    def _win32_window_target(self, monitor) -> tuple[int, int] | None:
+        """按脚本配置解析目标客户区；Off 或放不下时返回 None。
+
+        目标只给 16:9 的几档预设，不做任意尺寸：MAS 无从知道某个 MaaFW 项目要的
+        是什么比例，硬凑一个非标尺寸只会把问题从「窗口太小」换成「窗口比例怪」。
+        """
+
+        mode = str(self.script_config.get("Game", "WindowSize") or "Off")
+        if mode == "Off":
+            return None
+        if mode in _WIN32_WINDOW_SIZE_PRESETS:
+            return _WIN32_WINDOW_SIZE_PRESETS[mode]
+        if mode != "Fit":
+            return None
+        if monitor is None:
+            return None
+        for size in _WIN32_WINDOW_FIT_ORDER:
+            if can_host_client(monitor, *size):
+                return size
+        return None
+
+    def _prepare_win32_window(self, hwnd: int) -> None:
+        """记录桌面与窗口实测尺寸，并按配置把游戏窗口整形成目标客户区。
+
+        Win32 controller 截的是客户区，脚本侧的分辨率闸门校验的也是它。诊断这一段
+        无论是否整形都要打：真出问题时 MAS 自己必须能说出屏幕、DPI 和客户区三个
+        实测数字，而不是只能靠脚本自己的日志倒推。
+
+        整形失败一律只记日志不抛错——它是尽力而为的改善项，不该反过来把本来能跑的
+        任务打掉。
+        """
+
+        try:
+            self._append_log(f"桌面显示器: {describe_monitors()}")
+        except Exception as exc:
+            self._append_log(f"读取显示器信息失败: {exc}")
+            return
+
+        try:
+            monitor = monitor_from_window(hwnd)
+            before = get_client_size(hwnd)
+            self._append_log(
+                f"游戏窗口客户区: {_format_client_size(before)}"
+                f"{_format_physical_suffix(hwnd, before)}"
+                f"; 所在显示器: {monitor.describe() if monitor else '未知'}"
+            )
+
+            target = self._win32_window_target(monitor)
+            if target is None:
+                return
+            if before == target:
+                self._append_log(
+                    f"游戏窗口客户区已是 {target[0]}x{target[1]}，无需调整"
+                )
+                return
+
+            after = set_client_size(hwnd, *target)
+            if after is None:
+                self._append_log(
+                    f"游戏窗口无法调整为 {target[0]}x{target[1]}"
+                    "（全屏或无边框窗口没有可调整的外框），保持原样继续"
+                )
+                return
+            if after != target:
+                self._append_log(
+                    f"游戏窗口客户区调整为 {_format_client_size(after)}"
+                    f"，与目标 {target[0]}x{target[1]} 不一致，游戏可能限制了窗口尺寸"
+                )
+                return
+            self._append_log(
+                f"游戏窗口客户区已调整: {_format_client_size(before)}"
+                f" -> {_format_client_size(after)}"
+            )
+        except Exception as exc:
+            self._append_log(f"调整游戏窗口尺寸失败，保持原样继续: {exc}")
+
     async def _build_device_config(
         self,
         plan: MaaFWRunPlan,
@@ -713,9 +840,11 @@ class MaaFWPluginAutoProxyTask(TaskExecuteBase):
         if plan.controllerType == "Win32":
             controller = _find_controller(interface_model, plan.controllerName)
             win32_config = controller.win32
+            hwnd = await self._resolve_window_handle(controller)
+            await asyncio.to_thread(self._prepare_win32_window, hwnd)
             return MaaFWDeviceConfig(
                 type="Win32",
-                hWnd=await self._resolve_window_handle(controller),
+                hWnd=hwnd,
                 screencapMethod=_resolve_win32_method(
                     self.script_config.get("Device", "Win32ScreencapMethod"),
                     win32_config.screencap if win32_config else None,
@@ -1948,6 +2077,30 @@ def _is_process_path_running(executable_path: Path) -> bool:
             if raw_exe and Path(raw_exe).resolve() == target_path:
                 return True
     return False
+
+
+def _format_physical_suffix(hwnd: int, size: tuple[int, int] | None) -> str:
+    """缩放不是 100% 时补一个物理像素尺寸。
+
+    窗口自身坐标系与物理像素在高 DPI 下不一样，截图链路最终看到哪一个取决于
+    MaaFW 自己的 DPI 感知级别。诊断日志两个都给出来，出问题时不用再猜。
+    """
+
+    try:
+        physical = get_client_size(hwnd, physical=True)
+    except Exception:
+        return ""
+    if physical is None or physical == size:
+        return ""
+    return f"（物理 {physical[0]}x{physical[1]}）"
+
+
+def _format_client_size(size: tuple[int, int] | None) -> str:
+    """客户区尺寸的日志写法；取不到时明说取不到，不要写成 0x0。"""
+
+    if size is None:
+        return "未知"
+    return f"{size[0]}x{size[1]}"
 
 
 def _optional_int(value: Any) -> int | None:

--- a/app/utils/platform/common/display.py
+++ b/app/utils/platform/common/display.py
@@ -1,0 +1,16 @@
+from .errors import UnsupportedPlatformError
+
+
+def _unsupported(*args, **kwargs):
+    raise UnsupportedPlatformError("display")
+
+
+MonitorInfo = None
+
+per_monitor_dpi = _unsupported
+list_monitors = _unsupported
+monitor_from_window = _unsupported
+frame_size_for_client = _unsupported
+can_host_client = _unsupported
+find_host_monitor = _unsupported
+describe_monitors = _unsupported

--- a/app/utils/platform/common/window.py
+++ b/app/utils/platform/common/window.py
@@ -20,3 +20,5 @@ get_window_rect = _unsupported
 is_minimized = _unsupported
 restore_window = _unsupported
 force_activate_window = _unsupported
+get_client_size = _unsupported
+set_client_size = _unsupported

--- a/app/utils/platform/display.py
+++ b/app/utils/platform/display.py
@@ -1,0 +1,6 @@
+from . import IS_WINDOWS
+
+if IS_WINDOWS:
+    from .windows.display import *
+else:
+    from .common.display import *

--- a/app/utils/platform/windows/display.py
+++ b/app/utils/platform/windows/display.py
@@ -88,6 +88,46 @@ class MonitorInfo:
         )
 
 
+# 用私有的 WinDLL 实例，不是 `_user32`：后者是进程级共享缓存，在它上面
+# 声明 restype 会波及仓库里其它同样用它的模块（如 OkNte 的 launcher_start）。
+_user32 = ctypes.WinDLL("user32", use_last_error=True)
+_shcore = ctypes.WinDLL("shcore", use_last_error=True)
+
+
+def _declare_prototypes() -> None:
+    """显式声明返回类型。
+
+    ctypes 默认 restype=c_int，会把返回句柄的函数截成 32 位。截断后的失败往往不像
+    失败——比如设备枚举会表现成「一个都没有」，和「真的没有」无法区分。
+    老系统上缺失的函数用 AttributeError 跳过即可。
+    """
+
+    for dll, name, restype, argtypes in (
+        (_user32, "SetThreadDpiAwarenessContext", ctypes.c_void_p, [ctypes.c_void_p]),
+        (_user32, "GetWindowDpiAwarenessContext", ctypes.c_void_p, [wintypes.HWND]),
+        (_user32, "GetDpiForWindow", wintypes.UINT, [wintypes.HWND]),
+        (
+            _user32,
+            "MonitorFromWindow",
+            wintypes.HMONITOR,
+            [wintypes.HWND, wintypes.DWORD],
+        ),
+        (_user32, "GetMonitorInfoW", wintypes.BOOL, None),
+        (_user32, "EnumDisplayMonitors", wintypes.BOOL, None),
+        (_user32, "AdjustWindowRectExForDpi", wintypes.BOOL, None),
+        (_user32, "AdjustWindowRectEx", wintypes.BOOL, None),
+        (_shcore, "GetDpiForMonitor", ctypes.c_long, None),
+    ):
+        with suppress(AttributeError, OSError):
+            func = getattr(dll, name)
+            func.restype = restype
+            if argtypes is not None:
+                func.argtypes = argtypes
+
+
+_declare_prototypes()
+
+
 @contextmanager
 def per_monitor_dpi():
     """临时切到 per-monitor DPI 感知，保证拿到的是物理像素。
@@ -96,7 +136,7 @@ def per_monitor_dpi():
     会影响同进程里其它按逻辑像素工作的代码。
     """
 
-    user32 = ctypes.windll.user32
+    user32 = _user32
     previous = None
     with suppress(AttributeError, OSError):
         # Windows 10 1703 以下没有这个函数，拿不到就按当前感知级别继续。
@@ -123,7 +163,7 @@ def window_dpi_context(hwnd: int):
     按窗口自己的坐标系去设，游戏拿到的就是它认知里的 1280x720，比例精确是 16:9。
     """
 
-    user32 = ctypes.windll.user32
+    user32 = _user32
     previous = None
     with suppress(AttributeError, OSError):
         # Windows 10 1607+ 才有这两个函数；取不到就按当前感知级别继续。
@@ -142,7 +182,7 @@ def dpi_for_window(hwnd: int) -> int:
     """窗口自身坐标系下的 DPI。DPI-unaware 的窗口固定是 96。"""
 
     with suppress(AttributeError, OSError):
-        dpi = ctypes.windll.user32.GetDpiForWindow(wintypes.HWND(hwnd))
+        dpi = _user32.GetDpiForWindow(wintypes.HWND(hwnd))
         if dpi:
             return int(dpi)
     return DEFAULT_DPI
@@ -152,7 +192,7 @@ def _monitor_dpi(handle: int) -> int:
     dpi_x = wintypes.UINT()
     dpi_y = wintypes.UINT()
     try:
-        result = ctypes.windll.shcore.GetDpiForMonitor(
+        result = _shcore.GetDpiForMonitor(
             wintypes.HMONITOR(handle),
             MDT_EFFECTIVE_DPI,
             ctypes.byref(dpi_x),
@@ -168,9 +208,7 @@ def _monitor_dpi(handle: int) -> int:
 def _read_monitor(handle: int) -> MonitorInfo | None:
     info = _MONITORINFOEXW()
     info.cbSize = ctypes.sizeof(_MONITORINFOEXW)
-    if not ctypes.windll.user32.GetMonitorInfoW(
-        wintypes.HMONITOR(handle), ctypes.byref(info)
-    ):
+    if not _user32.GetMonitorInfoW(wintypes.HMONITOR(handle), ctypes.byref(info)):
         return None
     return MonitorInfo(
         device=info.szDevice,
@@ -205,9 +243,7 @@ def list_monitors() -> list[MonitorInfo]:
 
     with per_monitor_dpi():
         try:
-            ctypes.windll.user32.EnumDisplayMonitors(
-                None, None, _MONITORENUMPROC(callback), 0
-            )
+            _user32.EnumDisplayMonitors(None, None, _MONITORENUMPROC(callback), 0)
         except OSError:
             return []
     return monitors
@@ -220,7 +256,7 @@ def monitor_from_window(hwnd: int) -> MonitorInfo | None:
         return None
     with per_monitor_dpi():
         try:
-            handle = ctypes.windll.user32.MonitorFromWindow(
+            handle = _user32.MonitorFromWindow(
                 wintypes.HWND(hwnd), MONITOR_DEFAULTTONEAREST
             )
         except OSError:
@@ -246,7 +282,7 @@ def monitor_work_in_current_context(
     target = handle
     if not target:
         with suppress(OSError):
-            target = ctypes.windll.user32.MonitorFromWindow(
+            target = _user32.MonitorFromWindow(
                 wintypes.HWND(hwnd), MONITOR_DEFAULTTONEAREST
             )
     if not target:
@@ -254,9 +290,7 @@ def monitor_work_in_current_context(
 
     info = _MONITORINFOEXW()
     info.cbSize = ctypes.sizeof(_MONITORINFOEXW)
-    if not ctypes.windll.user32.GetMonitorInfoW(
-        wintypes.HMONITOR(target), ctypes.byref(info)
-    ):
+    if not _user32.GetMonitorInfoW(wintypes.HMONITOR(target), ctypes.byref(info)):
         return None
     return (info.rcWork.left, info.rcWork.top, info.rcWork.right, info.rcWork.bottom)
 
@@ -275,7 +309,7 @@ def frame_size_for_client(
     """
 
     rect = _RECT(0, 0, int(client_width), int(client_height))
-    user32 = ctypes.windll.user32
+    user32 = _user32
     adjusted = False
     with suppress(AttributeError, OSError):
         # Windows 10 1607+ 才有带 DPI 的版本。
@@ -334,3 +368,20 @@ def describe_monitors() -> str:
     if not monitors:
         return "未能枚举到显示器"
     return "; ".join(monitor.describe() for monitor in monitors)
+
+
+# 显式声明公开面：`platform/display.py` 用星号导入本模块，不声明的话 ctypes、wintypes
+# 这些实现细节会一起泄漏进 `app.utils.platform.display` 命名空间。
+__all__ = [
+    "MonitorInfo",
+    "per_monitor_dpi",
+    "window_dpi_context",
+    "dpi_for_window",
+    "list_monitors",
+    "monitor_from_window",
+    "monitor_work_in_current_context",
+    "frame_size_for_client",
+    "can_host_client",
+    "find_host_monitor",
+    "describe_monitors",
+]

--- a/app/utils/platform/windows/display.py
+++ b/app/utils/platform/windows/display.py
@@ -230,6 +230,37 @@ def monitor_from_window(hwnd: int) -> MonitorInfo | None:
         return _read_monitor(handle)
 
 
+def monitor_work_in_current_context(
+    hwnd: int, handle: int | None = None
+) -> tuple[int, int, int, int] | None:
+    """在**当前线程的 DPI 感知级别下**读取显示器工作区。
+
+    摆放窗口时必须用这个，不能用 `list_monitors()` 里那份物理像素的 work：
+    `GetWindowRect` / `SetWindowPos` 用的是调用线程感知级别下的坐标，而对
+    DPI-unaware 的窗口，那套坐标和物理像素在 150% 缩放下差 1.5 倍。两边混着比大小，
+    夹取会把窗口推到屏幕外，ScreenDC 截图随即抓到垃圾像素。
+
+    调用方负责先进入目标窗口的 DPI 上下文（见 `window_dpi_context`）。
+    """
+
+    target = handle
+    if not target:
+        with suppress(OSError):
+            target = ctypes.windll.user32.MonitorFromWindow(
+                wintypes.HWND(hwnd), MONITOR_DEFAULTTONEAREST
+            )
+    if not target:
+        return None
+
+    info = _MONITORINFOEXW()
+    info.cbSize = ctypes.sizeof(_MONITORINFOEXW)
+    if not ctypes.windll.user32.GetMonitorInfoW(
+        wintypes.HMONITOR(target), ctypes.byref(info)
+    ):
+        return None
+    return (info.rcWork.left, info.rcWork.top, info.rcWork.right, info.rcWork.bottom)
+
+
 def frame_size_for_client(
     client_width: int,
     client_height: int,

--- a/app/utils/platform/windows/display.py
+++ b/app/utils/platform/windows/display.py
@@ -1,0 +1,305 @@
+"""显示器几何查询。
+
+Win32 桌面游戏任务需要知道「桌面上有没有一块屏放得下目标窗口」：物理显示器断开
+时 Windows 会回落到很小的兜底分辨率，游戏窗口跟着被压小，脚本侧的分辨率闸门随后
+把整轮任务全部打掉。
+
+本模块只查询，不改动任何显示设置。DPI 感知用 `SetThreadDpiAwarenessContext` 按调用
+临时切换，不去动进程级的 DPI 感知——那会影响到同进程里其它按逻辑像素工作的代码。
+"""
+
+import ctypes
+from contextlib import contextmanager, suppress
+from ctypes import wintypes
+from dataclasses import dataclass
+
+DEFAULT_DPI = 96
+MONITORINFOF_PRIMARY = 0x00000001
+MONITOR_DEFAULTTONEAREST = 0x00000002
+MDT_EFFECTIVE_DPI = 0
+DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = -4
+# 普通可调整大小的窗口。用它换算「客户区 -> 窗口外框」的非客户区开销。
+WS_OVERLAPPEDWINDOW = 0x00CF0000
+
+
+class _RECT(ctypes.Structure):
+    _fields_ = [
+        ("left", wintypes.LONG),
+        ("top", wintypes.LONG),
+        ("right", wintypes.LONG),
+        ("bottom", wintypes.LONG),
+    ]
+
+
+class _MONITORINFOEXW(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", _RECT),
+        ("rcWork", _RECT),
+        ("dwFlags", wintypes.DWORD),
+        ("szDevice", ctypes.c_wchar * 32),
+    ]
+
+
+_MONITORENUMPROC = ctypes.WINFUNCTYPE(
+    wintypes.BOOL,
+    wintypes.HMONITOR,
+    wintypes.HDC,
+    ctypes.POINTER(_RECT),
+    wintypes.LPARAM,
+)
+
+
+@dataclass(frozen=True)
+class MonitorInfo:
+    """一块显示器的几何信息，坐标均为物理像素。"""
+
+    device: str
+    handle: int
+    bounds: tuple[int, int, int, int]
+    work: tuple[int, int, int, int]
+    dpi: int
+    primary: bool
+
+    @property
+    def size(self) -> tuple[int, int]:
+        left, top, right, bottom = self.bounds
+        return right - left, bottom - top
+
+    @property
+    def work_size(self) -> tuple[int, int]:
+        """去掉任务栏之后的可用区域。窗口能不能放下要看它，不是看整块屏。"""
+
+        left, top, right, bottom = self.work
+        return right - left, bottom - top
+
+    @property
+    def scaling(self) -> float:
+        return self.dpi / DEFAULT_DPI
+
+    def describe(self) -> str:
+        width, height = self.size
+        work_width, work_height = self.work_size
+        return (
+            f"{self.device} {width}x{height}"
+            f"(可用 {work_width}x{work_height})"
+            f" DPI={self.dpi}({self.scaling:.2f}x)"
+            f"{' 主显示器' if self.primary else ''}"
+        )
+
+
+@contextmanager
+def per_monitor_dpi():
+    """临时切到 per-monitor DPI 感知，保证拿到的是物理像素。
+
+    不用进程级的 `SetProcessDpiAwareness`：那是一次性且不可逆的全局副作用，
+    会影响同进程里其它按逻辑像素工作的代码。
+    """
+
+    user32 = ctypes.windll.user32
+    previous = None
+    with suppress(AttributeError, OSError):
+        # Windows 10 1703 以下没有这个函数，拿不到就按当前感知级别继续。
+        previous = user32.SetThreadDpiAwarenessContext(
+            ctypes.c_void_p(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+        )
+    try:
+        yield
+    finally:
+        if previous:
+            with suppress(OSError):
+                user32.SetThreadDpiAwarenessContext(previous)
+
+
+@contextmanager
+def window_dpi_context(hwnd: int):
+    """把当前线程切到目标窗口自己的 DPI 感知级别。
+
+    调整窗口尺寸必须用这个，而不是 `per_monitor_dpi`。多数游戏客户端是
+    DPI-unaware 的，Windows 会对它做 DPI 虚拟化：在 150% 缩放下，用物理像素去要
+    1280 宽，窗口自己只能取到 853 逻辑像素，换回物理是 1279.5，实测落到 1278。
+    结果是「整形成功」但宽度差 2 像素，脚本侧 ≥1280 的下限照样过不了。
+
+    按窗口自己的坐标系去设，游戏拿到的就是它认知里的 1280x720，比例精确是 16:9。
+    """
+
+    user32 = ctypes.windll.user32
+    previous = None
+    with suppress(AttributeError, OSError):
+        # Windows 10 1607+ 才有这两个函数；取不到就按当前感知级别继续。
+        context = user32.GetWindowDpiAwarenessContext(wintypes.HWND(hwnd))
+        if context:
+            previous = user32.SetThreadDpiAwarenessContext(context)
+    try:
+        yield
+    finally:
+        if previous:
+            with suppress(OSError):
+                user32.SetThreadDpiAwarenessContext(previous)
+
+
+def dpi_for_window(hwnd: int) -> int:
+    """窗口自身坐标系下的 DPI。DPI-unaware 的窗口固定是 96。"""
+
+    with suppress(AttributeError, OSError):
+        dpi = ctypes.windll.user32.GetDpiForWindow(wintypes.HWND(hwnd))
+        if dpi:
+            return int(dpi)
+    return DEFAULT_DPI
+
+
+def _monitor_dpi(handle: int) -> int:
+    dpi_x = wintypes.UINT()
+    dpi_y = wintypes.UINT()
+    try:
+        result = ctypes.windll.shcore.GetDpiForMonitor(
+            wintypes.HMONITOR(handle),
+            MDT_EFFECTIVE_DPI,
+            ctypes.byref(dpi_x),
+            ctypes.byref(dpi_y),
+        )
+    except (AttributeError, OSError):
+        return DEFAULT_DPI
+    if result != 0 or not dpi_x.value:
+        return DEFAULT_DPI
+    return int(dpi_x.value)
+
+
+def _read_monitor(handle: int) -> MonitorInfo | None:
+    info = _MONITORINFOEXW()
+    info.cbSize = ctypes.sizeof(_MONITORINFOEXW)
+    if not ctypes.windll.user32.GetMonitorInfoW(
+        wintypes.HMONITOR(handle), ctypes.byref(info)
+    ):
+        return None
+    return MonitorInfo(
+        device=info.szDevice,
+        handle=int(handle),
+        bounds=(
+            info.rcMonitor.left,
+            info.rcMonitor.top,
+            info.rcMonitor.right,
+            info.rcMonitor.bottom,
+        ),
+        work=(
+            info.rcWork.left,
+            info.rcWork.top,
+            info.rcWork.right,
+            info.rcWork.bottom,
+        ),
+        dpi=_monitor_dpi(handle),
+        primary=bool(info.dwFlags & MONITORINFOF_PRIMARY),
+    )
+
+
+def list_monitors() -> list[MonitorInfo]:
+    """枚举当前所有显示器。失败返回空列表，由调用方决定要不要当成致命。"""
+
+    monitors: list[MonitorInfo] = []
+
+    def callback(handle, _hdc, _rect, _param) -> bool:
+        monitor = _read_monitor(handle)
+        if monitor is not None:
+            monitors.append(monitor)
+        return True
+
+    with per_monitor_dpi():
+        try:
+            ctypes.windll.user32.EnumDisplayMonitors(
+                None, None, _MONITORENUMPROC(callback), 0
+            )
+        except OSError:
+            return []
+    return monitors
+
+
+def monitor_from_window(hwnd: int) -> MonitorInfo | None:
+    """窗口当前落在哪块屏上。多屏时判据要看这块，而不是主显示器。"""
+
+    if not hwnd:
+        return None
+    with per_monitor_dpi():
+        try:
+            handle = ctypes.windll.user32.MonitorFromWindow(
+                wintypes.HWND(hwnd), MONITOR_DEFAULTTONEAREST
+            )
+        except OSError:
+            return None
+        if not handle:
+            return None
+        return _read_monitor(handle)
+
+
+def frame_size_for_client(
+    client_width: int,
+    client_height: int,
+    dpi: int = DEFAULT_DPI,
+    style: int = WS_OVERLAPPEDWINDOW,
+    ex_style: int = 0,
+) -> tuple[int, int]:
+    """把目标客户区换算成所需的窗口外框尺寸。
+
+    非客户区（标题栏、边框）的高度随 DPI 变——150% 下标题栏约 48px、100% 下约
+    31px，写死余量在高 DPI 显示器上必然误判，所以走系统的换算函数。
+    """
+
+    rect = _RECT(0, 0, int(client_width), int(client_height))
+    user32 = ctypes.windll.user32
+    adjusted = False
+    with suppress(AttributeError, OSError):
+        # Windows 10 1607+ 才有带 DPI 的版本。
+        adjusted = bool(
+            user32.AdjustWindowRectExForDpi(
+                ctypes.byref(rect),
+                wintypes.DWORD(style),
+                wintypes.BOOL(False),
+                wintypes.DWORD(ex_style),
+                wintypes.UINT(int(dpi)),
+            )
+        )
+    if not adjusted:
+        with suppress(AttributeError, OSError):
+            user32.AdjustWindowRectEx(
+                ctypes.byref(rect),
+                wintypes.DWORD(style),
+                wintypes.BOOL(False),
+                wintypes.DWORD(ex_style),
+            )
+    return rect.right - rect.left, rect.bottom - rect.top
+
+
+def can_host_client(
+    monitor: MonitorInfo, client_width: int, client_height: int
+) -> bool:
+    """这块屏的可用区域放不放得下目标客户区（含标题栏与边框）。"""
+
+    frame_width, frame_height = frame_size_for_client(
+        client_width, client_height, monitor.dpi
+    )
+    work_width, work_height = monitor.work_size
+    return work_width >= frame_width and work_height >= frame_height
+
+
+def find_host_monitor(client_width: int, client_height: int) -> MonitorInfo | None:
+    """挑一块放得下目标客户区的屏；主显示器优先，其次可用面积最大的。"""
+
+    candidates = [
+        monitor
+        for monitor in list_monitors()
+        if can_host_client(monitor, client_width, client_height)
+    ]
+    if not candidates:
+        return None
+    for monitor in candidates:
+        if monitor.primary:
+            return monitor
+    return max(candidates, key=lambda item: item.work_size[0] * item.work_size[1])
+
+
+def describe_monitors() -> str:
+    """一行式的显示器概况，供诊断日志使用。"""
+
+    monitors = list_monitors()
+    if not monitors:
+        return "未能枚举到显示器"
+    return "; ".join(monitor.describe() for monitor in monitors)

--- a/app/utils/platform/windows/window.py
+++ b/app/utils/platform/windows/window.py
@@ -9,7 +9,7 @@ import win32process
 from .display import (
     dpi_for_window,
     frame_size_for_client,
-    monitor_from_window,
+    monitor_work_in_current_context,
     per_monitor_dpi,
     window_dpi_context,
 )
@@ -318,12 +318,16 @@ def _is_resizable_window(hwnd: int) -> bool:
 
 
 def set_client_size(
-    hwnd: int, client_width: int, client_height: int
+    hwnd: int,
+    client_width: int,
+    client_height: int,
+    monitor_handle: int | None = None,
 ) -> tuple[int, int] | None:
     """把窗口客户区调整为目标尺寸，返回实际结果；不可调整时返回 None。
 
-    位置尽量保持不动，放不下时才挪回所在显示器的可用区域内——窗口跑到屏幕外面
-    会让 ScreenDC 之类基于屏幕 DC 的截图方式抓到垃圾像素。
+    `monitor_handle` 指定目标显示器（`MonitorInfo.handle`）：窗口不在那块屏上时会被挪
+    过去。不传则留在当前所在的屏。位置尽量保持不动，放不下时才夹回工作区内——窗口跑到
+    屏幕外面会让 ScreenDC 这类基于屏幕 DC 的截图方式抓到垃圾像素。
     """
 
     if not hwnd or client_width <= 0 or client_height <= 0:
@@ -331,7 +335,6 @@ def set_client_size(
     if not _is_resizable_window(hwnd):
         return None
 
-    monitor = monitor_from_window(hwnd)
     # 用窗口自己的 DPI，不是显示器的：DPI-unaware 的窗口在 150% 缩放下按物理像素
     # 去设根本取不到目标值（1280 -> 实测 1278），差的那两像素足以卡住脚本侧的下限。
     dpi = dpi_for_window(hwnd)
@@ -345,8 +348,10 @@ def set_client_size(
             )
             left, top, _right, _bottom = win32gui.GetWindowRect(hwnd)
 
-            if monitor is not None:
-                work_left, work_top, work_right, work_bottom = monitor.work
+            # 工作区必须在**同一个 DPI 上下文里**取，否则和上面的窗口坐标不是一套尺度。
+            work = monitor_work_in_current_context(hwnd, monitor_handle)
+            if work is not None:
+                work_left, work_top, work_right, work_bottom = work
                 left = min(
                     max(left, work_left), max(work_left, work_right - frame_width)
                 )

--- a/app/utils/platform/windows/window.py
+++ b/app/utils/platform/windows/window.py
@@ -6,6 +6,14 @@ import win32con
 import win32gui
 import win32process
 
+from .display import (
+    dpi_for_window,
+    frame_size_for_client,
+    monitor_from_window,
+    per_monitor_dpi,
+    window_dpi_context,
+)
+
 
 def get_window_handles(pid: int) -> list[int]:
     """获取指定进程的所有窗口句柄"""
@@ -272,3 +280,88 @@ def force_activate_window(hwnd: int) -> bool:
         return True
     except Exception:
         return False
+
+
+def get_client_size(hwnd: int, physical: bool = False) -> tuple[int, int] | None:
+    """窗口客户区尺寸。
+
+    Win32 controller 截的就是客户区，脚本侧的分辨率闸门校验的也是它，所以诊断和
+    判据都要看这个数，而不是窗口外框或屏幕分辨率。
+
+    默认取**窗口自己坐标系**下的尺寸（DPI-unaware 的窗口就是它认知里的逻辑像素）；
+    `physical=True` 取物理像素。两者在缩放不为 100% 时不一样，诊断日志两个都要打：
+    截图链路最终看到哪一个取决于 MaaFW 自身的 DPI 感知级别，不该由这里替它假设。
+    """
+
+    if not hwnd:
+        return None
+    context = per_monitor_dpi() if physical else window_dpi_context(hwnd)
+    with context:
+        try:
+            left, top, right, bottom = win32gui.GetClientRect(hwnd)
+        except Exception:
+            return None
+    width, height = right - left, bottom - top
+    if width <= 0 or height <= 0:
+        return None
+    return width, height
+
+
+def _is_resizable_window(hwnd: int) -> bool:
+    """全屏/无边框窗口没有可调整的外框，整形对它们无意义也不安全。"""
+
+    try:
+        style = win32gui.GetWindowLong(hwnd, win32con.GWL_STYLE)
+    except Exception:
+        return False
+    return bool(style & win32con.WS_CAPTION) and bool(style & win32con.WS_THICKFRAME)
+
+
+def set_client_size(
+    hwnd: int, client_width: int, client_height: int
+) -> tuple[int, int] | None:
+    """把窗口客户区调整为目标尺寸，返回实际结果；不可调整时返回 None。
+
+    位置尽量保持不动，放不下时才挪回所在显示器的可用区域内——窗口跑到屏幕外面
+    会让 ScreenDC 之类基于屏幕 DC 的截图方式抓到垃圾像素。
+    """
+
+    if not hwnd or client_width <= 0 or client_height <= 0:
+        return None
+    if not _is_resizable_window(hwnd):
+        return None
+
+    monitor = monitor_from_window(hwnd)
+    # 用窗口自己的 DPI，不是显示器的：DPI-unaware 的窗口在 150% 缩放下按物理像素
+    # 去设根本取不到目标值（1280 -> 实测 1278），差的那两像素足以卡住脚本侧的下限。
+    dpi = dpi_for_window(hwnd)
+
+    with window_dpi_context(hwnd):
+        try:
+            style = win32gui.GetWindowLong(hwnd, win32con.GWL_STYLE)
+            ex_style = win32gui.GetWindowLong(hwnd, win32con.GWL_EXSTYLE)
+            frame_width, frame_height = frame_size_for_client(
+                client_width, client_height, dpi, style, ex_style
+            )
+            left, top, _right, _bottom = win32gui.GetWindowRect(hwnd)
+
+            if monitor is not None:
+                work_left, work_top, work_right, work_bottom = monitor.work
+                left = min(
+                    max(left, work_left), max(work_left, work_right - frame_width)
+                )
+                top = min(max(top, work_top), max(work_top, work_bottom - frame_height))
+
+            win32gui.SetWindowPos(
+                hwnd,
+                0,
+                left,
+                top,
+                frame_width,
+                frame_height,
+                win32con.SWP_NOZORDER | win32con.SWP_NOACTIVATE,
+            )
+        except Exception:
+            return None
+
+    return get_client_size(hwnd)

--- a/frontend/src/api/models/MaaFWConfig_Game.ts
+++ b/frontend/src/api/models/MaaFWConfig_Game.ts
@@ -23,5 +23,9 @@ export type MaaFWConfig_Game = {
      * 任务结束后是否关闭由 MAS 启动的游戏
      */
     CloseOnFinish?: (boolean | null);
+    /**
+     * Win32 controller 下把游戏窗口客户区调整为指定尺寸；Off 不调整，Fit 取屏幕放得下的最大一档
+     */
+    WindowSize?: ('Off' | 'Fit' | '1280x720' | '1600x900' | '1920x1080' | null);
 };
 

--- a/frontend/src/composables/useMaaFWScriptConfig.ts
+++ b/frontend/src/composables/useMaaFWScriptConfig.ts
@@ -82,6 +82,7 @@ export const getDefaultMaaFWScriptConfig = (): MaaFWScriptConfig => ({
     Arguments: '',
     WaitTime: 60,
     CloseOnFinish: true,
+    WindowSize: 'Off',
   },
   Update: {
     AutoUpdateMode: 'BeforeRun',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1299,6 +1299,11 @@ export default {
     maximumLinesWindowBefore: 'Maximum lines in a window before it is force-closed',
     pasteLogLinesTest: 'Paste the log lines to test, one per line...',
     closeLaunchedProcessAfterwards: 'Close the launched process afterwards',
+    gameWindowSize: 'Game window size',
+    gameWindowSizeTip:
+      'Resize the game window’s drawing area before the task starts. When a monitor is disconnected or powered off, Windows falls back to a very small resolution; the game window shrinks and the game remembers it, so every later run is undersized. Off by default.',
+    gameWindowSizeOff: 'Do not resize',
+    gameWindowSizeFit: 'Fit (largest size the screen can hold)',
     endPattern: 'End pattern',
     keepEditing: 'Keep editing',
     editHsrScript: 'Edit the HSR script',

--- a/frontend/src/i18n/locales/ja-JP.ts
+++ b/frontend/src/i18n/locales/ja-JP.ts
@@ -1240,6 +1240,11 @@ export default {
     maximumLinesWindowBefore: '範囲の最大行数。これに達すると強制的に閉じます',
     pasteLogLinesTest: 'テストしたいログ行を貼り付けてください（1 行に 1 件）...',
     closeLaunchedProcessAfterwards: '終了後に起動したプロセスを閉じる',
+    gameWindowSize: 'ゲームウィンドウサイズ',
+    gameWindowSizeTip:
+      'タスク開始前にゲームウィンドウの描画領域を指定サイズへ調整します。モニターを外したり電源を切ったりすると Windows は非常に低い解像度へ退避し、ゲームウィンドウが縮んだまま記憶されるため、以降の実行が常に条件を満たさなくなります。既定では調整しません。',
+    gameWindowSizeOff: '調整しない',
+    gameWindowSizeFit: '自動（画面に収まる最大サイズ）',
     endPattern: '終了用の正規表現',
     keepEditing: '編集を続ける',
     editHsrScript: 'HSR スクリプトを編集',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1230,6 +1230,11 @@ export default {
     maximumLinesWindowBefore: '窗口最大跨行数，达到后强制关闭',
     pasteLogLinesTest: '粘贴要测试的日志行，每行一条...',
     closeLaunchedProcessAfterwards: '结束后关闭启动进程',
+    gameWindowSize: '游戏窗口尺寸',
+    gameWindowSizeTip:
+      '任务开始前把游戏窗口的画面区域调整为指定尺寸。显示器断开或关闭时 Windows 会回落到很小的分辨率，游戏窗口会被压小并被游戏记住，之后每次运行都不达标。默认不调整。',
+    gameWindowSizeOff: '不调整',
+    gameWindowSizeFit: '自适应（取屏幕放得下的最大一档）',
     endPattern: '结束正则',
     keepEditing: '继续编辑',
     editHsrScript: '编辑 HSR 脚本',

--- a/frontend/src/types/script.ts
+++ b/frontend/src/types/script.ts
@@ -215,6 +215,8 @@ export type MaaFWLaunchMode = 'AttachOnly' | 'DirectExe'
 /** MaaFW 项目自动更新时机；解析与兼容映射见 composables/useMaaFWProjectUpdate.ts。 */
 export type MaaFWAutoUpdateMode = 'Off' | 'BeforeRun' | 'AfterRun'
 
+export type MaaFWWindowSize = 'Off' | 'Fit' | '1280x720' | '1600x900' | '1920x1080'
+
 export interface MaaFWScriptConfig {
   Info: {
     Name: string
@@ -246,6 +248,8 @@ export interface MaaFWScriptConfig {
     Arguments: string
     WaitTime: number
     CloseOnFinish: boolean
+    /** Win32 controller 下把游戏窗口画面区域调整为指定尺寸；Off 不调整，Fit 取屏幕放得下的最大一档。 */
+    WindowSize: MaaFWWindowSize
   }
   Update: {
     /** 自动更新时机：不更新 / 运行前 / 运行后。 */

--- a/frontend/src/views/EditView/Script/MaaFWScriptEdit/ControlConfigSection.vue
+++ b/frontend/src/views/EditView/Script/MaaFWScriptEdit/ControlConfigSection.vue
@@ -294,6 +294,28 @@
             </a-form-item>
           </a-col>
         </a-row>
+
+        <a-row v-if="isDesktopController" :gutter="24" class="control-detail-row">
+          <a-col :span="12">
+            <a-form-item>
+              <template #label>
+                <a-tooltip :title="t('edit.gameWindowSizeTip')">
+                  <span class="form-label">
+                    {{ t('edit.gameWindowSize') }}
+                    <QuestionCircleOutlined class="help-icon" aria-hidden="true" />
+                  </span>
+                </a-tooltip>
+              </template>
+              <a-select
+                v-model:value="maafwConfig.Game.WindowSize"
+                :options="windowSizeOptions"
+                size="large"
+                style="width: 100%"
+                @change="emit('change', 'Game', 'WindowSize', maafwConfig.Game.WindowSize)"
+              />
+            </a-form-item>
+          </a-col>
+        </a-row>
       </div>
     </Transition>
   </div>
@@ -346,6 +368,15 @@ const emit = defineEmits<{
   'emulator-select-change': [emulatorId: string]
   'select-launch-path': []
 }>()
+
+// 选项要放在 computed 里：t() 是响应式的，模块级常量数组切语言时不会更新。
+const windowSizeOptions = computed(() => [
+  { label: t('edit.gameWindowSizeOff'), value: 'Off' },
+  { label: t('edit.gameWindowSizeFit'), value: 'Fit' },
+  { label: '1280x720', value: '1280x720' },
+  { label: '1600x900', value: '1600x900' },
+  { label: '1920x1080', value: '1920x1080' },
+])
 
 const launchMode = computed<MaaFWLaunchMode>(() => props.maafwConfig.Game.LaunchMode)
 const launchModeDescription = computed(() => {

--- a/res/version.json
+++ b/res/version.json
@@ -16,7 +16,8 @@
                 "通知系统 支持扫码绑定微信 Claw 和 QQ 官方机器人并接收任务通知，绑定与启用状态保持独立，绑定失效或推送失败时会明确提示 by [@HarcoChen](https://github.com/HarcoChen)",
                 "HSR专项 用户配置页新增「额外脚本」，可在该用户任务开始前与结束后各执行一个自定义脚本（exe / bat / cmd / py 等），MAS 管控与脚本直控两种模式均生效 by [@qiyinxi](https://github.com/qiyinxi)",
                 "首页 快速启动支持多选并记住上次选择，可一次启动多个任务 by [@Craun718](https://github.com/Craun718)",
-                "MAA专项 托管结束后保存 MAA 写入配置文件的每日状态（如借战赚信用与访问好友的当天执行记录），同一天多次托管不再重复执行 by [@1w1w11w1](https://github.com/1w1w11w1)"
+                "MAA专项 托管结束后保存 MAA 写入配置文件的每日状态（如借战赚信用与访问好友的当天执行记录），同一天多次托管不再重复执行 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "MFW专项 Win32 桌面游戏新增「游戏窗口尺寸」设置，可在任务开始前把游戏窗口的画面区域调整为 1280x720 / 1600x900 / 1920x1080 或自适应，默认不调整；开启后若桌面上没有一块显示器放得下该尺寸，会在运行前直接说明而不是让任务跑一轮再失败"
             ],
             "程序优化": [
                 "启动界面 启动与初始化时的等待画面重做，只显示当前在做什么和一条进度条，首次安装或更新时才展示步骤进度，出错时给出一句话原因和一个主要操作、日志收进「详细信息」，并取消失败后的 60 秒自动重试 by [@qiyinxi](https://github.com/qiyinxi)",
@@ -45,7 +46,8 @@
                 "HSR专项 用户页仍以中文显示的一批界面文案（页面标题、用户名与剩余天数标签、历战余响与周常的本周完成状态、服务器与体力副本选项、管控任务列表的周常/日常与启用摘要等）接入多语言词表，英文与日文界面不再夹杂中文 by [@qiyinxi](https://github.com/qiyinxi)",
                 "日志清理 自动清理OCR图片 by [@HarcoChen](https://github.com/HarcoChen)",
                 "代码清理 单源化各脚本专项重复的任务报告推送核心与 QQ/微信通知公共助手，并清理前后端死代码与直通包装组件，行为保持不变 by [@1w1w11w1](https://github.com/1w1w11w1)",
-                "MAA专项 代理接管 MAA 配置时强制开启开始唤醒的账号切换开关，确保按用户配置的账号切号；用户未填写账号时仍不会切号 by [@1w1w11w1](https://github.com/1w1w11w1)"
+                "MAA专项 代理接管 MAA 配置时强制开启开始唤醒的账号切换开关，确保按用户配置的账号切号；用户未填写账号时仍不会切号 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "MFW专项 Win32 桌面游戏运行前会记录显示器分辨率、DPI 缩放与游戏窗口的实际画面尺寸，分辨率不达标导致任务失败时不必再靠脚本自己的日志倒推"
             ],
             "开发流程": [
                 "新增 GitHub Issue 模板，Bug 反馈按脚本专项、MaaFW 专项与通用问题分区，并附需求建议等模板与常见问题、文档站、官方群链接 by [@qiyinxi](https://github.com/qiyinxi)",
@@ -179,7 +181,7 @@
                 "修复 MaaFW 单个任务失败时运行日志不即时提示、要等整轮跑完才能看到的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 HSR 未配置 SRA 路径时多个用户会静默跑在同一个已登录账号上的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 MaaFW 游戏启动失败后仍继续投递剩余任务、空转到各自超时的问题，改为直接报错并进入下一次重试 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)"
             ]
         },
         "v5.5.0-beta.1": {

--- a/tests/platform/test_display_capacity.py
+++ b/tests/platform/test_display_capacity.py
@@ -1,0 +1,87 @@
+"""显示器容量判据的纯逻辑回归
+
+Win32 桌面游戏任务要回答的问题是「桌面上有没有一块屏放得下目标窗口」。判据必须
+按 DPI 换算非客户区：150% 缩放下标题栏约 48px、100% 下约 31px，写死余量在高 DPI
+显示器上必然误判。
+
+这里只测纯几何判据，不碰真实窗口。
+"""
+
+import pytest
+
+from app.utils.platform import IS_WINDOWS
+
+pytestmark = pytest.mark.skipif(not IS_WINDOWS, reason="显示器查询仅 Windows 实现")
+
+
+def _monitor(width: int, height: int, dpi: int = 96, taskbar: int = 0):
+    from app.utils.platform.display import MonitorInfo
+
+    return MonitorInfo(
+        device="\\\\.\\DISPLAYTEST",
+        handle=0,
+        bounds=(0, 0, width, height),
+        work=(0, 0, width, height - taskbar),
+        dpi=dpi,
+        primary=True,
+    )
+
+
+def test_frame_is_larger_than_client_and_grows_with_dpi() -> None:
+    """外框必须比客户区大，且高 DPI 下的非客户区更厚。"""
+
+    from app.utils.platform.display import frame_size_for_client
+
+    width_96, height_96 = frame_size_for_client(1280, 720, 96)
+    width_144, height_144 = frame_size_for_client(1280, 720, 144)
+
+    assert width_96 > 1280 and height_96 > 720
+    assert height_144 > height_96, "150% 缩放下标题栏更高，换算必须跟着变"
+
+
+def test_exactly_sized_screen_cannot_host_because_of_titlebar() -> None:
+    """屏幕正好等于目标客户区时放不下——非客户区还要占地方。
+
+    这正是写死余量或直接拿分辨率比大小会判错的那一档。
+    """
+
+    from app.utils.platform.display import can_host_client
+
+    assert not can_host_client(_monitor(1280, 720), 1280, 720)
+    assert can_host_client(_monitor(1920, 1080), 1280, 720)
+
+
+def test_taskbar_is_excluded_from_usable_area() -> None:
+    """判据看的是工作区，不是整块屏；任务栏占掉的高度不能算进去。"""
+
+    from app.utils.platform.display import can_host_client, frame_size_for_client
+
+    _, frame_height = frame_size_for_client(1280, 720, 96)
+    # 屏高刚好只比外框多 10px，任务栏一占就不够了。
+    screen_height = frame_height + 10
+    assert can_host_client(_monitor(1920, screen_height), 1280, 720)
+    assert not can_host_client(_monitor(1920, screen_height, taskbar=40), 1280, 720)
+
+
+def test_headless_fallback_resolution_cannot_host_720p_window() -> None:
+    """显示器断开后 Windows 的兜底分辨率放不下 1280x720 窗口。
+
+    这就是 2026-09-07 现场的成因：桌面被压小 -> 游戏窗口跟着变小 -> 脚本侧的
+    分辨率闸门把整轮任务打掉。
+    """
+
+    from app.utils.platform.display import can_host_client
+
+    assert not can_host_client(_monitor(1024, 768), 1280, 720)
+
+
+def test_ultrawide_virtual_display_can_host_even_though_not_16_9() -> None:
+    """屏幕不需要是 16:9，够大就行。
+
+    16:9 是对游戏窗口客户区的要求（Win32 controller 截的就是客户区），不是对
+    屏幕的要求。UU远程那种 2796x1290 的虚拟屏放得下 1280x720 窗口。
+    """
+
+    from app.utils.platform.display import can_host_client
+
+    assert can_host_client(_monitor(2796, 1290), 1280, 720)

--- a/tests/task/test_maafw_config.py
+++ b/tests/task/test_maafw_config.py
@@ -34,7 +34,7 @@ class MaaFWConfigTest(unittest.TestCase):
                 "Info": 5,
                 "Emulator": 2,
                 "Device": 11,
-                "Game": 5,
+                "Game": 6,
                 "Update": 8,
                 "Managed": 9,
                 "ManagedRuntime": 5,
@@ -44,8 +44,9 @@ class MaaFWConfigTest(unittest.TestCase):
             },
         )
         # 第一层删除后少了 Run.Engine 与 Game.{Path,LaunchURL,ProcessPath,ProcessName}；
-        # 自动更新接线新增 Update.AutoUpdateMode，故 Update 组 8 项、总计 61
-        self.assertEqual(_item_count(script), 61)
+        # 自动更新接线新增 Update.AutoUpdateMode 使 Update 组 8 项，
+        # 窗口整形新增 Game.WindowSize 使 Game 组 6 项，总计 62
+        self.assertEqual(_item_count(script), 62)
         self.assertNotIn("Engine", script._config_item_index["Run"])
         self.assertIn("DailyOnceTasks", script._config_item_index["Run"])
         self.assertIn("WeeklyOnceTasks", script._config_item_index["Run"])

--- a/tests/task/test_maafw_window_target.py
+++ b/tests/task/test_maafw_window_target.py
@@ -1,7 +1,11 @@
-"""MaaFW Win32 游戏窗口目标尺寸解析的纯逻辑回归
+"""MaaFW Win32 游戏窗口「目标尺寸 + 目标显示器」解析的纯逻辑回归
 
-`Game.WindowSize` 决定 MAS 要不要动游戏窗口、动成多大。默认 Off：MAS 无从知道某个
-MaaFW 项目要的是什么比例，只在用户明确指定时才整形。Fit 从大到小挑第一个放得下的。
+`Game.WindowSize` 决定 MAS 要不要动游戏窗口、动成多大、放到哪块屏。默认 Off：MAS 无从
+知道某个 MaaFW 项目要的是什么比例，只在用户明确指定时才整形。
+
+选屏与判据必须是同一次决策——早先的版本容量检查按「任意显示器」放行、整形却按「窗口当前
+所在显示器」执行，多屏尺寸不同时两者会对不上。这里用假的 find_host_monitor 覆盖真实显示器，
+测的是那次决策本身。
 """
 
 from types import SimpleNamespace
@@ -13,24 +17,14 @@ from app.utils.platform import IS_WINDOWS
 pytestmark = pytest.mark.skipif(not IS_WINDOWS, reason="窗口整形仅 Windows 实现")
 
 
-def _task(window_size: str):
-    from app.task.MaaFW.tools.embedded.runner_task import MaaFWPluginAutoProxyTask
-
-    task = object.__new__(MaaFWPluginAutoProxyTask)
-    task.script_config = SimpleNamespace(
-        get=lambda section, key: window_size
-        if (section, key) == ("Game", "WindowSize")
-        else None
-    )
-    return task
-
-
-def _monitor(width: int, height: int, dpi: int = 96):
+def _monitor(
+    width: int, height: int, dpi: int = 96, device: str = "TEST", handle: int = 1
+):
     from app.utils.platform.display import MonitorInfo
 
     return MonitorInfo(
-        device="\\\\.\\DISPLAYTEST",
-        handle=0,
+        device=device,
+        handle=handle,
         bounds=(0, 0, width, height),
         work=(0, 0, width, height),
         dpi=dpi,
@@ -38,40 +32,100 @@ def _monitor(width: int, height: int, dpi: int = 96):
     )
 
 
-def test_off_never_touches_the_window() -> None:
+def _task(window_size: str, monitors, monkeypatch):
+    """构造一个只带 Game.WindowSize 的任务，并把可用显示器换成 monitors。"""
+
+    from app.task.MaaFW.tools.embedded import runner_task
+    from app.utils.platform.display import can_host_client
+
+    def fake_find_host_monitor(width: int, height: int):
+        for monitor in monitors:
+            if can_host_client(monitor, width, height):
+                return monitor
+        return None
+
+    monkeypatch.setattr(runner_task, "find_host_monitor", fake_find_host_monitor)
+
+    task = object.__new__(runner_task.MaaFWPluginAutoProxyTask)
+    task.script_config = SimpleNamespace(
+        get=lambda section, key: (
+            window_size if (section, key) == ("Game", "WindowSize") else None
+        )
+    )
+    return task
+
+
+def test_off_never_touches_the_window(monkeypatch: pytest.MonkeyPatch) -> None:
     """默认不整形——用户没要求就不该替他决定窗口多大。"""
 
-    assert _task("Off")._win32_window_target(_monitor(3840, 2160)) is None
+    task = _task("Off", [_monitor(3840, 2160)], monkeypatch)
+    assert task._win32_window_plan() is None
 
 
-def test_explicit_preset_ignores_screen_size() -> None:
-    """指定了具体尺寸就照做，容量检查交给 check() 的闸门。"""
+def test_explicit_preset_returns_the_monitor_that_can_host_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """显式尺寸同样要求真有屏放得下，并把那块屏一起返回。"""
 
-    assert _task("1280x720")._win32_window_target(_monitor(1024, 768)) == (1280, 720)
-    assert _task("1920x1080")._win32_window_target(_monitor(3840, 2160)) == (1920, 1080)
+    big = _monitor(3840, 2160, device="BIG", handle=2)
+    task = _task("1920x1080", [big], monkeypatch)
+    assert task._win32_window_plan() == ((1920, 1080), big)
 
 
-def test_fit_picks_the_largest_that_actually_fits() -> None:
+def test_explicit_preset_gives_up_when_no_monitor_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """放不下就返回 None，交由 check() 的闸门给出可读的失败原因。
+
+    早先显式尺寸分支不做容量判断，会把窗口设成超出工作区的尺寸再被夹到屏幕外，
+    ScreenDC 截图随即抓到垃圾像素。
+    """
+
+    task = _task("1920x1080", [_monitor(1024, 768)], monkeypatch)
+    assert task._win32_window_plan() is None
+
+
+def test_fit_picks_the_largest_that_actually_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Fit 从大到小挑第一个放得下的，而不是无脑取最大。"""
 
-    task = _task("Fit")
-    assert task._win32_window_target(_monitor(3840, 2160)) == (1920, 1080)
-    assert task._win32_window_target(_monitor(1920, 1080)) == (1600, 900)
-    assert task._win32_window_target(_monitor(1600, 900)) == (1280, 720)
+    def plan_for(width: int, height: int):
+        task = _task("Fit", [_monitor(width, height)], monkeypatch)
+        return task._win32_window_plan()[0]
+
+    assert plan_for(3840, 2160) == (1920, 1080)
+    assert plan_for(1920, 1080) == (1600, 900)
+    assert plan_for(1600, 900) == (1280, 720)
 
 
-def test_fit_gives_up_when_nothing_fits() -> None:
-    """兜底分辨率下一档都放不下，返回 None 交由闸门给出可读的失败原因。"""
+def test_fit_gives_up_when_nothing_fits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """兜底分辨率下一档都放不下。"""
 
-    assert _task("Fit")._win32_window_target(_monitor(1024, 768)) is None
-    assert _task("Fit")._win32_window_target(None) is None
+    assert _task("Fit", [_monitor(1024, 768)], monkeypatch)._win32_window_plan() is None
+    assert _task("Fit", [], monkeypatch)._win32_window_plan() is None
 
 
-def test_fit_accounts_for_dpi_scaling() -> None:
+def test_larger_secondary_monitor_is_chosen_over_the_small_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """多屏尺寸不同时，选的是放得下的那块，不是第一块。
+
+    这正是选屏与判据分家时会错的场景：窗口在小屏上，检查却按大屏放行。
+    """
+
+    small = _monitor(1024, 768, device="SMALL", handle=1)
+    big = _monitor(2560, 1440, device="BIG", handle=2)
+    size, host = _task("Fit", [small, big], monkeypatch)._win32_window_plan()
+    assert size == (1920, 1080)
+    assert host.device == "BIG"
+
+
+def test_fit_accounts_for_dpi_scaling(monkeypatch: pytest.MonkeyPatch) -> None:
     """同样的屏幕像素，高 DPI 下非客户区更厚，可能就掉一档。
 
-    临界屏幕由换算函数自己算出来，不写死——写死的数字既容易和实际的边框宽度
-    对不上，也无法说明「差别真的来自 DPI」。
+    临界屏幕由换算函数自己算出来，不写死——写死的数字既容易和实际的边框宽度对不上，
+    也无法说明「差别真的来自 DPI」。
     """
 
     from app.utils.platform.display import frame_size_for_client
@@ -83,6 +137,11 @@ def test_fit_accounts_for_dpi_scaling() -> None:
     # 宽度对两档都够，高度只够 96 那一档。
     screen = max(width_96, width_192), height_96
 
-    task = _task("Fit")
-    assert task._win32_window_target(_monitor(*screen, dpi=96)) == (1920, 1080)
-    assert task._win32_window_target(_monitor(*screen, dpi=192)) != (1920, 1080)
+    plan_96 = _task(
+        "Fit", [_monitor(*screen, dpi=96)], monkeypatch
+    )._win32_window_plan()
+    plan_192 = _task(
+        "Fit", [_monitor(*screen, dpi=192)], monkeypatch
+    )._win32_window_plan()
+    assert plan_96[0] == (1920, 1080)
+    assert plan_192 is None or plan_192[0] != (1920, 1080)

--- a/tests/task/test_maafw_window_target.py
+++ b/tests/task/test_maafw_window_target.py
@@ -145,3 +145,49 @@ def test_fit_accounts_for_dpi_scaling(monkeypatch: pytest.MonkeyPatch) -> None:
     )._win32_window_plan()
     assert plan_96[0] == (1920, 1080)
     assert plan_192 is None or plan_192[0] != (1920, 1080)
+
+
+def test_capacity_gate_is_silent_when_reshaping_is_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """没开整形就不该拦——用户自己管窗口时 MAS 无从判断多大算够。"""
+
+    task = _task("Off", [_monitor(1024, 768)], monkeypatch)
+    assert task._check_desktop_capacity() is None
+
+
+def test_capacity_gate_passes_when_some_monitor_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task("1280x720", [_monitor(1920, 1080)], monkeypatch)
+    assert task._check_desktop_capacity() is None
+
+
+def test_capacity_gate_reports_target_and_actual_monitors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """拦下来时必须说清楚要多大、现在有什么，否则用户无从下手。"""
+
+    from app.task.MaaFW.tools.embedded import runner_task
+
+    monkeypatch.setattr(
+        runner_task, "describe_monitors", lambda: "DISPLAY1 1024x768(可用 1024x728)"
+    )
+    task = _task("1920x1080", [_monitor(1024, 768)], monkeypatch)
+    message = task._check_desktop_capacity()
+
+    assert message is not None
+    assert "1920x1080" in message, "要说清楚需要多大"
+    assert "1024x768" in message, "要说清楚现在有什么"
+
+
+def test_capacity_gate_uses_min_client_for_fit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fit 模式按最低档 1280x720 判定，不按最大档——否则小屏会被误拦。"""
+
+    task = _task("Fit", [_monitor(1600, 900)], monkeypatch)
+    assert task._check_desktop_capacity() is None
+
+    task = _task("Fit", [_monitor(1024, 768)], monkeypatch)
+    assert task._check_desktop_capacity() is not None

--- a/tests/task/test_maafw_window_target.py
+++ b/tests/task/test_maafw_window_target.py
@@ -1,0 +1,88 @@
+"""MaaFW Win32 游戏窗口目标尺寸解析的纯逻辑回归
+
+`Game.WindowSize` 决定 MAS 要不要动游戏窗口、动成多大。默认 Off：MAS 无从知道某个
+MaaFW 项目要的是什么比例，只在用户明确指定时才整形。Fit 从大到小挑第一个放得下的。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.utils.platform import IS_WINDOWS
+
+pytestmark = pytest.mark.skipif(not IS_WINDOWS, reason="窗口整形仅 Windows 实现")
+
+
+def _task(window_size: str):
+    from app.task.MaaFW.tools.embedded.runner_task import MaaFWPluginAutoProxyTask
+
+    task = object.__new__(MaaFWPluginAutoProxyTask)
+    task.script_config = SimpleNamespace(
+        get=lambda section, key: window_size
+        if (section, key) == ("Game", "WindowSize")
+        else None
+    )
+    return task
+
+
+def _monitor(width: int, height: int, dpi: int = 96):
+    from app.utils.platform.display import MonitorInfo
+
+    return MonitorInfo(
+        device="\\\\.\\DISPLAYTEST",
+        handle=0,
+        bounds=(0, 0, width, height),
+        work=(0, 0, width, height),
+        dpi=dpi,
+        primary=True,
+    )
+
+
+def test_off_never_touches_the_window() -> None:
+    """默认不整形——用户没要求就不该替他决定窗口多大。"""
+
+    assert _task("Off")._win32_window_target(_monitor(3840, 2160)) is None
+
+
+def test_explicit_preset_ignores_screen_size() -> None:
+    """指定了具体尺寸就照做，容量检查交给 check() 的闸门。"""
+
+    assert _task("1280x720")._win32_window_target(_monitor(1024, 768)) == (1280, 720)
+    assert _task("1920x1080")._win32_window_target(_monitor(3840, 2160)) == (1920, 1080)
+
+
+def test_fit_picks_the_largest_that_actually_fits() -> None:
+    """Fit 从大到小挑第一个放得下的，而不是无脑取最大。"""
+
+    task = _task("Fit")
+    assert task._win32_window_target(_monitor(3840, 2160)) == (1920, 1080)
+    assert task._win32_window_target(_monitor(1920, 1080)) == (1600, 900)
+    assert task._win32_window_target(_monitor(1600, 900)) == (1280, 720)
+
+
+def test_fit_gives_up_when_nothing_fits() -> None:
+    """兜底分辨率下一档都放不下，返回 None 交由闸门给出可读的失败原因。"""
+
+    assert _task("Fit")._win32_window_target(_monitor(1024, 768)) is None
+    assert _task("Fit")._win32_window_target(None) is None
+
+
+def test_fit_accounts_for_dpi_scaling() -> None:
+    """同样的屏幕像素，高 DPI 下非客户区更厚，可能就掉一档。
+
+    临界屏幕由换算函数自己算出来，不写死——写死的数字既容易和实际的边框宽度
+    对不上，也无法说明「差别真的来自 DPI」。
+    """
+
+    from app.utils.platform.display import frame_size_for_client
+
+    width_96, height_96 = frame_size_for_client(1920, 1080, 96)
+    width_192, height_192 = frame_size_for_client(1920, 1080, 192)
+    assert height_192 > height_96, "高 DPI 的非客户区必须更厚，否则这条测不到东西"
+
+    # 宽度对两档都够，高度只够 96 那一档。
+    screen = max(width_96, width_192), height_96
+
+    task = _task("Fit")
+    assert task._win32_window_target(_monitor(*screen, dpi=96)) == (1920, 1080)
+    assert task._win32_window_target(_monitor(*screen, dpi=192)) != (1920, 1080)


### PR DESCRIPTION
## 问题

显示器断开或关闭时 Windows 会回落到很小的兜底分辨率，游戏窗口被压小并被游戏自己记住（Unity 会把窗口尺寸写进注册表），之后每次运行都不达标。MaaFW Win32 controller 截的是**窗口客户区**，脚本侧的分辨率闸门校验的也是它，于是整轮任务被打掉——而 MAS 自己一个尺寸都没记，只能靠脚本日志倒推。

配套的 #598 修的是「被强停却报成功」，这个 PR 修的是「一开始就别让窗口不达标」。

## 改动

**新增 `app/utils/platform/{windows,common}/display.py`**：显示器枚举、工作区、DPI、`HMONITOR` 反查，以及「某块屏放不放得下目标客户区」的判据。按 `AdjustWindowRectExForDpi` 换算非客户区，不写死余量——150% 下标题栏约 48px、100% 下约 31px。

**诊断（无条件）**：Win32 任务运行前记录显示器分辨率、DPI 缩放与游戏窗口实测客户区。

**整形（`Game.WindowSize`，默认 Off）**：把窗口客户区摆成 1280x720 / 1600x900 / 1920x1080 或 Fit。默认关是有意的：MAS 无从知道某个 MaaFW 项目要的是什么比例，只在用户明确指定时才动窗口。开启后 `check()` 会先确认桌面上有屏放得下，放不下就当场说清楚而不是让任务跑一轮再失败。

## 一个真机才暴露的坑

整形必须用**窗口自己的 DPI 感知级别**，不是显示器的。多数游戏客户端是 DPI-unaware，Windows 对它做 DPI 虚拟化：在 150% 缩放下按物理像素去要 1280 宽，窗口自己只能取到 853 逻辑像素，换回物理是 1279.5，实测落到 **1278**——「整形成功」但宽度差 2 像素，脚本侧 ≥1280 的下限照样过不了。按窗口自身坐标系设，拿到的就是精确的 1280x720。

纯逻辑测试测不到这一段，是真窗口手测打出来的。

诊断日志因此同时给出窗口自身坐标与物理像素：截图链路最终看到哪一个取决于 MaaFW 自己的 DPI 感知级别，不该由 MAS 替它假设。

## 验证

后端（本分支 `.venv`，Python 3.12）：

| 检查 | 结果 |
| --- | --- |
| `python -m pytest tests` | 487 passed, 3 skipped |
| `--collect-only -q` | 490 collected，退出 0 |
| `ruff check` / `format --check`（改动文件） | 通过 |

前端：`yarn typecheck` 通过；`yarn lint` 通过；`yarn test` 402 passed / 3 failed，失败的 3 条都在 `electron/services/`（`backendService`、`runtimeInitializationService`），该目录未改动且这两个测试不引用 `src/`，为 dev 基线既有失败。

新增提交的纯逻辑测试 10 条：容量判据（含「屏幕正好等于目标客户区时放不下」「任务栏要从可用区扣掉」「1024x768 兜底分辨率放不下 720p 窗口」「超宽虚拟屏不是 16:9 但够大就行」）与目标尺寸解析（Fit 从大到小挑第一个放得下的、按 DPI 掉档）。

真窗口手测（tkinter，DPI-unaware，与游戏客户端同类）：400x300 → 1280x720 精确命中，窗口留在工作区内，重复整形结果稳定。

## 待维护者补齐

`frontend/src/api` 未重新生成：`yarn openapi` 需要连一个跑着的后端，而开发版与正式版在同一台机器上无法并存，起后端会打掉正在运行的实例。`Game.WindowSize` 的生成模型待执行 `yarn openapi` 补齐；手写的 `types/script.ts` 已同步，功能不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

新增可选的 Win32 游戏窗口尺寸设置和桌面容量验证，以确保 MaaFW 任务在所需的客户端区域分辨率下运行。

新功能：
- 添加可选的 Win32 游戏窗口客户端区域尺寸设置，支持固定预设和自动适配选择。
- 在 MaaFW 脚本编辑器中提供窗口尺寸控制，并添加本地化标签和默认值。

错误修复：
- 当没有已连接的显示器能够容纳配置的游戏窗口尺寸时，阻止 Win32 任务启动。
- 改进因显示器断开连接或关闭电源导致游戏窗口尺寸不足时的恢复机制。

增强功能：
- 添加 Windows 显示器枚举、DPI 感知的几何计算、显示器容量检查，以及在保留诊断信息的同时调整窗口客户端区域大小。
- 在执行 Win32 任务前记录显示器详情、DPI 缩放比例，以及测量得到的逻辑和物理客户端区域尺寸。

测试：
- 添加针对显示器容量计算、任务栏和 DPI 影响、备用分辨率以及窗口尺寸目标选择的回归测试。

杂项：
- 更新 MaaFW 配置架构、前端类型和配置清单，以支持新的窗口尺寸选项。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增可选的 DPI 感知 Win32 游戏窗口大小设置和桌面容量验证，确保 MaaFW 任务以可用的客户端分辨率启动。

新功能：
- 新增可选的 Win32 游戏客户端区域大小设置，支持关闭、适应和标准 16:9 预设。
- 在 MaaFW 配置和脚本编辑器中公开游戏窗口大小设置，并提供本地化标签。

错误修复：
- 当没有已连接的显示器能够容纳配置的游戏客户端区域时，阻止 Win32 任务启动。
- 改进因显示器断开连接或关闭而导致的已记忆游戏窗口过小问题的恢复机制。

增强功能：
- 新增支持 DPI 感知的 Windows 显示器几何信息、工作区容量检查、窗口大小设置，以及逻辑和物理客户端尺寸诊断。

测试：
- 新增针对显示器容量、任务栏和 DPI 影响、备用分辨率以及 Fit 目标选择的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增可选的 DPI 感知 Win32 游戏窗口大小调整和桌面容量检查，确保 MaaFW 任务启动时使用可用的客户端分辨率。

新功能：
- 新增可选的 Win32 游戏客户区大小设置，支持“关闭”、“适配”和标准 16:9 预设，并在 MaaFW 配置编辑器中提供设置。
- 新增支持 DPI 感知的 Windows 显示器枚举，以及针对已配置游戏窗口大小的桌面容量验证。

错误修复：
- 当没有已连接的显示器能够容纳所请求的游戏客户区时，阻止 Win32 任务启动。
- 在任务执行前调整符合条件的窗口大小，以恢复尺寸过小的已记忆游戏窗口。

增强功能：
- 在 Win32 任务运行前，记录显示器几何信息、DPI 缩放比例，以及游戏客户区的逻辑尺寸和物理尺寸。
- 在保持优雅降级的同时，将调整大小后的窗口限制在显示器工作区内；当无法调整大小或调整失败时，继续使用回退机制。

测试：
- 新增针对显示器容量、任务栏空间、依赖 DPI 的窗口框架尺寸、回退分辨率和“适配”目标选择的回归测试覆盖。

杂项：
- 更新 MaaFW 配置架构、前端类型、默认值、本地化标签以及配置清单，以支持新的窗口大小设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增可选的、支持 DPI 感知的 Win32 游戏窗口大小调整和桌面容量检查，确保 MaaFW 任务以可用的客户端分辨率启动。

新功能：
- 新增可选的 Win32 游戏客户区大小设置，支持关闭、适应和标准 16:9 预设，并在 MaaFW 配置编辑器中提供该选项。
- 新增支持 DPI 感知的 Windows 显示器枚举和桌面容量验证，用于检查请求的游戏窗口大小。

错误修复：
- 当没有连接的显示器能够容纳配置的游戏客户区时，阻止 Win32 任务启动。
- 当用户启用窗口大小设置时，在执行前恢复尺寸过小的已记忆游戏窗口。

增强功能：
- 在 Win32 任务运行前记录显示器几何信息、DPI 缩放比例，以及游戏客户区的逻辑和物理尺寸。
- 将调整大小后的窗口限制在所选显示器的工作区域内，并在无法调整大小或调整失败时继续执行。

测试：
- 新增针对显示器容量、任务栏占用空间、依赖 DPI 的窗口框架尺寸、备用分辨率和“适应”目标选择的回归测试。

杂项：
- 更新 MaaFW 配置模型、前端类型、默认值、本地化标签，以及新增窗口大小选项后的配置项数量。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增可选的 DPI 感知 Win32 游戏窗口大小调整和桌面容量验证功能，确保 MaaFW 任务以可用的客户端分辨率启动。

新功能：
- 新增可选的 Win32 游戏客户端区域大小设置，支持关闭、适应和标准 16:9 预设，并在 MaaFW 配置编辑器中提供该选项。
- 新增 DPI 感知的 Windows 显示器容量检查，以及针对配置的客户端大小在运行前进行窗口放置。

错误修复：
- 当没有已连接的显示器能够容纳所请求的游戏客户端区域时，阻止 Win32 任务启动。
- 启用窗口大小调整后，在执行前恢复尺寸不足的已记忆游戏窗口。

增强功能：
- 在 Win32 诊断信息中记录显示器几何信息、DPI 缩放比例，以及游戏客户端区域的逻辑和物理尺寸；当无法调整大小或调整失败时，仍保留平滑回退机制。

测试：
- 新增针对显示器容量、任务栏空间、依赖 DPI 的窗口边框大小、回退分辨率、多显示器选择和适应目标选择的回归测试。

杂项：
- 更新 MaaFW 配置模型、前端类型、默认值、本地化标签以及配置清单，以支持新的窗口大小选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional DPI-aware Win32 game window sizing and desktop capacity validation so MaaFW tasks start with a usable client resolution.

New Features:
- Add optional Win32 game client-area sizing with Off, Fit, and standard 16:9 presets, exposed in the MaaFW configuration editor.
- Add DPI-aware Windows monitor capacity checks and pre-run window placement for configured client sizes.

Bug Fixes:
- Prevent Win32 tasks from starting when no connected display can accommodate the requested game client area.
- Recover undersized remembered game windows before execution when window sizing is enabled.

Enhancements:
- Record monitor geometry, DPI scaling, and logical and physical game client-area dimensions for Win32 diagnostics while preserving graceful fallback when resizing is unavailable or fails.

Tests:
- Add regression coverage for display capacity, taskbar space, DPI-dependent frame sizing, fallback resolutions, multi-monitor selection, and Fit target selection.

Chores:
- Update MaaFW configuration models, frontend types, defaults, localized labels, and configuration inventory for the new window-size option.

</details>

</details>

</details>

</details>

</details>