### PR TITLE
fix(electron): 初始化进度与后端状态回调在渲染进程销毁后不再向 WebContents 发送事件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次
 - MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)
 - 修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题 by [@1w1w11w1](https://github.com/1w1w11w1)
+- 修复初始化或更新进行中关闭窗口时，主进程偶发报「Object has been destroyed」崩溃退出的问题
 
 ### 开发流程
 

--- a/frontend/electron/ipc/initializationHandlers.ts
+++ b/frontend/electron/ipc/initializationHandlers.ts
@@ -60,6 +60,20 @@ let initService: InitializationService | null = null
 let backendService: BackendService | null = null
 
 /**
+ * 向发起 IPC 调用的渲染进程回推事件。
+ *
+ * 初始化进度回调与后端状态回调都活得比一次 IPC 调用长：窗口已关闭、应用正在退出时，
+ * Runtime 子进程仍会往 stdout 吐 bootstrap 进度，后端子进程退出也会触发状态回调。这时
+ * 再对已销毁的 `WebContents` 调用 `send` 会抛「Object has been destroyed」，并且是在
+ * 子进程事件回调里抛出、无人接住，直接成为主进程的未捕获异常。渲染进程已销毁时静默丢弃。
+ */
+function sendToSender(event: IpcMainInvokeEvent, channel: string, payload: unknown): void {
+  const sender = event.sender
+  if (sender.isDestroyed()) return
+  sender.send(channel, payload)
+}
+
+/**
  * 获取或创建初始化服务实例
  */
 function getInitService(targetBranch: string = 'dev'): InitializationService {
@@ -140,7 +154,7 @@ async function runStageViaRuntime(
     stage,
     progress => {
       if (progress.stage !== stage) return
-      event.sender.send(progressChannel, progress)
+      sendToSender(event, progressChannel, progress)
     },
     selectedMirror,
     toRetryMode(rebuild)
@@ -237,7 +251,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
     const installer = new PythonInstaller(appRoot, mirrorService)
 
     const result = await installer.install(progress => {
-      event.sender.send('python-progress', progress)
+      sendToSender(event, 'python-progress', progress)
     }, selectedMirror)
 
     if (!result.success) {
@@ -271,7 +285,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
     const installer = new PipInstaller(appRoot, mirrorService)
 
     const result = await installer.install(progress => {
-      event.sender.send('pip-progress', progress)
+      sendToSender(event, 'pip-progress', progress)
     }, selectedMirror)
 
     if (!result.success) {
@@ -305,7 +319,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
     const installer = new GitInstaller(appRoot, mirrorService)
 
     const result = await installer.install(progress => {
-      event.sender.send('git-progress', progress)
+      sendToSender(event, 'git-progress', progress)
     }, selectedMirror)
 
     if (!result.success) {
@@ -342,7 +356,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
       const repoService = new RepositoryService(appRoot, mirrorService, targetBranch)
 
       const result = await repoService.pullRepository(progress => {
-        event.sender.send('repository-progress', progress)
+        sendToSender(event, 'repository-progress', progress)
       }, selectedMirror)
 
       if (!result.success) {
@@ -379,7 +393,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
       const depService = new DependencyService(appRoot, mirrorService)
 
       const result = await depService.installDependencies(progress => {
-        event.sender.send('dependency-progress', progress)
+        sendToSender(event, 'dependency-progress', progress)
       }, selectedMirror)
 
       if (!result.success) {
@@ -425,7 +439,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
       const result = await initService.initialize(progress => {
         // 发送进度到渲染进程
-        event.sender.send('initialization-progress', progress)
+        sendToSender(event, 'initialization-progress', progress)
       }, startBackend)
 
       if (result.success) {
@@ -434,7 +448,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
         // 设置状态回调
         backendService.setStatusCallback(status => {
-          event.sender.send('backend-status', status)
+          sendToSender(event, 'backend-status', status)
         })
 
         logger.info(`初始化成功完成，阶段: ${result.completedStages.join(', ')}`)
@@ -454,7 +468,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
     const initService = getInitService(targetBranch)
 
     const result = await initService.updateOnly(progress => {
-      event.sender.send('initialization-progress', progress)
+      sendToSender(event, 'initialization-progress', progress)
     })
 
     if (!result.success) {
@@ -473,7 +487,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
     // 设置状态回调
     backend.setStatusCallback(status => {
-      event.sender.send('backend-status', status)
+      sendToSender(event, 'backend-status', status)
     })
 
     const result = await backend.startBackend()
@@ -505,7 +519,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
     // 设置状态回调
     backend.setStatusCallback(status => {
-      event.sender.send('backend-status', status)
+      sendToSender(event, 'backend-status', status)
     })
 
     const result = await backend.restartBackend()
@@ -538,7 +552,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
       const result = await updateBackendViaRuntime(
         typeof targetVersion === 'string' ? targetVersion : '',
-        progress => event.sender.send(BACKEND_UPDATE_PROGRESS_CHANNEL, progress),
+        progress => sendToSender(event, BACKEND_UPDATE_PROGRESS_CHANNEL, progress),
         {
           backend: getBackendService(),
           launchConfig: resolveRuntimeLaunchConfig(getAppRoot()),
@@ -559,7 +573,7 @@ export function registerInitializationHandlers(_mainWindow: BrowserWindow) {
 
       logger.info(`重试 Runtime 后端更新: ${action}`)
       const result = await retryBackendUpdate(action, progress =>
-        event.sender.send(BACKEND_UPDATE_PROGRESS_CHANNEL, progress)
+        sendToSender(event, BACKEND_UPDATE_PROGRESS_CHANNEL, progress)
       )
 
       if (!result.success) {

--- a/res/version.json
+++ b/res/version.json
@@ -25,7 +25,8 @@
                 "MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题",
                 "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次",
                 "MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)",
-                "修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题 by [@1w1w11w1](https://github.com/1w1w11w1)"
+                "修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "修复初始化或更新进行中关闭窗口时，主进程偶发报「Object has been destroyed」崩溃退出的问题"
             ],
             "开发流程": [
                 "首页卫星图标改从全局图标表取，新增专项时不再漏掉主页卫星"


### PR DESCRIPTION
> 由 Sentry 每日分诊自动推送，**未经人工复核**。来源：`AUTO-MAS-DESKTOP-16`（与 #652 的 `AUTO-MAS-DESKTOP-11` 同一家族）。

Closes #665
Closes #652

## 摘要

- `initializationHandlers.ts` 里 13 处 `event.sender.send(...)` 统一改走 `sendToSender`，渲染进程已销毁时静默丢弃。
- 覆盖两条线上崩溃：Runtime bootstrap 进度回调（beta.4，`DESKTOP-16`）与后端退出时的状态回调（beta.2，`DESKTOP-11`），都是窗口先没了、回调后到、`send` 抛 `Object has been destroyed` 成为主进程未捕获异常。
- `CHANGELOG.md` 补一条「修复」，`res/version.json` 由 `scripts/changelog.py sync` 生成。

## 本地验证

工作树 `D:\MAS\code\trees\dispguard`，基线 `refs/remotes/upstream/dev` @ `3aa8b0702`，从 `frontend/` 运行：

- `corepack yarn typecheck` — 通过（exit 0）
- `corepack yarn lint` — 通过（exit 0）
- `corepack yarn oxfmt electron/ipc/initializationHandlers.ts --check` — 通过
- `corepack yarn test` — **453 通过 / 1 失败**。失败的是 `electron/services/backendService.test.ts › managed 模式 › 不传 --repo、不先跑 environment ensure，--app-root 就是用户数据根`（`Test timed out in 5000ms`）。**该失败在未改动的 dev 基线 `3aa8b0702` 与 09-10 的 `1587a57dc` 上原样复现**，本 PR 未触碰 `backendService.ts`，属既有失败，与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

防止初始化和后端回调向已销毁的渲染器进程发送 IPC 事件。

错误修复：
- 防止在渲染器窗口已销毁后，初始化或后端状态回调尝试发送事件而导致主进程崩溃。

增强功能：
- 集中处理渲染器事件传递，安全丢弃针对已销毁 WebContents 的回调。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

防止在渲染器进程销毁后，初始化和后端回调 IPC 传递导致崩溃。

Bug 修复：
- 防止在渲染器 WebContents 被销毁后，初始化进度和后端状态回调导致主进程崩溃。

增强功能：
- 集中处理渲染器事件传递，以便安全丢弃针对已销毁 WebContents 的回调。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard initialization and backend callback IPC delivery against destroyed renderer processes.

Bug Fixes:
- Prevent initialization progress and backend status callbacks from crashing the main process after the renderer WebContents has been destroyed.

Enhancements:
- Centralize renderer event delivery so callbacks targeting destroyed WebContents are safely discarded.

</details>

</details>