### PR TITLE
ci: 同步 dev 分支的 GitHub 工作流

### DIFF
--- a/.github/workflows/append-version-contributor.yml
+++ b/.github/workflows/append-version-contributor.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
 
 concurrency:
   group: version-contributors-dev
@@ -28,30 +27,25 @@ jobs:
           ref: dev
           fetch-depth: 0
 
+      - name: 获取 PR 提交
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"
+
       - name: 设置 Python 环境
         uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.12'
 
-      - name: 标记并提交更新条目贡献者
+      - name: 标记更新条目贡献者
+        id: append
         env:
-          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # 人工合并不受 workflow concurrency 限制。每次都从最新 dev 重算；若推送期间
-          # dev 又前进，就丢弃这次本地提交并重试，避免在旧结果上 rebase 同一个热文件。
-          for attempt in 1 2 3; do
-            git fetch --no-tags origin dev
-            git checkout --detach --force origin/dev
-
-            python - <<'PY'
-          import json
+          python - <<'PY'
           import os
           import subprocess
           import sys
@@ -59,45 +53,40 @@ jobs:
           sys.path.insert(0, "scripts")
           import changelog
 
-          addition = changelog.validate_pr_changelog(
-              changelog.read_changelog_ref(os.environ["PR_BASE_SHA"]),
-              changelog.read_changelog_ref(os.environ["PR_MERGE_SHA"]),
-          )
-          metadata = json.loads(
-              subprocess.check_output(
-                  [
-                      "gh",
-                      "pr",
-                      "view",
-                      os.environ["PR_NUMBER"],
-                      "--json",
-                      "author,commits",
-                  ],
-                  text=True,
-                  encoding="utf-8",
-              )
-          )
-          authors = [metadata["author"]]
-          for commit in metadata["commits"]:
-              authors.extend(commit.get("authors", []))
+          def load(ref: str) -> dict:
+              """取某个 ref 上的 CHANGELOG.md；取不到或格式不对都当作空，不阻断合并后流程。"""
+              try:
+                  content = subprocess.check_output(
+                      ["git", "show", f"{ref}:CHANGELOG.md"],
+                      text=True,
+                      encoding="utf-8",
+                      stderr=subprocess.DEVNULL,
+                  )
+              except subprocess.CalledProcessError:
+                  print(f"{ref} 上没有 CHANGELOG.md，跳过对比")
+                  return {}
+              try:
+                  return changelog.parse_changelog(content)[1]
+              except changelog.ChangelogError as error:
+                  print(f"{ref} 上的 CHANGELOG.md 无法解析，跳过对比：{error}")
+                  return {}
 
-          ignored_logins = {"claude", "copilot"}
-          seen = set()
-          suffixes = []
-          for author in authors:
-              if not isinstance(author, dict):
-                  continue
-              login = author.get("login")
-              key = login.lower() if login else None
-              if (
-                  key is None
-                  or key in seen
-                  or key in ignored_logins
-                  or key.endswith("[bot]")
-              ):
-                  continue
-              seen.add(key)
-              suffixes.append(f" by [@{login}](https://github.com/{login})")
+          base = load(os.environ["PR_BASE_SHA"])
+          head = load(f"origin/pr-{os.environ['PR_NUMBER']}")
+          suffix = f" by [@{os.environ['PR_AUTHOR']}]({os.environ['PR_AUTHOR_URL']})"
+
+          # 本次 PR 新增的条目 = head 有而 base 没有的。按 (版本, 分类, 原文) 三元组记，
+          # 否则同一句话若在旧版本段里也存在，那一条会被一起补上署名。
+          additions = set()
+          for version, categories in head.items():
+              base_categories = base.get(version, {})
+              for category, items in categories.items():
+                  base_items = set(base_categories.get(category, []))
+                  additions.update(
+                      (version, category, item)
+                      for item in items
+                      if item not in base_items
+                  )
 
           _, current, current_dates = changelog.parse_changelog(
               changelog.read_text(changelog.CHANGELOG_PATH)
@@ -107,15 +96,8 @@ jobs:
           for version, categories in current.items():
               for category, items in categories.items():
                   for index, item in enumerate(items):
-                      if (version, category, item) != addition:
-                          continue
-
-                      updated = item
-                      for suffix in suffixes:
-                          if suffix not in updated:
-                              updated = f"{updated}{suffix}"
-                      if updated != item:
-                          items[index] = updated
+                      if (version, category, item) in additions and suffix not in item:
+                          items[index] = f"{item}{suffix}"
                           changed = True
 
           if changed:
@@ -123,21 +105,23 @@ jobs:
                   changelog.CHANGELOG_PATH,
                   changelog.render_changelog(current, current_dates),
               )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"changed={str(changed).lower()}\n")
           PY
