### PR TITLE
fix(MAA): 剿灭周完成判定必须有进度行佐证 (release/v5.4.0)

### DIFF
--- a/app/task/MAA/AutoProxy.py
+++ b/app/task/MAA/AutoProxy.py
@@ -110,11 +110,15 @@ def _parse_annihilation_weekly_progress(log: str) -> tuple[int, int] | None:
 
 
 def _has_completed_annihilation_week(log: str) -> bool:
-    """判断剿灭日志是否表明本周额度已完成。"""
+    """判断剿灭日志是否表明本周额度已完成。
+
+    MAA 理智不足无法开战时同样打印「完成任务: 剿灭作战」且无进度行，
+    与已达上限在日志上不可区分，故无进度行一律视为未达标，宁可下次重试。
+    """
 
     progress = _parse_annihilation_weekly_progress(log)
     return "完成任务: 剿灭作战" in log and (
-        progress is None or progress[0] >= progress[1]
+        progress is not None and progress[0] >= progress[1]
     )
 
 

--- a/tests/task/test_maa_annihilation_week.py
+++ b/tests/task/test_maa_annihilation_week.py
@@ -1,0 +1,18 @@
+# v5.4.0 结构下需先初始化 app.core：直接先导 app.task 会经
+# MAA.__init__ -> manager -> app.core.__init__ -> task_manager 触发循环导入
+# （dev 侧已重构消除，此处为 release 局部守卫，不影响生产入口）。
+import app.core  # noqa: F401
+
+from app.task.MAA.AutoProxy import _has_completed_annihilation_week
+
+
+def test_week_completed_requires_progress_line_at_cap() -> None:
+    log = "完成任务: 剿灭作战\n剿灭模式 : 1800 / 1800"
+    assert _has_completed_annihilation_week(log) is True
+    assert _has_completed_annihilation_week("剿灭模式 : 1850 / 1800\n完成任务: 剿灭作战") is True
+
+
+def test_week_not_completed_without_cap_progress() -> None:
+    assert _has_completed_annihilation_week("完成任务: 剿灭作战\n剿灭模式 : 1480 / 1800") is False
+    assert _has_completed_annihilation_week("开始任务: 剿灭作战\n完成任务: 剿灭作战") is False
+    assert _has_completed_annihilation_week("剿灭模式 : 1480 / 1800") is False


### PR DESCRIPTION
自 dev 回移 #662（fix(MAA): 剿灭周完成判定必须有进度行佐证）。

- 测试按 485aa62e 先例加 `import app.core` 守卫，规避 v5.4.0 的循环导入

## 本地验证

- `python -m pytest tests/task/test_maa_annihilation_week.py -q`：2 passed

## Sourcery 摘要

在将任务视为完成之前，确保通过进度证据确认湮灭周已完成。

错误修复：
- 要求存在一条有效的湮灭周进度记录，且进度达到或超过每周上限，然后才将 MAA 任务视为已完成，从而避免将无进度的完成日志误判为已完成。

测试：
- 增加对达到上限、低于上限以及缺少进度的湮灭周日志的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure annihilation-week completion is confirmed by progress evidence before accepting the task as complete.

Bug Fixes:
- Require a valid annihilation-week progress line at or above the weekly cap before treating the MAA task as completed, preventing no-progress completion logs from being misclassified.

Tests:
- Add coverage for capped, below-cap, and missing-progress annihilation-week logs.

</details>