### PR TITLE
fix(maafw): Agent 隔离 venv 依赖安装接入镜像并让失败可诊断

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - 修复后端就绪前退出时只能反复重试的问题，现同时提供「重建运行环境」入口 by [@qiyinxi](https://github.com/qiyinxi)
 - MAA专项 修复未返回分服关卡数据时用户配置页打不开的问题 by [@qiyinxi](https://github.com/qiyinxi)
 - 模拟器管理 修复部分 MuMu 因命令输出混有日志而无法读取信息的问题 by [@qiyinxi](https://github.com/qiyinxi)
+- MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败
 
 ### 开发流程
 

--- a/app/api/scripts.py
+++ b/app/api/scripts.py
@@ -221,6 +221,7 @@ def _maafw_script_config(script_id: str) -> RuntimeMaaFWConfig:
 # 这两种 CDK 状态不需要额外提示：ok 是正常，absent 在选 GitHub 源时本就无关。
 _MAAFW_CDK_QUIET_STATUSES = frozenset({"ok", "absent"})
 _maafw_update_logger = get_logger("MaaFW 项目更新")
+_maafw_env_logger = get_logger("MFW 运行环境")
 
 
 def _maafw_update_send_log(line: str) -> None:
@@ -1295,6 +1296,13 @@ async def prepare_maafw_agent_env(
                 progress=publish_progress,
             )
         except Exception as exc:
+            # 失败原因此前只活在响应体与 WS 事件里，两边都不落盘：用户报障时
+            # app.log 里一行都没有，只能对着界面截图猜。准备过程的逐行日志
+            # （pip 的 stderr 就在里面）一并记下来，别再丢。
+            _maafw_env_logger.error(f"MFW 运行环境准备失败: {exc}")
+            if logs:
+                detail = "\n".join(sanitize_log_message(str(line)) for line in logs)
+                _maafw_env_logger.error(f"MFW 运行环境准备日志:\n{detail}")
             publish_progress(
                 {
                     "stage": "failed",

--- a/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Callable
 
 from ..automas_maafw_runtime_pool import runtime_managed_uv_executable
+from ..automas_maafw_runtime_pool.installer import (
+    is_package_index_offline,
+    resolve_package_index_candidates,
+)
 from .models import MaaFWAgentCommandPlan, MaaFWAgentEnvPrepareResult
 from .planner import MaaFWAgentEnvError, venv_base_python_missing, venv_python_exe
 
@@ -21,6 +25,9 @@ AGENT_COMPAT_SHIM_DIR_NAME = ".auto_mas_shims"
 PIP_HEALTH_CHECK_TIMEOUT = 15
 PROJECT_PYTHON_HEALTH_TIMEOUT = 15
 PIP_INSTALL_TIMEOUT = 120
+# pip install 本身单独给足余量：与运行池的 RUNTIME_INSTALL_TIMEOUT_SECONDS 对齐，
+# 且每个镜像候选各享一次完整超时。venv 创建与 ensurepip 仍用上面那个。
+PIP_INSTALL_PER_INDEX_TIMEOUT = 300
 VENV_PROBE_TIMEOUT = 30
 # uv 兜底可能需要下载 managed Python,给足余量
 UV_VENV_TIMEOUT = 300
@@ -286,10 +293,15 @@ def _prepare_isolated_venv_env(
     if install_dependencies:
         packages = _load_project_agent_requirements(project_path)
         log(f"[Python环境] 隔离 venv 安装项目依赖: {', '.join(packages)}")
-        if not _pip_install(
+        installed, failure_detail = _pip_install(
             python_exe, packages, cwd=str(project_path), env=test_env, log=log
-        ):
-            raise MaaFWAgentEnvError(f"隔离 venv 依赖安装失败: {python_exe}")
+        )
+        if not installed:
+            # 原来只报解释器路径，用户拿它做不了任何事，真实原因还只写进一个
+            # 没人持久化的 list。带上原因，现有告警条就能自己说明白。
+            raise MaaFWAgentEnvError(
+                f"隔离 venv 依赖安装失败: {failure_detail or python_exe}"
+            )
     else:
         log("[Python环境] 当前调用禁用依赖安装，仅写入隔离 venv manifest")
 
@@ -648,6 +660,27 @@ def _try_ensurepip(
     return False
 
 
+def _pip_index_arg_candidates() -> list[tuple[str, list[str]]]:
+    """按序返回 pip 的索引候选 ``(日志标签, 参数)``，与运行池 installer 同源。
+
+    Runtime 经 AUTO_MAS_MIRROR_PACKAGE_INDEX 注入镜像列表；键存在但为空表示
+    要求完全离线，此时只跑一次 --no-index，绝不联网（运行池遵守这条契约，
+    这里此前不遵守，属于契约漏洞）。用户显式设了 PIP_INDEX_URL 就尊重它，
+    不参与候选轮换——参数留空交给 pip 自己解析，但标签要如实写出用的是哪个，
+    否则日志里会和「谁都没配」长得一模一样。
+    """
+
+    if is_package_index_offline():
+        return [("离线", ["--no-index"])]
+    user_index = str(os.environ.get("PIP_INDEX_URL") or "").strip()
+    if user_index:
+        return [(f"PIP_INDEX_URL={user_index}", [])]
+    candidates = resolve_package_index_candidates()
+    if not candidates:
+        return [("PyPI 默认索引", [])]
+    return [(candidate, ["--index-url", candidate]) for candidate in candidates]
+
+
 def _pip_install(
     python_exe: str,
     packages: list[str],
@@ -655,28 +688,55 @@ def _pip_install(
     cwd: str | None,
     env: dict[str, str],
     log: Callable[[str], None],
-) -> bool:
-    try:
-        result = subprocess.run(
-            [python_exe, "-m", "pip", "install", "--quiet", *packages],
-            capture_output=True,
-            timeout=PIP_INSTALL_TIMEOUT,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=cwd,
-            env=env,
-        )
-        if result.returncode == 0:
-            log(f"[Python环境] pip install 完成: {', '.join(packages)}")
-            return True
-        detail = (result.stderr or result.stdout or "").strip()
-        log(f"[Python环境] pip install 未成功: {detail[:300]}")
-    except subprocess.TimeoutExpired:
-        log(f"[Python环境] pip install 超时 ({PIP_INSTALL_TIMEOUT}s)")
-    except Exception as exc:
-        log(f"[Python环境] pip install 异常: {exc}")
-    return False
+) -> tuple[bool, str]:
+    """安装隔离 venv 依赖，返回 (是否成功, 最后一次失败原因)。
+
+    与运行池的 ``_run_with_source_rotation`` 有一处有意的分歧：那边超时直接抛出、
+    不换源，这里超时也接着试下一个候选。装不上的首要成因就是某个索引连不通，而
+    连不通的典型表现正是超时，不换源等于白轮换。反过来，解释器自己起不来
+    （``OSError``）与索引无关，立即停手，不必对着每个候选各失败一次。
+    """
+
+    last_detail = ""
+    for label, index_args in _pip_index_arg_candidates():
+        try:
+            result = subprocess.run(
+                [
+                    python_exe,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--quiet",
+                    *index_args,
+                    *packages,
+                ],
+                capture_output=True,
+                timeout=PIP_INSTALL_PER_INDEX_TIMEOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=cwd,
+                env=env,
+            )
+            if result.returncode == 0:
+                log(f"[Python环境] pip install 完成 ({label}): {', '.join(packages)}")
+                return True, ""
+            last_detail = (result.stderr or result.stdout or "").strip()
+            log(f"[Python环境] pip install 未成功 ({label}): {last_detail[:300]}")
+        except subprocess.TimeoutExpired:
+            last_detail = f"{label} 超时 ({PIP_INSTALL_PER_INDEX_TIMEOUT}s)"
+            log(
+                f"[Python环境] pip install 超时 ({label}, {PIP_INSTALL_PER_INDEX_TIMEOUT}s)"
+            )
+        except OSError as exc:
+            # 起不了子进程（venv 被删、python.exe 不在了）与索引无关，别再轮换。
+            last_detail = f"无法启动 {python_exe}: {exc}"
+            log(f"[Python环境] pip install 无法启动 ({label}): {exc}")
+            break
+        except Exception as exc:
+            last_detail = f"{label}: {exc}"
+            log(f"[Python环境] pip install 异常 ({label}): {exc}")
+    return False, last_detail[:300]
 
 
 def _python_supports_venv(python: str) -> bool:

--- a/frontend/src/views/EditView/Script/MaaFWScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/MaaFWScriptEdit.vue
@@ -73,7 +73,12 @@
               已就绪的 Agent：{{ envAgents.map(a => a.runtimeKind || '未知').join('、') }}
             </template>
             <template v-if="envFailed" #description>
-              运行环境没准备好，后面几步配了也跑不起来。请检查网络与项目路径后重试。
+              <div>运行环境没准备好，后面几步配了也跑不起来。请检查网络与项目路径后重试。</div>
+              <div v-if="envFailureLogs.length" class="env-log-box">
+                <div v-for="(line, index) in envFailureLogs" :key="index" class="env-log-line">
+                  {{ line }}
+                </div>
+              </div>
             </template>
             <template v-if="envFailed" #action>
               <a-button size="small" :loading="envPreparing" @click="retryAgentEnvPrepare">
@@ -458,6 +463,9 @@ const envFailed = ref(false)
 const envMessage = ref('')
 const envPercent = ref<number | null>(null)
 const envLogs = ref<string[]>([])
+// 失败时只摊开末尾这些行：前面多是「创建隔离 venv」之类的流水，真正的报错
+// （比如 pip 的 stderr）总在最后。整份日志仍在 envLogs 里。
+const envFailureLogs = computed(() => envLogs.value.slice(-12))
 const envAgents = ref<{ runtimeKind?: string | null; executable: string }[]>([])
 let envSubscriptionId: string | null = null
 
@@ -510,6 +518,9 @@ const runAgentEnvPrepare = async (targetPath?: string, force = false) => {
     if (!response || response.code !== 200 || !response.data) {
       envFailed.value = true
       envMessage.value = response?.message || 'MFW 运行环境准备失败'
+      // 失败响应里同样带着逐行日志，而且这才是最需要它的时候：原先这里直接
+      // return，把唯一一份失败原因扔了，用户只剩一句「准备失败」。
+      if (response?.data?.logs?.length) envLogs.value = response.data.logs
       message.error(envMessage.value)
       return
     }

--- a/res/version.json
+++ b/res/version.json
@@ -18,7 +18,8 @@
                 "修复 MFW、M9A、HSR 与主页的一批问题：多项设置从未生效、MFW 更新不上、HSR 周常与历战余响提前翻页、重返未来 1999 倒计时偏移、国内下载源缺分支导致初始化失败",
                 "修复后端就绪前退出时只能反复重试的问题，现同时提供「重建运行环境」入口 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MAA专项 修复未返回分服关卡数据时用户配置页打不开的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "模拟器管理 修复部分 MuMu 因命令输出混有日志而无法读取信息的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "模拟器管理 修复部分 MuMu 因命令输出混有日志而无法读取信息的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败"
             ],
             "开发流程": [
                 "首页卫星图标改从全局图标表取，新增专项时不再漏掉主页卫星"


### PR DESCRIPTION
## 问题

`automas_maafw_agent_env/env.py` 的 `_pip_install` 是全产品唯一不带 `--index-url` 的依赖安装：裸连 PyPI、单次 120s。后端依赖走初始化流程选的镜像，MaaFW 运行池走 Runtime 经 `AUTO_MAS_MIRROR_PACKAGE_INDEX` 注入的候选并按序轮换（`installer.py:1306`），只有它没接。所以镜像不通的网络下，运行池那步能装完、紧接着的 Agent 依赖必挂。

`git log -S "index-url"` 在该模块零命中：不是回归，是运行池接 Runtime 镜像时这条路径没跟着迁。

## 改动

**接镜像**：`_pip_install` 复用运行池同一套索引来源与离线契约（`AUTO_MAS_MIRROR_PACKAGE_INDEX` 键存在但为空 = 要求完全离线，只跑 `--no-index`）；用户显式设了 `PIP_INDEX_URL` 则尊重它、不参与轮换。

与运行池 `_run_with_source_rotation` 有一处**有意的分歧**：那边超时直接抛出不换源，这里超时继续试下一个候选——装不上的首要成因就是某个索引连不通，而连不通的典型表现正是超时。反过来解释器起不来（`OSError`）与索引无关，立即停手。

**让失败可诊断**：pip 的 stderr 原本就被抓着，但三处被丢——后端返回 `code=500` 却包在 HTTP 200 里且没有任何 logger 调用；前端错误分支在读 `response.data.logs` 之前就 `return`；模板里 `envLogs` 从未渲染（`.env-log-box` / `.env-log-line` 两个样式一直是孤儿）。结果是 app.log 一行都没有，用户只剩一句「隔离 venv 依赖安装失败: &lt;python.exe 路径&gt;」。三处一并补上。

Ref #656

## 本地验证

| 检查 | 结果 |
| --- | --- |
| `python -m pytest tests` | 747 passed, 3 skipped, 171 subtests |
| `python -m pytest tests --collect-only -q` | exit 0 |
| `yarn typecheck` / `yarn lint` | 均 exit 0 |
| `ruff check` / `ruff format --check`（本次改动文件） | 干净 |

`app/api/scripts.py` 既有的 2 个 ruff 错误（`I001`、`F841`）与全仓 51 个文件的 format 不干净在基线上同样复现，非本次引入。

镜像轮换与离线 `--no-index` 的真实网络行为没有搭环境复现；后端那条 ERROR 日志也没有起后端手测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

修复 MaaFW Agent 隔离环境依赖安装的镜像适配问题，并完善失败日志的记录与展示。

错误修复：
- 使 MaaFW Agent 隔离 venv 的依赖安装遵循镜像、显式 PIP_INDEX_URL 和离线配置，避免在镜像不可用时直接连接 PyPI 失败。
- 让依赖安装在镜像间按序重试，并在索引超时和解释器无法启动时提供相应处理。
- 保留并持久化运行环境准备失败日志，同时在前端错误提示中展示关键日志，便于诊断依赖安装失败原因。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复 MaaFW Agent 隔离环境依赖安装的镜像适配问题，并完善失败日志的记录与展示。

Bug Fixes:
- 使 MaaFW Agent 隔离 venv 的依赖安装遵循镜像、显式 PIP_INDEX_URL 和离线配置，避免在镜像不可用时直接连接 PyPI 失败。
- 让依赖安装在镜像间按序重试，并在索引超时和解释器无法启动时提供相应处理。
- 保留并持久化运行环境准备失败日志，同时在前端错误提示中展示关键日志，便于诊断依赖安装失败原因。

</details>