### PR TITLE
fix(runtime): uv 下载完成瞬间不再把「安装 Python」段显示成完成

### DIFF
--- a/frontend/electron/services/runtimeInitializationService.test.ts
+++ b/frontend/electron/services/runtimeInitializationService.test.ts
@@ -359,7 +359,8 @@ describe('进度桥接', () => {
     bridge.observe('workspace.clone', '正在同步后端仓库', 42.86)
     bridge.observe('workspace.clone', '正在接收后端仓库数据', 63.4)
     expect(updates[2]).toMatchObject({ stage: 'python', status: 'completed', progress: 100 })
-    expect(updates[3]).toMatchObject({ stage: 'repository', status: 'started', progress: 10 })
+    // 段开始时带着真实百分比就照发（#570 起的既有行为，当时没同步这条期望值）
+    expect(updates[3]).toMatchObject({ stage: 'repository', status: 'started', progress: 43 })
     expect(updates[4]).toMatchObject({ stage: 'repository', status: 'running', progress: 63 })
   })
 
@@ -369,8 +370,93 @@ describe('进度桥接', () => {
 
     bridge.observe('dependencies.sync', '正在同步锁定依赖')
     expect(updates).toEqual([
-      { stage: 'dependency', status: 'started', progress: 10, message: '正在同步锁定依赖' },
+      {
+        stage: 'dependency',
+        status: 'started',
+        progress: 10,
+        message: '正在同步锁定依赖',
+        indeterminate: true,
+      },
     ])
+  })
+
+  /**
+   * 一个界面段里装着好几个 Runtime stage（uv.download 之后还有校验、解压、python.*），
+   * 所以 100 只能由段收口发出；running 途中不得让渲染层看到 100，段内也不得倒退。
+   */
+  function expectStageMonotonicAndClosedOnce(
+    updates: BootstrapProgressUpdate[],
+    stage: BootstrapProgressUpdate['stage']
+  ): void {
+    const inStage = updates.filter(u => u.stage === stage)
+    expect(inStage.length).toBeGreaterThan(1)
+
+    expect(inStage.some(u => u.status === 'running' && u.progress === 100)).toBe(false)
+
+    const full = inStage.filter(u => u.progress === 100)
+    expect(full).toHaveLength(1)
+    expect(full[0]).toMatchObject({ status: 'completed', indeterminate: false })
+    expect(inStage[inStage.length - 1]).toBe(full[0])
+
+    for (let i = 1; i < inStage.length; i += 1) {
+      expect(inStage[i].progress).toBeGreaterThanOrEqual(inStage[i - 1].progress)
+    }
+  }
+
+  it('uv.download 末块强制回报的 100 不会把「安装 Python」段提前显示成完成', () => {
+    const updates: BootstrapProgressUpdate[] = []
+    const bridge = new BootstrapProgressBridge(update => updates.push(update))
+
+    for (const percent of [0, 3.2, 41.7, 88.9, 100]) {
+      bridge.observe('uv.download', '正在下载固定版本 uv', percent)
+    }
+    bridge.finish('运行环境准备完成')
+
+    expectStageMonotonicAndClosedOnce(updates, 'python')
+    // 段内 running 的上限是 99，末块的 100 被钳住而不是透传
+    const running = updates.filter(u => u.stage === 'python' && u.status === 'running')
+    expect(running.map(u => u.progress)).toEqual([10, 42, 89, 99])
+    expect(running.every(u => u.indeterminate === false)).toBe(true)
+  })
+
+  it('repair 链路里 uv 下载完成后 python.* 无 percent 的事件不会把进度压回 10', () => {
+    const updates: BootstrapProgressUpdate[] = []
+    const bridge = new BootstrapProgressBridge(update => updates.push(update))
+
+    bridge.observe('uv.download', '正在下载固定版本 uv', 0)
+    bridge.observe('uv.download', '正在下载固定版本 uv', 50)
+    bridge.observe('uv.download', '正在下载固定版本 uv', 100)
+    bridge.observe('uv.verify', '固定版本 uv 已校验')
+    bridge.observe('python.check', '正在检查受管 Python')
+    bridge.observe('python.install', '正在准备受管 Python')
+    bridge.observe('python.install', '受管 Python 已就绪')
+    bridge.observe('dependencies.rebuild', '正在重建依赖环境')
+    bridge.finish('运行环境准备完成')
+
+    expectStageMonotonicAndClosedOnce(updates, 'python')
+    expectStageMonotonicAndClosedOnce(updates, 'dependency')
+
+    // 无 percent 的事件仍是 indeterminate，但数字不倒退
+    const pythonAfterDownload = updates.filter(
+      u => u.stage === 'python' && u.status === 'running' && u.indeterminate
+    )
+    expect(pythonAfterDownload.length).toBeGreaterThan(0)
+    expect(pythonAfterDownload.every(u => u.progress === 99)).toBe(true)
+  })
+
+  it('镜像轮换让下载从 0 重来时段内进度不倒退', () => {
+    const updates: BootstrapProgressUpdate[] = []
+    const bridge = new BootstrapProgressBridge(update => updates.push(update))
+
+    for (const percent of [0, 60, 0, 5]) {
+      bridge.observe('uv.download', '正在下载固定版本 uv', percent)
+    }
+
+    const progress = updates.filter(u => u.stage === 'python').map(u => u.progress)
+    expect(progress).toEqual([10, 60, 60, 60])
+    for (let i = 1; i < progress.length; i += 1) {
+      expect(progress[i]).toBeGreaterThanOrEqual(progress[i - 1])
+    }
   })
 })
 