-            # 署名写进 CHANGELOG.md 正文后，生成物要跟着重算。
-            python scripts/changelog.py sync
-            git add CHANGELOG.md res/version.json frontend/package.json app/core/config.py pyproject.toml uv.lock
-            if git diff --cached --quiet; then
-              echo "无需补充贡献者署名"
-              exit 0
-            fi
 
-            git commit -m "chore(version): mark PR entry contributors"
-            if git push origin HEAD:dev; then
-              exit 0
-            fi
-            echo "dev 在第 ${attempt} 次提交期间发生变化，重新计算"
-          done
+      # 署名写进 CHANGELOG.md 正文后，res/version.json 要跟着重算。
+      - name: 重新生成版本信息
+        if: steps.append.outputs.changed == 'true'
+        run: python scripts/changelog.py sync
 
-          echo "连续 3 次推送均遇到 dev 更新，未能写入贡献者署名" >&2
-          exit 1
+      - name: 提交贡献者信息
+        if: steps.append.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # sync 只有在 dev 本来就不一致时才会动后四个文件，一并纳入避免 rebase 撞未暂存改动。
+          git add CHANGELOG.md res/version.json frontend/package.json app/core/config.py pyproject.toml uv.lock
+          git commit -m "chore(version): mark PR entry contributors"
+          git pull --rebase origin dev
+          git push origin HEAD:dev

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -28,13 +28,6 @@ permissions:
   contents: write
   actions: write
 
-env:
-  # AUTO-MAS-Project/AUTO-MAS-Runtime 的发布版本，随桌面安装包一起分发。钉死具体版本、不追
-  # latest：Runtime 有自己的发布节奏，本仓库的改动不应该在没有联调的情况下自动带出一个新
-  # Runtime。Runtime 不自更新，只随这里构建的安装包整体升级；本仓库如有依赖 Runtime 新行为
-  # 的改动（T13 系列），必须等 Runtime 一侧先发布对应版本，再手动把这个版本号提上去。
-  RUNTIME_VERSION: v0.1.4
-
 jobs:
 
   build:
@@ -52,6 +45,18 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+
+      - name: 读取 Runtime 版本
+        run: |
+          # 从本次构建所选分支读取独立版本文件，不再依赖默认分支中的工作流常量。
+          $runtimeVersionFile = Join-Path '${{ github.workspace }}' 'res\runtime-version.txt'
+          $runtimeVersion = (Get-Content -LiteralPath $runtimeVersionFile -Raw).Trim()
+          if ($runtimeVersion -notmatch '^v\d+(\.\d+)*([-+][0-9A-Za-z.-]+)?$') {
+            throw "Runtime 版本格式无效：$runtimeVersion"
+          }
+          Add-Content -LiteralPath $env:GITHUB_ENV -Value "RUNTIME_VERSION=$runtimeVersion" -Encoding utf8
+          Write-Host "本次构建使用 Runtime $runtimeVersion"
+        shell: pwsh
 
       - name: 设置 Node.js 环境
         uses: actions/setup-node@v7.0.0
