### PR TITLE
fix(frontend): 卫星组件等待后端就绪后再初始化，消除启动期误弹的 Network Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题
 - MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次
 - MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)
+- 修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题
 
 ### 开发流程
 

--- a/frontend/src/components/SatelliteAnimation.backendReady.test.ts
+++ b/frontend/src/components/SatelliteAnimation.backendReady.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('./SatelliteAnimation.vue', import.meta.url), 'utf8')
+
+describe('SatelliteAnimation backend readiness gating', () => {
+  it('initializes the scene only after the backend connection is open', () => {
+    const mounted = source.slice(source.indexOf('onMounted(async'))
+    const readyIndex = mounted.indexOf('await waitBackendReady()')
+    expect(readyIndex).toBeGreaterThan(-1)
+    expect(mounted.indexOf('await initScene()')).toBeGreaterThan(readyIndex)
+  })
+
+  it('gates foreground-resume snapshot refresh and polling behind backend readiness', () => {
+    expect(source).toContain('void waitBackendReady().then(')
+  })
+
+  it('disposes the readiness listener on unmount', () => {
+    expect(source).toContain('disposeBackendReadyListener?.()')
+  })
+})

--- a/frontend/src/components/SatelliteAnimation.vue
+++ b/frontend/src/components/SatelliteAnimation.vue
@@ -13,6 +13,7 @@ import { useSatelliteStatus, type SatelliteModuleStatus } from '@/composables/us
 import type { ScriptType } from '@/types/script'
 import { requestUpdateCheck } from '@/composables/useUpdateChecker'
 import { usePerformanceStore } from '@/stores/performance'
+import { connectionState, onConnected } from '@/services/websocket/connection'
 import { createAnimationFrameScheduler } from './satelliteAnimationLoop'
 import {
   createExplosionFragmentMotion,
@@ -154,6 +155,20 @@ function startStatusPolling() {
   updateInterval = setInterval(() => void refreshSatelliteStatuses(), CONFIG.statusUpdateInterval)
 }
 
+// 后端未就绪（主 WS 未 open）时不发请求：启动遮罩期间立即初始化会把脚本列表与
+// 运行快照打向尚未监听的端口，请求直接以 "Network Error" 弹错，卫星也会整场不渲染。
+let disposeBackendReadyListener: (() => void) | null = null
+
+function waitBackendReady(): Promise<void> {
+  if (connectionState().value === 'open') return Promise.resolve()
+  return new Promise(resolve => {
+    disposeBackendReadyListener = onConnected(() => {
+      disposeBackendReadyListener = null
+      resolve()
+    })
+  })
+}
+
 function showCardsImmediately() {
   if (centerCard) {
     const frontMaterial = getCardFrontMaterial(centerCard)
@@ -233,6 +248,7 @@ function disposeCardMesh(card: CardMesh) {
 
 onUnmounted(() => {
   isUnmounted = true
+  disposeBackendReadyListener?.()
   window.removeEventListener('resize', handleResize)
   disposeScene()
 })
@@ -1297,13 +1313,18 @@ watch(
       startAnimation()
     }
     updateSatelliteStates()
-    void refreshSatelliteStatuses()
-    startStatusPolling()
+    void waitBackendReady().then(() => {
+      if (isUnmounted || performanceStore.isBackgrounded) return
+      void refreshSatelliteStatuses()
+      startStatusPolling()
+    })
   }
 )
 
 onMounted(async () => {
   isUnmounted = false
+  await waitBackendReady()
+  if (isUnmounted) return
   try {
     await initScene()
   } catch (e) {

--- a/res/version.json
+++ b/res/version.json
@@ -23,7 +23,8 @@
                 "MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题",
                 "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次",
-                "MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)"
+                "MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)",
+                "修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题"
             ],
             "开发流程": [
                 "首页卫星图标改从全局图标表取，新增专项时不再漏掉主页卫星"


### PR DESCRIPTION
## 摘要
- 应用启动遮罩期间，首页卫星组件会立即请求脚本列表与运行快照；此时后端尚未开始监听，请求直接失败并弹出 "Network Error" 提示，又被压在遮罩后面，用户看到的是一条莫名其妙的报错；同时首帧脚本列表失败后，卫星整个会话都不再渲染。
- 现在卫星组件等待主 WebSocket 就绪后再初始化场景、拉取快照与开始轮询，复用现有连接层原语，后端无改动。
- 效果：启动后不再出现无意义的 Network Error 提示，冷启动后首页卫星动画正常显示。

## 测试
- `yarn lint --max-warnings 1`、`yarn typecheck` 通过；`yarn test` 453/454，唯一失败项 `electron/services/backendService.test.ts` 在未改动的 origin/dev 基线上同样失败（预存问题，与本 PR 无关）
- 新增源码断言测试锁定「后端就绪后才初始化」约束

## Sourcery 摘要

在初始化和刷新主页卫星组件之前，等待后端 WebSocket 连接建立。

错误修复：
- 通过将卫星组件的初始化和刷新延迟到后端连接就绪后，避免启动时出现 Network Error 通知，并确保冷启动后主页卫星动画能够正确渲染。

测试：
- 添加测试以确保后端就绪状态门控生效，并清理就绪状态监听器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Wait for the backend WebSocket connection before initializing and refreshing the homepage satellite component.

Bug Fixes:
- Prevent startup-time Network Error notifications and ensure the homepage satellite animation renders correctly after a cold launch by deferring satellite initialization and refreshes until the backend connection is ready.

Tests:
- Add tests enforcing backend-readiness gating and cleanup of the readiness listener.

</details>