### PR TITLE
refactor(home): 首页卫星图标改从全局脚本图标表取，新增专项不会再漏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@
 - BetterGI专项 清理未达提交规范的测试文件及其格式、静态检查问题，并移除误提交的 npm 镜像源 by [@1w1w11w1](https://github.com/1w1w11w1)
 - BetterGI专项 重新生成与后端接口定义脱节的前端接口代码 by [@qiyinxi](https://github.com/qiyinxi)
 - 开发流程 禁止 AI 助手协助 force push by [@Craun718](https://github.com/Craun718)
+- 首页卫星的图标改从全局脚本图标表取，新增脚本专项时不会再漏掉主页卫星
 
 ## [v5.5.0-beta.2] - 2026-08-31
 

--- a/frontend/src/composables/satellite-config.test.ts
+++ b/frontend/src/composables/satellite-config.test.ts
@@ -1,9 +1,40 @@
 import { describe, expect, it } from 'vitest'
 import { centerIconUrl, satelliteModules } from './satellite-config'
+import { SCRIPT_LOGOS } from '@/utils/scriptLogos'
+import type { ScriptType } from '@/types/script'
+
+/**
+ * 主页卫星历史上漏过三次（HSR、OK-NTE 由 4fb31ef5 事后补，MaaFW 由 a5cfad20 事后补），
+ * 原因是这里维护了一份和 SCRIPT_LOGOS 平行的脚本类型清单，少一个不会报错。现在图标统一
+ * 从 SCRIPT_LOGOS 取，这些用例负责钉住「除显式排除的以外，每个脚本类型都有卫星」。
+ */
+const EXPECTED_EXCLUSIONS: readonly ScriptType[] = ['General']
 
 describe('satellite icon config', () => {
-  it('loads the center and OK-WW icons from root assets', () => {
+  it('中心图标可用', () => {
     expect(centerIconUrl).not.toBe('')
-    expect(satelliteModules.some(module => module.scriptType === 'Okww')).toBe(true)
+  })
+
+  it('除显式排除的以外，每个脚本类型都有一颗卫星', () => {
+    const allTypes = Object.keys(SCRIPT_LOGOS) as ScriptType[]
+    const expected = allTypes.filter(type => !EXPECTED_EXCLUSIONS.includes(type))
+    const actual = satelliteModules.map(module => module.scriptType)
+
+    expect([...actual].sort()).toEqual([...expected].sort())
+  })
+
+  it('每颗卫星都有非空图标', () => {
+    for (const module of satelliteModules) {
+      expect(module.iconUrl, `${module.scriptType} 缺少图标`).not.toBe('')
+    }
+  })
+
+  it('通用脚本不上轨道，因为它的图标就是中心图标', () => {
+    expect(satelliteModules.some(module => module.scriptType === 'General')).toBe(false)
+    expect(SCRIPT_LOGOS.General).toBe(centerIconUrl)
+  })
+
+  it('MAA 排在第一位，未列入顺序表的类型排在后面', () => {
+    expect(satelliteModules[0]?.scriptType).toBe('MAA')
   })
 })

--- a/frontend/src/composables/satellite-config.ts
+++ b/frontend/src/composables/satellite-config.ts
@@ -1,4 +1,6 @@
+import centerIcon from '@/assets/AUTO-MAS.ico'
 import type { ScriptType } from '@/types/script'
+import { SCRIPT_LOGOS } from '@/utils/scriptLogos'
 
 export interface SatelliteModule {
   scriptType: ScriptType
@@ -6,32 +8,22 @@ export interface SatelliteModule {
   enabled: boolean
 }
 
-const iconModules = import.meta.glob<{ default: string }>(['@/assets/*.png', '@/assets/*.ico'], {
-  eager: true,
-  query: 'url',
-})
+/**
+ * 不上轨道的脚本类型。
+ *
+ * 通用脚本在 SCRIPT_LOGOS 里用的就是 AUTO-MAS 自己的图标，也就是这圈卫星的中心图标，
+ * 放上去会出现一颗和中心一模一样的卫星。
+ */
+const EXCLUDED_FROM_ORBIT: readonly ScriptType[] = ['General']
 
-function getIconUrl(filename: string): string {
-  const key = Object.keys(iconModules).find(k => k.endsWith(`/${filename}`))
-  if (!key) return ''
-  const mod = iconModules[key]
-  return typeof mod === 'string' ? mod : (mod as { default: string }).default
-}
-
-const filenameToScriptType: Record<string, ScriptType> = {
-  'MAA.png': 'MAA',
-  'SRC.png': 'SRC',
-  'M9A.png': 'M9A',
-  'MaaEnd.png': 'MaaEnd',
-  'ok-ww.ico': 'Okww',
-  'ok-nte.ico': 'OkNte',
-  'hsr.png': 'HSR',
-  'maafw.png': 'MaaFW',
-  'bettergi.ico': 'BetterGI',
-  'zzz-od.ico': 'ZzzOd',
-}
-
-const iconFilenames: ScriptType[] = [
+/**
+ * 卫星在轨道上的排列顺序。
+ *
+ * 只影响观感，不是白名单：没列进来的脚本类型排在后面，所以新增脚本类型时不用动这里也
+ * 会自动出现在主页上。图标来源统一走 SCRIPT_LOGOS —— 它声明成 `Record<ScriptType, string>`，
+ * 新增脚本类型时不补图标会当场 typecheck 报错，不会像以前那样悄悄漏掉。
+ */
+const ORBIT_ORDER: readonly ScriptType[] = [
   'MAA',
   'SRC',
   'M9A',
@@ -44,15 +36,20 @@ const iconFilenames: ScriptType[] = [
   'ZzzOd',
 ]
 
-export const satelliteModules: SatelliteModule[] = iconFilenames
-  .map(type => {
-    const filename = Object.entries(filenameToScriptType).find(([, t]) => t === type)?.[0] ?? ''
-    return {
-      scriptType: type,
-      iconUrl: getIconUrl(filename),
-      enabled: true,
-    }
-  })
-  .filter(module => module.iconUrl !== '')
+function orbitRank(type: ScriptType): number {
+  const index = ORBIT_ORDER.indexOf(type)
+  return index === -1 ? ORBIT_ORDER.length : index
+}
 
-export const centerIconUrl = getIconUrl('AUTO-MAS.ico')
+export const satelliteModules: SatelliteModule[] = (
+  Object.keys(SCRIPT_LOGOS) as ScriptType[]
+)
+  .filter(type => !EXCLUDED_FROM_ORBIT.includes(type))
+  .sort((left, right) => orbitRank(left) - orbitRank(right))
+  .map(type => ({
+    scriptType: type,
+    iconUrl: SCRIPT_LOGOS[type],
+    enabled: true,
+  }))
+
+export const centerIconUrl = centerIcon

--- a/res/version.json
+++ b/res/version.json
@@ -138,7 +138,8 @@
                 "新增 GitHub Issue 模板，Bug 反馈按脚本专项、MaaFW 专项与通用问题分区，并附需求建议等模板与常见问题、文档站、官方群链接 by [@qiyinxi](https://github.com/qiyinxi)",
                 "BetterGI专项 清理未达提交规范的测试文件及其格式、静态检查问题，并移除误提交的 npm 镜像源 by [@1w1w11w1](https://github.com/1w1w11w1)",
                 "BetterGI专项 重新生成与后端接口定义脱节的前端接口代码 by [@qiyinxi](https://github.com/qiyinxi)",
-                "开发流程 禁止 AI 助手协助 force push by [@Craun718](https://github.com/Craun718)"
+                "开发流程 禁止 AI 助手协助 force push by [@Craun718](https://github.com/Craun718)",
+                "首页卫星的图标改从全局脚本图标表取，新增脚本专项时不会再漏掉主页卫星"
             ]
         },
         "v5.5.0-beta.2": {


### PR DESCRIPTION
主页卫星的脚本类型清单是手工维护的，和 `SCRIPT_LOGOS` 平行存在。它是普通数组，少一个不报错；末尾还有一句 `.filter(module => module.iconUrl !== '')`，图标文件名写错就静默丢掉，连日志都没有。

因此漏过三次：

```
4fb31ef5  hotfix: 补充NTE新主页入口，补充HSR和NTE的卫星图
a5cfad20  fix(home): 首页卫星补上 MaaFW，否则它跑起来首页没有反馈
```

改成从 `SCRIPT_LOGOS` 取图标。它声明成 `Record<ScriptType, string>`，新增脚本类型时不补图标会当场 typecheck 报错，漏不掉。

原有的轨道排列顺序保留，但它降级成纯观感项、不再是白名单——没列进顺序表的类型排在后面，所以下一个新脚本不动这里也会自动上轨。

通用脚本仍然不上轨道，理由写进了注释：它在 `SCRIPT_LOGOS` 里用的就是 `AUTO-MAS.ico`，也就是卫星圈的中心图标，放上去会出现一颗和中心一模一样的卫星。

测试从「只断言 Okww 存在」改成钉住「除显式排除的以外，每个脚本类型都有卫星」。

**用户可见行为不变**：仍是同样 10 颗卫星、同样顺序，所以 changelog 记在「开发流程」。

## 验证

| 检查 | 结果 |
| --- | --- |
| `yarn vitest run src/composables/satellite-config.test.ts` | 5 passed |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

从集中式脚本图标注册表中获取首页卫星图标，确保新脚本类型不会被悄然遗漏。

错误修复：
- 确保除明确排除的通用脚本外，每种脚本类型都作为首页卫星显示，并且具有非空图标。

增强功能：
- 使用集中式脚本图标注册表提供首页卫星图标，同时保留现有的轨道顺序，并自动将新添加的类型排列在之后。
- 强化卫星配置测试，以检测缺失的脚本覆盖范围和无效图标。

测试：
- 更新卫星配置测试，以验证完整的脚本覆盖范围、图标可用性、排除项和排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Source homepage satellite icons from the centralized script icon registry so new script types cannot be silently omitted.

Bug Fixes:
- Ensure every script type except the explicitly excluded general script appears as a homepage satellite with a non-empty icon.

Enhancements:
- Use the centralized script icon registry for homepage satellite icons while preserving the existing orbit order and automatically placing newly added types afterward.
- Strengthen satellite configuration tests to detect missing script coverage and invalid icons.

Tests:
- Update satellite configuration tests to validate complete script coverage, icon availability, exclusions, and ordering.

</details>