@@ -366,6 +371,23 @@ jobs:
 
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
+
+      - name: 同步发行版分支到 CNB
+        # 同步失败不该阻断发版：本改动进入默认分支之前，dispatch 会因为默认分支上的
+        # sync-cnb.yml 还没有 workflow_dispatch 而被拒，那时这一步必然报错。
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 上一步用 GITHUB_TOKEN 推分支和 tag，而 GITHUB_TOKEN 造成的 push / create
+          # 不会触发 sync-cnb.yml，CNB 上于是没有当版 release/vX.Y.Z 分支。Runtime 首次
+          # 克隆受管工作区按 [cnb, github] 顺序找这个分支，国内用户在 cnb 上找不到、又
+          # 连不上 github，初始化直接卡死（GIT_CLONE_FAILED）。
+          # workflow_dispatch 是该限制的明确例外，可以用 GITHUB_TOKEN 调起。
+          # 在触发本次构建的分支上 dispatch：sync-cnb 的 checkout 用 fetch-depth: 0，
+          # 本来就会取到全部分支与 tag 再整体镜像过去，跑在哪个分支上都能带上刚推的
+          # 发行版分支。
+          gh workflow run sync-cnb.yml --ref "$GITHUB_REF_NAME"
 
       - name: 发布发行版
         uses: softprops/action-gh-release@v3.0.2

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-changelog:
@@ -35,8 +36,6 @@ jobs:
     steps:
       - name: 检出代码
         uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
 
       - name: 设置 Python 环境
         uses: actions/setup-python@v7.0.0
@@ -48,9 +47,17 @@ jobs:
       - name: 检查更新日志格式与版本号一致性
         run: python scripts/changelog.py check
 
-      # HEAD 是 GitHub 为当前 base 与 PR head 生成的合并提交，避免开放中的 PR
-      # 因其他署名提交推进了 base 而被误判为删除历史条目。
-      - name: 检查 PR 恰好新增一条更新日志
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: python scripts/changelog.py check-pr "$PR_BASE_SHA" HEAD
+      - name: 检查 PR 文件列表
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            if (!files.some(file => file.filename === 'CHANGELOG.md')) {
+              core.setFailed('每个 PR 都必须包含对 CHANGELOG.md 的更改。');
+            }

--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -28,6 +28,13 @@ name: Sync to CNB
 on:
   push:
   create:
+  # 发行版分支由 build-app.yml 用 GITHUB_TOKEN 推送，而 GITHUB_TOKEN 造成的 push /
+  # create **不会**触发其它工作流，本工作流因此不会为发版跑一次——CNB 上于是缺当版
+  # release/vX.Y.Z 分支，而 Runtime 首次克隆受管工作区正是按 [cnb, github] 顺序找它。
+  # workflow_dispatch 与 repository_dispatch 是该限制的例外，可以被 GITHUB_TOKEN 显式
+  # 调起，所以 build-app.yml 在推完发行版分支后会 `gh workflow run` 这里。也可以在
+  # Actions 页面手动跑一次，用来给漏同步的历史版本补分支。
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary by Sourcery

同步并强化 GitHub 工作流，改进更新日志贡献者处理、Runtime 版本管理及发行版分支同步。

New Features:
- 使构建流程从分支内的版本文件读取并校验 Runtime 版本。
- 在发行版构建完成后支持手动触发 CNB 同步，以确保发行版分支可用。

Bug Fixes:
- 调整贡献者署名流程，准确标记 PR 新增的更新日志条目并降低与 dev 分支并发更新的冲突。
- 修复使用 GITHUB_TOKEN 推送发行版分支后不会自动同步至 CNB 的问题。

Enhancements:
- 将 PR 更新日志校验改为要求每个 PR 修改 CHANGELOG.md，并移除基于合并提交的单条新增校验。

CI:
- 更新多个 GitHub Actions 工作流的权限、版本读取及跨仓库同步流程。

Deployment:
- 增加发行版分支到 CNB 的显式同步触发机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

同步并强化 GitHub 工作流，改进更新日志贡献者处理、Runtime 版本管理及发行版分支同步。

New Features:
- 使构建流程从分支内的版本文件读取并校验 Runtime 版本。
- 在发行版构建完成后支持手动触发 CNB 同步，以确保发行版分支可用。

Bug Fixes:
- 调整贡献者署名流程，准确标记 PR 新增的更新日志条目并降低与 dev 分支并发更新的冲突。
- 修复使用 GITHUB_TOKEN 推送发行版分支后不会自动同步至 CNB 的问题。

Enhancements:
- 将 PR 更新日志校验改为要求每个 PR 修改 CHANGELOG.md，并移除基于合并提交的单条新增校验。

CI:
- 更新多个 GitHub Actions 工作流的权限、版本读取及跨仓库同步流程。

Deployment:
- 增加发行版分支到 CNB 的显式同步触发机制。

</details>