--- a/frontend/electron/services/runtimeInitializationService.ts
+++ b/frontend/electron/services/runtimeInitializationService.ts
@@ -262,10 +262,17 @@ const STAGE_STARTED_PROGRESS = 10
  * 进度百分比只用 Runtime 真给的 `percent`：没有可靠总量时用 `indeterminate` 明确告诉
  * 界面展示持续活动状态。`progress=10` 只为兼容仍要求数字的旧消费方，不再作为精确百分比
  * 呈现；这样既保留当前 IPC 形状，也不会让长耗时阶段看起来卡死在 10%。
+ *
+ * Runtime 会为 `uv.download` 发真实字节百分比，且写入末块时必定回报一次 100；但一个界面段
+ * 里装着好几个 Runtime stage（`uv.download` 之后还有校验、解压、`python.*`），段没结束就
+ * 不能让渲染层看到 100，所以 running 的百分比钳在 [10, 99]，100 只由段收口发出。段内进度
+ * 还要单调：镜像轮换会让下载从 0 重来，后续无 percent 的事件也不能把数字压回段起始值。
  */
 export class BootstrapProgressBridge {
   private index = -1
   private closed = false
+  /** 当前段已经发出过的最高进度；进新段时重置，保证段内只增不减。 */
+  private stageProgress = STAGE_STARTED_PROGRESS
 
   constructor(private readonly emit: (update: BootstrapProgressUpdate) => void) {}
 
@@ -299,20 +306,27 @@ export class BootstrapProgressBridge {
     if (target > this.index) {
       this.closeStagesBefore(target)
       this.index = target
+      // 段刚开始时若已有真实百分比就照发，这是 dev 既有行为；只是同样受 [10, 99] 约束，
+      // 并作为本段单调递增的起点。
+      this.stageProgress =
+        percent === undefined ? STAGE_STARTED_PROGRESS : clampRunningPercent(percent)
       this.emit({
         stage: RUNTIME_BOOTSTRAP_STAGE_ORDER[target],
         status: 'started',
-        progress: percent === undefined ? STAGE_STARTED_PROGRESS : clampPercent(percent),
+        progress: this.stageProgress,
         message,
         indeterminate: percent === undefined,
       })
       return
     }
 
+    if (percent !== undefined) {
+      this.stageProgress = Math.max(this.stageProgress, clampRunningPercent(percent))
+    }
     this.emit({
       stage: RUNTIME_BOOTSTRAP_STAGE_ORDER[target],
       status: 'running',
-      progress: percent === undefined ? STAGE_STARTED_PROGRESS : clampPercent(percent),
+      progress: this.stageProgress,
       message,
       indeterminate: percent === undefined,
     })
@@ -353,9 +367,10 @@ export class BootstrapProgressBridge {
   }
 }
 
-function clampPercent(percent: number): number {
+/** running 途中的百分比钳在 [段起始值, 99]：100 留给段收口，避免段内多个 stage 提前显示完成。 */
+function clampRunningPercent(percent: number): number {
   if (!Number.isFinite(percent)) return STAGE_STARTED_PROGRESS
-  return Math.min(100, Math.max(0, Math.round(percent)))
+  return Math.min(99, Math.max(STAGE_STARTED_PROGRESS, Math.round(percent)))
 }
 
 // ==================== 结果 ====================

--- a/res/version.json
+++ b/res/version.json
@@ -54,6 +54,7 @@
                 "开发流程 禁止 AI 助手协助 force push by [@Craun718](https://github.com/Craun718)"
             ],
             "修复BUG": [
+                "Runtime 接入 修复首次初始化时 uv 下载完成瞬间「安装 Python」被显示为完成、随后进度又倒退的问题",
                 "修复启动界面「查看日志」打开的窗口一片空白、后端启动失败时没有查看日志入口、出错说明文字贴在窗口顶部，以及日志文件打不开时没有任何提示（历史记录页还会误报「日志文件已打开」）的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复深色模式下初始化界面连同标题栏整体变暗的问题",
                 "OK-NTE专项 加固切换账号流程：预防弹窗及屏保等意外情况 by [@AthenaHibou](https://github.com/AthenaHibou)",


### PR DESCRIPTION
## 问题

Runtime 自 `5deb1d8` 起会为 `uv.download` 发真实字节百分比，且下载器在写入末块时**必定**强制回报一次 100。桥接层原样透传，`useInitializationFlow` 见到 `>= 100` 就把当前段标成完成——**uv 下载完末字节的瞬间「安装 Python」就显示完成**，而 SHA-256 校验、解压、`uv --version` 实测都还没跑；紧接着 `python.*` 的事件没有 percent，进度又被压回段起始值 10。

`repair` 与 `environment ensure` 链路中间没有 workspace 段隔开，`python.*` 直接落回同一段，所以这个倒退会停满整个 Python 重装（受限网络下是 20.9 MiB 的下载时长）。镜像轮换让下载从 0 重来时，界面还会出现可见的百分比倒退。

## 改动

- running 的百分比钳在 `[10, 99]`，100 只由段收口发出——一个界面段里装着好几个 Runtime stage，段没结束就不能让渲染层看到 100
- 段内记录已发出的最高进度，保证只增不减
- 段开始时带着真实百分比仍照发（#570 起的既有行为），只是同样受上限约束

只改桥接层与它的测试，渲染层未动。

## 本地验证

`D:\...\frontend`，corepack yarn 4.9.1 / vitest 4.1.9：

- `corepack yarn test`：44 文件 / 414 用例，413 通过
- `corepack yarn typecheck`：exit 0
- `corepack yarn lint`：exit 0

新增三条桥接层用例（末块 100 不提前收口、repair 顺序不倒退、镜像轮换不倒退），在改实现前均为红。

两点需要说明：

1. **另对齐了两条既有期望值**：`repository started` 的 `progress` 10 → 43、`dependency started` 的 `toEqual` 补 `indeterminate: true`。这两条自 #570 起就与实现不符、**在 dev 基线上本来就是红的**，本次未改变任何行为。
2. **`backendService.test.ts > managed 模式 > 不传 --repo…` 5 秒超时是基线 `48ed4ccc` 上的既有失败**：把本 PR 改动的两个文件临时换回 dev 原版复跑，仍然红。本 PR 不处理。

未做：没有真机跑过带真实字节进度的 Runtime 初始化看界面表现，结论来自单元测试与渲染层代码路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

通过将 100% 保留给已完成的阶段，并防止阶段内的进度回退，确保运行时引导进度准确。

Bug 修复：
- 防止运行时下载完成百分比过早将 Python 安装进度阶段标记为已完成。
- 在下载重试以及后续不带百分比的事件发生时，保持每个引导阶段内的进度单调递增。

增强功能：
- 将进行中的进度保持在 100% 以下，并仅将 100% 保留给阶段完成，同时保留实际的起始百分比。

测试：
- 添加桥接测试，覆盖下载完成处理、修复进度单调性和镜像轮换重试。

维护：
- 根据当前行为调整现有进度桥接测试的预期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep runtime bootstrap progress accurate by reserving 100% for completed segments and preventing progress regressions within a segment.

Bug Fixes:
- Prevent runtime download completion percentages from prematurely marking the Python installation progress segment as complete.
- Preserve monotonic progress within each bootstrap segment across download retries and subsequent events without percentages.

Enhancements:
- Keep running progress below 100 and reserve 100 exclusively for segment completion while preserving real starting percentages.

Tests:
- Add bridge tests covering download completion handling, repair progress monotonicity, and mirror-rotation retries.

Chores:
- Align existing progress bridge test expectations with current behavior.

</details>