### PR TITLE
fix(maafw): 运行池与脚本子进程隔离宿主 uv 配置与 Python 环境变量 (release/v5.5.0-beta.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败
 - MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题
 - MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次
+- MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量
 
 ### 开发流程
 

--- a/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Callable
 
 from ..automas_maafw_runtime_pool import runtime_managed_uv_executable
+from ..automas_maafw_runtime_pool.host_environment import (
+    strip_host_python_environment,
+)
 from ..automas_maafw_runtime_pool.installer import (
     is_package_index_offline,
     resolve_package_index_candidates,
@@ -351,6 +354,8 @@ def _ensure_isolated_venv(
                 text=True,
                 encoding="utf-8",
                 errors="replace",
+                # 引导解释器同样不能被宿主 PYTHONHOME / PYTHONPATH 带偏。
+                env=strip_host_python_environment(),
             )
         except subprocess.TimeoutExpired as exc:
             raise MaaFWAgentEnvError(
@@ -379,12 +384,13 @@ def _create_venv_with_uv(venv_path: Path, log: Callable[[str], None]) -> None:
     log(f"[Python环境] 引导 Python 均缺少 venv 模块，改用 uv 创建: {venv_path}")
     try:
         result = subprocess.run(
-            [uv_exe, "venv", "--seed", str(venv_path)],
+            [uv_exe, "venv", "--seed", "--no-config", str(venv_path)],
             capture_output=True,
             timeout=UV_VENV_TIMEOUT,
             text=True,
             encoding="utf-8",
             errors="replace",
+            env=strip_host_python_environment(),
         )
     except subprocess.TimeoutExpired as exc:
         raise MaaFWAgentEnvError(
@@ -516,14 +522,8 @@ def _project_interface_hash(project_path: Path) -> str:
 
 
 def _build_agent_env_for_pip(project_path: Path) -> dict[str, str]:
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("UV_PROJECT_ENVIRONMENT", None)
-    env.pop("PYTHONHOME", None)
-    env.pop("PYTHONUSERBASE", None)
-    env.pop("PIP_TARGET", None)
-    env.pop("PIP_PREFIX", None)
-    env.pop("PIP_USER", None)
+    # 剔除名单与运行池 / worker 共用；隔离 venv 里的 pip 只认项目根这一条 PYTHONPATH。
+    env = strip_host_python_environment()
     env["PYTHONPATH"] = str(project_path)
     return env
 
@@ -759,6 +759,8 @@ def _python_supports_venv(python: str) -> bool:
             capture_output=True,
             timeout=VENV_PROBE_TIMEOUT,
             text=True,
+            # 宿主 PYTHONHOME 会让解释器起不来、PYTHONWARNINGS=error 会让探测误判成「不可用」。
+            env=strip_host_python_environment(),
         )
     except (OSError, subprocess.SubprocessError):
         return False

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/environment.py
@@ -29,6 +29,9 @@ from app.task.MaaFW.tools.core.automas_maafw_runtime_pool import (
     canonicalize_requirements,
     install_python_runtime,
 )
+from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.host_environment import (
+    strip_host_python_environment,
+)
 from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.installer import (
     MaaFWRuntimeInstallCancelled,
     host_bootstrap_python_request,
@@ -1015,24 +1018,15 @@ def build_runner_environment(
     *,
     import_paths: Iterable[str | Path] = (),
 ) -> dict[str, str]:
-    env = os.environ.copy()
-    for name in (
-        "PYTHONHOME",
-        "PYTHONUSERBASE",
-        "PIP_TARGET",
-        "PIP_PREFIX",
-        "PIP_USER",
-    ):
-        env.pop(name, None)
+    # 宿主的 PYTHONPATH / PYTHONWARNINGS 等一律不进 worker：worker 能 import 什么只由
+    # import_paths 决定（剔除名单与运行池 / agent 共用，见 host_environment 模块）。
+    env = strip_host_python_environment()
 
     venv = Path(venv_path).resolve()
     scripts_dir = venv / ("Scripts" if os.name == "nt" else "bin")
     resolved_import_paths = [
         str(Path(path).resolve()) for path in import_paths if Path(path).exists()
     ]
-    existing_python_path = env.get("PYTHONPATH", "")
-    if existing_python_path:
-        resolved_import_paths.append(existing_python_path)
 
     env["VIRTUAL_ENV"] = str(venv)
     env["PYTHONNOUSERSITE"] = "1"

--- a/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runner/runner.py
@@ -61,6 +61,9 @@ from app.task.MaaFW.tools.core.automas_maafw_runner.environment import (
     pin_agent_maafw_requirement,
     project_maafw_runtime_path,
 )
+from app.task.MaaFW.tools.core.automas_maafw_runtime_pool.host_environment import (
+    strip_host_python_environment,
+)
 
 try:
     from .models import MaaFWDeviceConfig
@@ -1920,23 +1923,16 @@ class MaaFWRunner:
         再显式设置当前项目所需的 PYTHONPATH；PATH 前置 agent Python 目录、
         Scripts 目录、项目根目录与项目必要 dll 目录。
         """
-        env = os.environ.copy()
+        # 先按共用名单剔除 worker 自己与宿主的 Python 变量，再叠加项目 interface 声明的
+        # 环境：项目给自己 agent 设的值要保留。worker 自己需要 PYTHONSAFEPATH（见
+        # build_runner_environment），但不能透传给项目 agent：agent 以 `python ./agent/main.py`
+        # 启动，靠脚本目录进 sys.path[0] 才能 import 同级模块，官方模板就是这么写的，
+        # 继承过去会当场 ModuleNotFoundError——它随 PYTHON* 前缀一起被剔除。
+        env = strip_host_python_environment()
         env.update(self.plan.piEnv)
 
         project_path = Path(self.plan.path)
 
-        # 清理 AUTO-MAS 自身环境变量，防止 agent 串到 MAS .venv
-        env.pop("VIRTUAL_ENV", None)
-        env.pop("UV_PROJECT_ENVIRONMENT", None)
-        env.pop("PYTHONHOME", None)
-        env.pop("PYTHONUSERBASE", None)
-        env.pop("PIP_TARGET", None)
-        env.pop("PIP_PREFIX", None)
-        env.pop("PIP_USER", None)
-        # worker 自己需要 PYTHONSAFEPATH（见 build_runner_environment），但不能透传给
-        # 项目 agent：agent 以 `python ./agent/main.py` 启动，靠脚本目录进 sys.path[0]
-        # 才能 import 同级模块，官方模板就是这么写的，继承过去会当场 ModuleNotFoundError。
-        env.pop("PYTHONSAFEPATH", None)
         # 不继承 MAS 的 PYTHONPATH，显式设置为当前项目根目录
         python_path_items: list[str] = []
         if getattr(agent_plan, "runtimeKind", None) == "isolated_venv":
@@ -2253,6 +2249,8 @@ class MaaFWRunner:
                 text=True,
                 encoding="utf-8",
                 errors="replace",
+                # 引导解释器同样不能被宿主 PYTHONHOME / PYTHONPATH 带偏。
+                env=strip_host_python_environment(),
             )
             if result.returncode != 0:
                 detail = (result.stderr or result.stdout or "").strip()
@@ -2272,16 +2270,8 @@ class MaaFWRunner:
 
         与 _build_agent_env 不同的是，此方法不依赖 agent_plan，用于 pip 检测阶段。
         """
-        env = os.environ.copy()
-        env.pop("VIRTUAL_ENV", None)
-        env.pop("UV_PROJECT_ENVIRONMENT", None)
-        env.pop("PYTHONHOME", None)
-        env.pop("PYTHONUSERBASE", None)
-        env.pop("PIP_TARGET", None)
-        env.pop("PIP_PREFIX", None)
-        env.pop("PIP_USER", None)
-        # 与 _build_agent_env 同理：agent 侧不能带 PYTHONSAFEPATH
-        env.pop("PYTHONSAFEPATH", None)
+        # 与 _build_agent_env 同一份剔除名单（含 agent 侧不能带的 PYTHONSAFEPATH）。
+        env = strip_host_python_environment()
         env["PYTHONPATH"] = str(project_path)
         return env
 

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/host_environment.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/host_environment.py
@@ -1,0 +1,81 @@
+"""MFW 专项各子进程共用的宿主环境隔离口径。
+
+运行池的 uv / pip、worker、项目 agent 与 agent 的 pip 检测都从 ``os.environ`` 复制一份再改，
+此前每处各维护一份 ``pop`` 名单且互不一致：``PYTHONHOME`` / ``PYTHONUSERBASE`` 都剔了，
+``PYTHONWARNINGS=error``（第一条 DeprecationWarning 就崩）、``PYTHONOPTIMIZE``（断言被删）、
+``PYTHONINSPECT``（进程退不出）、``PYTHONDEVMODE`` 却原样穿过去。受 Runtime 监督时这些已在
+Runtime 边界按增补 2 C20 剔除，但旧启动链路（``AUTO_MAS_RUNTIME_MODE=off``）与开发态直接继承
+宿主环境，后端必须自己守住同一条线。
+
+口径与 Runtime 一致：所有 ``PYTHON`` 开头的宿主变量默认不放行（新版本解释器新增的也不放行），
+只保留不改变「加载什么代码、以什么模式运行」的编码 / 缓冲 / 字节码落盘 / 用户站点开关；
+激活中的虚拟环境标记、pip 的安装位置覆盖、颜色强制与 Rust 调试变量一并剔除。
+``PIP_INDEX_URL`` / ``AUTO_MAS_*`` 等用户显式给 MFW 专项的开关不在名单内，仍按各处既有约定生效。
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+#: 宿主 ``PYTHON*`` 变量里仅有的放行项。
+PASSTHROUGH_PYTHON_KEYS: frozenset[str] = frozenset(
+    {
+        "PYTHONIOENCODING",
+        "PYTHONUTF8",
+        "PYTHONUNBUFFERED",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTHONNOUSERSITE",
+    }
+)
+
+#: ``PYTHON*`` 之外同样不从宿主继承的变量。
+ISOLATED_HOST_KEYS: frozenset[str] = frozenset(
+    {
+        # 启动链路（Runtime → uv run → 后端）或用户终端里激活的环境指向：交给 uv / pip 前
+        # 必须剔除，否则外部 uv 会把项目环境解析到 MAS 自己的 venv 上。
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+        "UV_PROJECT_ENVIRONMENT",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
+        "__PYVENV_LAUNCHER__",
+        # pip 的安装位置覆盖会把包装到 venv 之外。
+        "PIP_TARGET",
+        "PIP_PREFIX",
+        "PIP_USER",
+        # FORCE_COLOR / CLICOLOR_FORCE 会压过 uv 的 --color never 往日志里塞 ANSI 序列；
+        # RUST_LOG 不加 -v 也会让 uv 往 stderr 倾倒 TRACE。
+        "FORCE_COLOR",
+        "CLICOLOR_FORCE",
+        "CLICOLOR",
+        "NO_COLOR",
+        "RUST_LOG",
+        "RUST_BACKTRACE",
+        "RUST_MIN_STACK",
+    }
+)
+
+
+def is_isolated_host_key(name: str) -> bool:
+    """按 Windows 的大小写不敏感语义判断一个宿主变量是否不得下传。"""
+
+    upper = name.upper()
+    if upper.startswith("PYTHON"):
+        return upper not in PASSTHROUGH_PYTHON_KEYS
+    return upper in ISOLATED_HOST_KEYS
+
+
+def strip_host_python_environment(
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """返回剔除了宿主 Python / uv 相关变量的环境副本；缺省从 ``os.environ`` 复制。
+
+    调用方在返回值上再显式设置自己需要的 ``PYTHONPATH`` / ``VIRTUAL_ENV`` 等，
+    这样每处只需要声明「我要什么」，不必各自记住「要剔什么」。
+    """
+
+    source = os.environ if environment is None else environment
+    return {
+        name: value for name, value in source.items() if not is_isolated_host_key(name)
+    }

--- a/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_runtime_pool/installer.py
@@ -18,6 +18,7 @@ from typing import Any
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+from .host_environment import strip_host_python_environment
 
 logger = logging.getLogger("automas.maafw.runtime_pool.installer")
 
@@ -725,6 +726,7 @@ def _create_environment_with_uv(
             bootstrap,
             "--no-python-downloads",
             "--no-project",
+            "--no-config",
             "--cache-dir",
             str(uv_cache_dir),
             "--link-mode",
@@ -890,6 +892,7 @@ def _find_pool_managed_python(
                 "--managed-python",
                 "--no-project",
                 "--no-python-downloads",
+                "--no-config",
                 "--resolve-links",
                 "--cache-dir",
                 str(cache_dir),
@@ -967,6 +970,7 @@ def _install_pool_managed_python(
         str(python_root),
         "--no-bin",
         "--no-registry",
+        "--no-config",
         "--cache-dir",
         str(cache_dir),
         "--no-progress",
@@ -1158,6 +1162,8 @@ def _python_supports_venv(python: str) -> bool:
             text=True,
             encoding="utf-8",
             errors="replace",
+            # 探测与真正拉起解释器用同一份环境，宿主 PYTHONHOME / PYTHONWARNINGS 不参与判定。
+            env=_clean_process_environment(),
         )
     except (OSError, subprocess.SubprocessError):
         return False
@@ -1279,6 +1285,9 @@ def _install_requirements_with_uv(
             "install",
             "--python",
             str(python_executable),
+            # 用户级 / 项目级 uv.toml（额外 [[index]]、offline、exclude-newer …）
+            # 不得参与池的解析，索引与镜像只由本文件的候选逻辑决定。
+            "--no-config",
             "--cache-dir",
             str(cache_dir),
             "--link-mode",
@@ -1347,6 +1356,7 @@ def _probe_python_identity(python_executable: Path) -> dict[str, str]:
             text=True,
             encoding="utf-8",
             errors="replace",
+            env=_clean_process_environment(),
         )
     except (OSError, subprocess.SubprocessError) as exc:
         raise RuntimeError(
@@ -1585,20 +1595,8 @@ def _run_with_source_rotation(
 
 
 def _clean_process_environment() -> dict[str, str]:
-    env = os.environ.copy()
-    for name in (
-        # 启动链路（Runtime → uv run → 后端）注入的 venv 指向，交给 uv/pip
-        # 前必须剔除，否则外部 uv 会把项目环境解析到 MAS 的 runtime venv 上
-        "VIRTUAL_ENV",
-        "UV_PROJECT_ENVIRONMENT",
-        "PYTHONHOME",
-        "PYTHONUSERBASE",
-        "PYTHONPATH",
-        "PIP_TARGET",
-        "PIP_PREFIX",
-        "PIP_USER",
-    ):
-        env.pop(name, None)
+    # 剔除名单与 worker / agent 各处共用（host_environment 模块），这里只补自己的要求。
+    env = strip_host_python_environment()
     env["PYTHONNOUSERSITE"] = "1"
     return env
 
@@ -1694,6 +1692,7 @@ def _resolved_requirements_with_uv(
                 "freeze",
                 "--python",
                 str(python_executable),
+                "--no-config",
                 "--cache-dir",
                 str(cache_dir),
             ],

--- a/res/version.json
+++ b/res/version.json
@@ -21,7 +21,8 @@
                 "模拟器管理 修复部分 MuMu 因命令输出混有日志而无法读取信息的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败",
                 "MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题",
-                "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次"
+                "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次",
+                "MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量"
             ],
             "开发流程": [
                 "首页卫星图标改从全局图标表取，新增专项时不再漏掉主页卫星"


### PR DESCRIPTION
把 dev 上已合并的 #679（`ec6ca3333`）镜像到 `release/v5.5.0-beta.4`，代码 diff 原样 cherry-pick，无冲突；CHANGELOG 只追加对应一条，`res/version.json` 由 `scripts/changelog.py sync` 重生成，`version` 字段不动。

- 运行池全部 uv 调用统一 `--no-config`，用户全局 / 项目级 `uv.toml` 不再参与池的解析；
- 运行池 / worker / 项目 agent / agent 的 pip 检测与引导 venv、解释器探测共用一份宿主变量剔除名单（`PYTHON*` 前缀剔除，只放行编码 / 缓冲 / 字节码 / 用户站点开关），worker 不再追加宿主 `PYTHONPATH`。

不依赖 Runtime 发版，beta.4 + Runtime v0.1.6 直接生效。

本地验证（release 分支树）：`python -m pytest tests -q` → 757 passed, 3 skipped；collect 退出码 0；改动文件 ruff check / format 全过；`scripts/changelog.py check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

将 MaaFW 运行时池和脚本子进程与主机的 uv 配置及 Python 环境设置隔离开来。

错误修复：
- 防止运行时池依赖解析和 Python 子进程启动受到主机 uv 配置文件或非预期 Python 环境变量的影响。
- 确保 worker、agent 和隔离环境探测流程始终忽略主机的 Python 路径及运行时选择变量，同时保留明确支持的设置。

改进：
- 在运行时池、worker、agent 和环境设置流程之间集中处理主机 Python 及进程环境的清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate MaaFW runtime-pool and script subprocesses from host uv configuration and Python environment settings.

Bug Fixes:
- Prevent runtime-pool dependency resolution and Python subprocess startup from being affected by host uv configuration files or unintended Python environment variables.
- Ensure workers, agents, and isolated-environment probes consistently ignore host Python path and runtime-selection variables while preserving explicitly supported settings.

Enhancements:
- Centralize host Python and process-environment sanitization across the runtime pool, workers, agents, and environment setup flows.

</details>