### PR TITLE
fix(MAA): 剿灭周完成判定必须有进度行佐证 (release/v5.5.0-beta.4)

### DIFF
--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -146,11 +146,15 @@ def _parse_annihilation_weekly_progress(log: str) -> tuple[int, int] | None:
 
 
 def _has_completed_annihilation_week(log: str) -> bool:
-    """判断剿灭日志是否表明本周额度已完成。"""
+    """判断剿灭日志是否表明本周额度已完成。
+
+    MAA 理智不足无法开战时同样打印「完成任务: 剿灭作战」且无进度行，
+    与已达上限在日志上不可区分，故无进度行一律视为未达标，宁可下次重试。
+    """
 
     progress = _parse_annihilation_weekly_progress(log)
     return "完成任务: 剿灭作战" in log and (
-        progress is None or progress[0] >= progress[1]
+        progress is not None and progress[0] >= progress[1]
     )
 
 

--- a/tests/task/test_maa_annihilation_week.py
+++ b/tests/task/test_maa_annihilation_week.py
@@ -1,0 +1,13 @@
+from app.task.MAA.AutoProxy import _has_completed_annihilation_week
+
+
+def test_week_completed_requires_progress_line_at_cap() -> None:
+    log = "完成任务: 剿灭作战\n剿灭模式 : 1800 / 1800"
+    assert _has_completed_annihilation_week(log) is True
+    assert _has_completed_annihilation_week("剿灭模式 : 1850 / 1800\n完成任务: 剿灭作战") is True
+
+
+def test_week_not_completed_without_cap_progress() -> None:
+    assert _has_completed_annihilation_week("完成任务: 剿灭作战\n剿灭模式 : 1480 / 1800") is False
+    assert _has_completed_annihilation_week("开始任务: 剿灭作战\n完成任务: 剿灭作战") is False
+    assert _has_completed_annihilation_week("剿灭模式 : 1480 / 1800") is False


### PR DESCRIPTION
自 dev 回移 #662（fix(MAA): 剿灭周完成判定必须有进度行佐证），内容一致：代码修复 + 纯逻辑回归测试。

## 本地验证

- `python -m pytest tests/task/test_maa_annihilation_week.py -q`：2 passed

## Sourcery 摘要

修正剿灭周完成检测逻辑，要求 MAA 日志中有相互印证的进度上限记录。

错误修复：
- 要求日志中存在显示已达到上限的每周剿灭进度行，然后才将作战视为已完成，从而避免因理智不足导致的运行被错误识别为成功。

测试：
- 增加对已达上限、未达上限、缺少进度以及仅有进度的剿灭日志的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct annihilation-week completion detection to require corroborating cap progress in the MAA log.

Bug Fixes:
- Require a weekly annihilation progress line showing the cap has been reached before treating the operation as completed, preventing insufficient-sanity runs from being falsely recognized as successful.

Tests:
- Add regression coverage for capped, uncapped, missing-progress, and progress-only annihilation logs.

</details>