### PR TITLE
fix(maa): 修复关闭理智作战后活动关优先任务从任务队列消失

### DIFF
--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -833,10 +833,10 @@ class AutoProxyTask(TaskExecuteBase):
         source_queue = gui_new_set["Configurations"]["Default"].get("TaskQueue", [])
         if not isinstance(source_queue, list):
             source_queue = []
+        # 活动关优先是独立任务，仅由自身开关控制，不受理智作战开关影响
         activity_stage = None
         if (
             self.mode == "Routine"
-            and self.task_dict["Fight"]
             and self.cur_user_config.get("Task", "IfActivityFirst")
         ):
             stage_info = await Config.get_stage_info(

--- a/res/version.json
+++ b/res/version.json
@@ -109,7 +109,8 @@
                 "MFW专项 从新链路回退到旧链路后准备项目运行环境时，改为直接复用 Runtime 已经装好的 uv，不再要求用户自己再准备一份 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 准备运行环境确实找不到 uv 时改为给出可照做的中文提示，写明 uv.exe 该放的完整路径，以及本机已有完整 Python 3.12 时可改设环境变量跳过下载 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 修复脚本侧强制停止任务（如 MaaEnd 分辨率不达标时的强停）被记成「任务完成」的问题：现在被强停的任务按失败记录，本轮剩余任务不再投递，不会再出现整轮一件事没做却报成全部成功 by [@qiyinxi](https://github.com/qiyinxi)",
-                "MAA专项 修复 MAA 卡死后不会被判定为超时、任务一直挂着的问题：MAA 每隔一段时间输出的日志停滞提示被当成任务仍在推进，把超时计时反复重置，剿灭等超时阈值长于提示间隔的模式永远等不到超时；现已识别新旧两版 MAA 的该提示，MAA 的五种界面语言均生效 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MAA专项 修复 MAA 卡死后不会被判定为超时、任务一直挂着的问题：MAA 每隔一段时间输出的日志停滞提示被当成任务仍在推进，把超时计时反复重置，剿灭等超时阈值长于提示间隔的模式永远等不到超时；现已识别新旧两版 MAA 的该提示，MAA 的五种界面语言均生效 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MAA专项 修复关闭理智作战后活动关优先任务一并从任务队列中消失的问题 by [@1w1w11w1](https://github.com/1w1w11w1)"
             ]
         },
         "v5.5.0-beta.2": {
@@ -178,7 +179,7 @@
                 "修复 MaaFW 单个任务失败时运行日志不即时提示、要等整轮跑完才能看到的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 HSR 未配置 SRA 路径时多个用户会静默跑在同一个已登录账号上的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 MaaFW 游戏启动失败后仍继续投递剩余任务、空转到各自超时的问题，改为直接报错并进入下一次重试 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)"
+                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)",
             ]
         },
         "v5.5.0-beta.1": {


### PR DESCRIPTION
## 摘要

- 关闭「理智作战」开关时，即使「活动关优先」已开启，活动关优先任务也不会写入 MAA 的实际任务队列，导致活动关不生效
- 现在活动关优先仅由其自身的开关控制，与「理智作战」开关互不影响

已在 res/version.json 的 v5.5.0-beta.3 节补充用户可见的修复记录。

## Sourcery 总结

使优先活动任务的调度独立于理智操作设置，确保已配置的活动阶段不会从 MAA 队列中被移除。

错误修复：
- 当禁用理智操作时，确保优先活动任务仍保留在 MAA 任务队列中，以便按配置执行活动阶段。

改进：
- 使优先活动任务的选择仅取决于其自身的配置开关，不受理智操作开关影响。

杂项：
- 在 5.5.0-beta.3 版本中为该修复添加面向用户的发布说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep activity-first task scheduling independent from the sanity-operation setting so configured activity stages are not dropped from the MAA queue.

Bug Fixes:
- Ensure activity-first tasks remain in the MAA task queue when sanity operations are disabled, so activity stages are executed as configured.

Enhancements:
- Make activity-first task selection depend solely on its own configuration switch, independently of the sanity-operation switch.

Chores:
- Add a user-visible release note for the fix in version 5.5.0-beta.3.

</details>