### PR TITLE
fix(version): 去掉 version.json 里导致解析失败的尾逗号

### DIFF
--- a/res/version.json
+++ b/res/version.json
@@ -179,7 +179,7 @@
                 "修复 MaaFW 单个任务失败时运行日志不即时提示、要等整轮跑完才能看到的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 HSR 未配置 SRA 路径时多个用户会静默跑在同一个已登录账号上的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复 MaaFW 游戏启动失败后仍继续投递剩余任务、空转到各自超时的问题，改为直接报错并进入下一次重试 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复 MaaFW 用户级通知配置形同虚设的问题，运行结束后按用户自己配置的渠道推送统计信息 by [@qiyinxi](https://github.com/qiyinxi)"
             ]
         },
         "v5.5.0-beta.1": {


### PR DESCRIPTION
`v5.5.0-beta.2` 的 `修复BUG` 数组末尾多了一个逗号，`res/version.json` 当前不是合法 JSON：

```
$ python -m json.tool res/version.json
Expecting value: line 183 column 13 (char 20116)
```

逐个提交回溯，是 `0c53faf2`（#605）引入的，在它之前的每个提交都合法：

```
OK  6371d062 chore(version): mark PR entry contributors
坏  0c53faf2 fix(maa): 修复关闭理智作战后活动关优先任务从任务队列消失
```

**后果**：`检查 version.json 变更` 这条 CI 对所有基于当前 dev 的 PR 都会红。

只删这一个逗号，不走 `json.load` + `json.dumps` 重写文件——那会顺带改动无关的缩进与换行。差异一行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- 修复 res/version.json 中的尾逗号，使文件恢复为合法 JSON 并通过相关校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复 res/version.json 中的尾逗号，使文件恢复为合法 JSON 并通过相关校验。

</details>