### PR TITLE
fix(zzzod): 清理启动链路泄漏的 uv 环境变量

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 
 - Emulator 2.0 修复模拟器已经在运行时不打开游戏、以及雷电 0 号与 MuMu 同时运行时操作会打到另一台模拟器上的问题 by [@qiyinxi](https://github.com/qiyinxi)
 - 日志采集 修复任务运行期间脚本日志按天滚动（跨零点）后，零点前的运行日志历史与节点详情丢失的问题 by [@AthenaHibou](https://github.com/AthenaHibou)
+- 修复绝区零一条龙由 MAS 运行时启动器报「运行环境同步失败」无法启动，且「自动」启动器模式失败后不切换另一启动器的问题
 - 社区签到结果统一附加到任务报告，修复重复推送并按通知渠道展示奖励与失败原因 by [@Lance0174](https://github.com/Lance0174)
 - Runtime 接入 修复首次初始化时 uv 下载完成瞬间「安装 Python」被显示为完成、随后进度又倒退的问题 by [@qiyinxi](https://github.com/qiyinxi)
 - 修复启动界面「查看日志」打开的窗口一片空白、后端启动失败时没有查看日志入口、出错说明文字贴在窗口顶部，以及日志文件打不开时没有任何提示（历史记录页还会误报「日志文件已打开」）的问题 by [@qiyinxi](https://github.com/qiyinxi)

--- a/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
@@ -498,6 +498,7 @@ def _project_interface_hash(project_path: Path) -> str:
 def _build_agent_env_for_pip(project_path: Path) -> dict[str, str]:
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    env.pop("UV_PROJECT_ENVIRONMENT", None)
     env.pop("PYTHONHOME", None)
     env.pop("PYTHONUSERBASE", None)
     env.pop("PIP_TARGET", None)

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
@@ -1877,6 +1877,7 @@ class MaaFWRunner:
 
         # 清理 AUTO-MAS 自身环境变量，防止 agent 串到 MAS .venv
         env.pop("VIRTUAL_ENV", None)
+        env.pop("UV_PROJECT_ENVIRONMENT", None)
         env.pop("PYTHONHOME", None)
         env.pop("PYTHONUSERBASE", None)
         env.pop("PIP_TARGET", None)
@@ -2219,6 +2220,7 @@ class MaaFWRunner:
         """
         env = os.environ.copy()
         env.pop("VIRTUAL_ENV", None)
+        env.pop("UV_PROJECT_ENVIRONMENT", None)
         env.pop("PYTHONHOME", None)
         env.pop("PYTHONUSERBASE", None)
         env.pop("PIP_TARGET", None)

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
@@ -1587,6 +1587,10 @@ def _run_with_source_rotation(
 def _clean_process_environment() -> dict[str, str]:
     env = os.environ.copy()
     for name in (
+        # 启动链路（Runtime → uv run → 后端）注入的 venv 指向，交给 uv/pip
+        # 前必须剔除，否则外部 uv 会把项目环境解析到 MAS 的 runtime venv 上
+        "VIRTUAL_ENV",
+        "UV_PROJECT_ENVIRONMENT",
         "PYTHONHOME",
         "PYTHONUSERBASE",
         "PYTHONPATH",

--- a/app/task/ZzzOd/AutoProxy.py
+++ b/app/task/ZzzOd/AutoProxy.py
@@ -993,8 +993,12 @@ class AutoProxyTask(TaskExecuteBase):
                     break
 
                 # 自动模式：启动器未能启动（无应用层日志且运行记录无变化）时，
-                # 自动切换到另一启动器并占用下一轮重试
+                # 自动切换到另一启动器并占用下一轮重试。切换后必须先中止上一
+                # 个仍在运行的启动器进程（如卡在「按回车键退出」的错误提示），
+                # 否则下一轮 open_process 会因进程管理器仍被占用而抛
+                # 「无法同时管理多个进程」，切换永远不会真正发生
                 if await self._maybe_switch_launcher(log):
+                    await self.kill_managed_process()
                     continue
 
                 logger.warning(

--- a/app/task/ZzzOd/AutoProxy.py
+++ b/app/task/ZzzOd/AutoProxy.py
@@ -993,12 +993,14 @@ class AutoProxyTask(TaskExecuteBase):
                     break
 
                 # 自动模式：启动器未能启动（无应用层日志且运行记录无变化）时，
-                # 自动切换到另一启动器并占用下一轮重试。切换后必须先中止上一
-                # 个仍在运行的启动器进程（如卡在「按回车键退出」的错误提示），
-                # 否则下一轮 open_process 会因进程管理器仍被占用而抛
-                # 「无法同时管理多个进程」，切换永远不会真正发生
+                # 自动切换到另一启动器并占用下一轮重试。切换会先改写
+                # launcher_exe_path，中止残留进程必须用切换前的旧路径显式传入
+                # （如卡在「按回车键退出」的错误提示），否则下一轮 open_process
+                # 会因进程管理器仍被占用而抛「无法同时管理多个进程」，切换永远
+                # 不会真正发生
+                stale_launcher_path = self.launcher_exe_path
                 if await self._maybe_switch_launcher(log):
-                    await self.kill_managed_process()
+                    await self.kill_managed_process(exe_path=stale_launcher_path)
                     continue
 
                 logger.warning(
@@ -1455,11 +1457,15 @@ class AutoProxyTask(TaskExecuteBase):
         except Exception:
             pass
 
-    async def kill_managed_process(self, kill_game: bool = False) -> None:
+    async def kill_managed_process(
+        self, kill_game: bool = False, exe_path: Path | None = None
+    ) -> None:
         """中止 ZZZ-OD 启动器进程；kill_game 为真时由 MAS 结束游戏进程。
 
         游戏由启动器拉起、可能不在启动器进程树内（进程管理器跟踪不到），
         按进程名结束——手动停止调度时同样收尾游戏，不依赖一条龙 --close-game。
+        exe_path 显式指定按路径兜底结束的目标，默认当前 launcher_exe_path；
+        切换启动器后旧进程仍在时，必须传切换前的旧路径。
         """
 
         if self.launcher_process_manager is not None:
@@ -1469,9 +1475,10 @@ class AutoProxyTask(TaskExecuteBase):
                 logger.opt(exception=True).warning(
                     f"通过进程管理器中止 ZZZ-OD 进程失败: {e}"
                 )
-        if self.launcher_exe_path is not None:
+        fallback_path = exe_path if exe_path is not None else self.launcher_exe_path
+        if fallback_path is not None:
             try:
-                await System.kill_process(self.launcher_exe_path)
+                await System.kill_process(fallback_path)
             except Exception as e:
                 logger.opt(exception=True).warning(f"中止 ZZZ-OD 主进程失败: {e}")
         if kill_game:

--- a/main.py
+++ b/main.py
@@ -41,6 +41,15 @@ from app.utils import get_logger, is_supervised, resource_path, sanitize_log_mes
 
 logger = get_logger("主程序")
 
+# 清理启动链路（Runtime → uv run → 后端）注入的 Python/uv 环境变量。MAS 自身
+# 不消费它们，但进程环境会原样传给所有被 MAS 拉起的子进程（专项脚本启动器、
+# 提权 ShellExecute 等）：外部脚本自己的 uv 会把项目环境解析到 MAS 的 runtime
+# venv 上、甚至尝试删除该目录（曾导致 ZzzOd 启动器报「运行环境同步失败」）
+for _leaked_env in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT"):
+    _leaked_value = os.environ.pop(_leaked_env, None)
+    if _leaked_value is not None:
+        logger.info(f"已清理启动链路注入的环境变量: {_leaked_env}={_leaked_value}")
+
 # 正式版固定端口；开发环境错开一位，避免与用户已装正式版抢占同一端口
 DEFAULT_HTTP_PORT = 36163
 DEV_HTTP_PORT = 36164

--- a/main.py
+++ b/main.py
@@ -43,12 +43,30 @@ logger = get_logger("主程序")
 
 # 清理启动链路（Runtime → uv run → 后端）注入的 Python/uv 环境变量。MAS 自身
 # 不消费它们，但进程环境会原样传给所有被 MAS 拉起的子进程（专项脚本启动器、
-# 提权 ShellExecute 等）：外部脚本自己的 uv 会把项目环境解析到 MAS 的 runtime
-# venv 上、甚至尝试删除该目录（曾导致 ZzzOd 启动器报「运行环境同步失败」）
-for _leaked_env in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT"):
-    _leaked_value = os.environ.pop(_leaked_env, None)
-    if _leaked_value is not None:
-        logger.info(f"已清理启动链路注入的环境变量: {_leaked_env}={_leaked_value}")
+# 提权 ShellExecute 等）：外部脚本自己的 uv/pip 会把环境解析到 MAS 的 runtime
+# venv 上、甚至尝试删除该目录（曾导致 ZzzOd 启动器报「运行环境同步失败」并
+# 损坏 venv）。uv run 实际注入 VIRTUAL_ENV、UV_PROJECT_ENVIRONMENT、UV、
+# UV_RUN_RECURSION_DEPTH 与 PATH 前置 <venv>/Scripts 五样，逐一摘除
+_leaked_venv = os.environ.pop("VIRTUAL_ENV", None)
+for _leaked_env in ("UV", "UV_PROJECT_ENVIRONMENT", "UV_RUN_RECURSION_DEPTH"):
+    os.environ.pop(_leaked_env, None)
+if _leaked_venv is not None:
+    logger.info(f"已清理启动链路注入的环境变量: VIRTUAL_ENV={_leaked_venv}")
+    # <venv>/Scripts（内含 python.exe/pip.exe）插在 PATH 里不摘的话，任何经
+    # PATH 裸调 python/pip 的子进程都会命中 MAS 的 runtime venv；按该值精确
+    # 摘除对应段，PATH 其余内容不动
+    _venv_scripts = os.path.normcase(
+        os.path.join(_leaked_venv, "Scripts" if os.name == "nt" else "bin").rstrip("\\/")
+    )
+    _path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    _kept_entries = [
+        _entry
+        for _entry in _path_entries
+        if os.path.normcase(_entry.rstrip("\\/")) != _venv_scripts
+    ]
+    if _kept_entries != _path_entries:
+        os.environ["PATH"] = os.pathsep.join(_kept_entries)
+        logger.info(f"已从 PATH 摘除启动链路注入的段: {_venv_scripts}")
 
 # 正式版固定端口；开发环境错开一位，避免与用户已装正式版抢占同一端口
 DEFAULT_HTTP_PORT = 36163

--- a/res/version.json
+++ b/res/version.json
@@ -73,6 +73,7 @@
             "修复": [
                 "Emulator 2.0 修复模拟器已经在运行时不打开游戏、以及雷电 0 号与 MuMu 同时运行时操作会打到另一台模拟器上的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "日志采集 修复任务运行期间脚本日志按天滚动（跨零点）后，零点前的运行日志历史与节点详情丢失的问题 by [@AthenaHibou](https://github.com/AthenaHibou)",
+                "修复绝区零一条龙由 MAS 运行时启动器报「运行环境同步失败」无法启动，且「自动」启动器模式失败后不切换另一启动器的问题",
                 "社区签到结果统一附加到任务报告，修复重复推送并按通知渠道展示奖励与失败原因 by [@Lance0174](https://github.com/Lance0174)",
                 "Runtime 接入 修复首次初始化时 uv 下载完成瞬间「安装 Python」被显示为完成、随后进度又倒退的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复启动界面「查看日志」打开的窗口一片空白、后端启动失败时没有查看日志入口、出错说明文字贴在窗口顶部，以及日志文件打不开时没有任何提示（历史记录页还会误报「日志文件已打开」）的问题 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
- main.py 启动时剔除 Runtime/uv run 注入的 VIRTUAL_ENV 与 UV_PROJECT_ENVIRONMENT： 这两个变量会随进程环境传给所有被 MAS 拉起的子进程，外部脚本自己的 uv 会把 项目环境解析到 MAS 运行时 venv 上、甚至尝试删除该目录（ZzzOd 启动器报 「运行环境同步失败」并损坏 venv 的根因）
- ZzzOd 自动模式切换启动器前先中止残留的卡死进程，避免下一轮 open_process 抛「无法同时管理多个进程」，切换永远不会真正发生
- MaaFW runtime pool 环境剔除名单补充上述两个变量，防御同类泄漏

## Summary by Sourcery

清理 MAS 启动链路中的虚拟环境污染，并确保 ZzzOd 自动模式能够可靠切换启动器。

Bug Fixes:
- 修复 MAS 启动链路泄漏 Python/uv 虚拟环境变量及 PATH，避免外部脚本错误复用或破坏 MAS runtime 环境。
- 修复 ZzzOd 自动启动器切换失败后因残留进程占用而无法切换的问题。

Enhancements:
- 加强 MaaFW runtime、runner 与 pip 环境构建时的环境隔离，防止 MAS 的虚拟环境变量传递给外部项目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

清理 MAS 启动链路中的虚拟环境污染，并确保 ZzzOd 自动模式能够可靠切换启动器。

Bug Fixes:
- 修复 MAS 启动链路泄漏 Python/uv 虚拟环境变量及 PATH，避免外部脚本错误复用或破坏 MAS runtime 环境。
- 修复 ZzzOd 自动启动器切换失败后因残留进程占用而无法切换的问题。

Enhancements:
- 加强 MaaFW runtime、runner 与 pip 环境构建时的环境隔离，防止 MAS 的虚拟环境变量传递给外部项目。

</details>

<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



</details>