### PR TITLE
fix(maafw): 首次全量更新清理旧版布局残留 (release/v5.5.0-beta.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败
 - MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题
 - MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次
+- MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题
 - MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量
 
 ### 开发流程

--- a/app/task/MaaFW/tools/core/automas_maafw_project_update/apply.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_project_update/apply.py
@@ -138,7 +138,11 @@ def apply_package_transaction(
     """Apply a package using a durable stage/backup transaction.
 
     The function only removes files previously recorded in the updater-owned
-    project manifest. Unknown user files remain untouched during full updates.
+    project manifest. Unknown user files remain untouched during full updates —
+    except inside the resource bundle directories on the very first update of a
+    project the updater never installed, where there is no such manifest and
+    stale files from the previous layout would otherwise break the new version;
+    see :func:`_orphan_paths_without_baseline`.
     """
 
     root = project_path.expanduser().resolve(strict=False)
@@ -212,6 +216,16 @@ def apply_package_transaction(
             _validate_plan_base(root, plan, old_manifest, current)
             if plan.package_type == "full":
                 stale = set(old_manifest.get("files", {})) - set(plan.files)
+                if not old_manifest.get("files"):
+                    orphans = _orphan_paths_without_baseline(root, plan)
+                    if orphans:
+                        preview = ", ".join(sorted(orphans)[:10])
+                        suffix = " ..." if len(orphans) > 10 else ""
+                        send_update_log(
+                            f"MaaFW 项目无基线清单，本次全量更新清理 {len(orphans)} "
+                            f"个旧版残留文件: {preview}{suffix}"
+                        )
+                    stale |= orphans
             else:
                 stale = set(plan.deleted)
             touched = sorted(set(plan.files) | stale)
@@ -576,6 +590,96 @@ def _validate_plan_base(
         source = plan.files.get(relative)
         if source is None or _sha256_file(source) != expected:
             raise UpdateApplyError(f"delta file hash mismatch: {relative}")
+
+
+def _package_resource_directories(plan: PackagePlan) -> set[str]:
+    """新版 interface.json 声明的资源包目录，项目相对 posix 路径。
+
+    实测四个发行包写的都是 ``./resource`` / ``./resource_pack/base`` 这样的相对
+    路径；``{PROJECT_DIR}`` 前缀在规格里存在但没见项目用过，这里一并去掉。
+    """
+
+    source = plan.files.get("interface.json")
+    if source is None or not source.is_file():
+        return set()
+    try:
+        data = json.loads(source.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError):
+        return set()
+    entries = data.get("resource")
+    if not isinstance(entries, list):
+        return set()
+
+    directories: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        raw = entry.get("path")
+        for candidate in raw if isinstance(raw, list) else [raw]:
+            if not isinstance(candidate, str):
+                continue
+            text = candidate.strip().replace("\\", "/").replace("{PROJECT_DIR}", "")
+            while text.startswith("./"):
+                text = text[2:]
+            text = text.strip("/")
+            if not text:
+                continue
+            try:
+                directories.add(safe_relative_path(text))
+            except UpdateApplyError:
+                continue
+    return directories
+
+
+def _orphan_paths_without_baseline(project_path: Path, plan: PackagePlan) -> set[str]:
+    """没有基线清单时，从磁盘上算出全量包应当清掉的旧版残留。
+
+    正常路径靠更新器自己的清单算 stale：装过一次之后「上一版铺了哪些文件」是已知
+    的，只删这些，用户自己放进项目的文件一概不碰。
+
+    但项目**第一次**被更新时没有这份清单——用户是直接指到一棵已经解压好的目录，
+    那棵树不是更新器铺的（日志里那句「本地无可信更新基线」说的就是这件事）。此时
+    stale 恒为空，全量包退化成纯覆盖：新版删掉或挪走的文件会原地留下。实测
+    MaaYYs v3.10.2 → v3.15.5 把 ``resource_pack/base/pipeline/kun28.json`` 挪进了
+    ``战斗/`` 子目录，旧的那份留在原地，两份都定义顶层节点 ``困28``，MaaFramework
+    直接拒收整个资源包（``key already exists``），项目从此每次运行都失败。
+
+    **扫描范围只有新版 interface.json 声明的资源包目录。** 这条边界是拿真实包在
+    测试床上试出来的：一开始按「包自己铺的顶层目录」扫，结果 v3.15.5 的包里带了
+    ``preset/``（两个自带预设），而 MXU 也把**用户自建的预设**写在同一个目录，用户
+    预设于是被当成残留删掉。``tasks/``、``assets/`` 同理都可能混着用户内容。资源包
+    目录不一样：它是 MaaFramework 直接加载的纯内容，也正是节点重名会炸掉整个项目
+    的地方——修的就是这个，扫这里就够。
+
+    另外跳过我们自己铺进项目的东西（``.auto_mas`` 前缀）与字节码（由解释器重写，
+    见 :func:`_is_bytecode_artifact`）。
+
+    残留风险说清楚：没有基线时无法区分「旧版本装的」和「用户自己塞进资源目录的」，
+    因此用户手放在资源目录里的覆写也会被清掉。这与全量包语义一致（它就是要把项目
+    换成新版本），删除动作仍走既有事务——进 touched、先备份、post-validate 失败整体
+    回滚。装过这一次之后清单就有了，后续更新走回精确口径。
+    """
+
+    orphans: set[str] = set()
+    for relative_dir in sorted(_package_resource_directories(plan)):
+        prefix = f"{relative_dir}/"
+        if not any(name.startswith(prefix) for name in plan.files):
+            # 包里没往这个资源目录铺任何文件：声明与实际对不上，不能拿它当
+            # 「这个目录本该是空的」的依据。
+            continue
+        directory = _project_target(project_path, relative_dir)
+        if directory.is_symlink() or not directory.is_dir():
+            continue
+        for path in directory.rglob("*"):
+            if path.is_symlink() or not path.is_file():
+                continue
+            relative = safe_relative_path(path.relative_to(project_path).as_posix())
+            if relative in plan.files or _is_bytecode_artifact(relative):
+                continue
+            if any(part.startswith(".auto_mas") for part in relative.split("/")):
+                continue
+            orphans.add(relative)
+    return orphans
 
 
 def _is_bytecode_artifact(relative: str) -> bool:

--- a/res/version.json
+++ b/res/version.json
@@ -22,6 +22,7 @@
                 "MFW专项 修复运行环境准备时 Agent 依赖不走镜像、直连 PyPI 导致「隔离 venv 依赖安装失败」的问题，现按镜像依次重试；失败原因也会写进日志并显示在提示条上，不再只有一句准备失败",
                 "MFW专项 修复 beta.4 下 MFW 脚本完全无法运行、一开跑就报「MaaFW runner worker exited without result」并提示缺少 loguru 的问题",
                 "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次",
+                "MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题",
                 "MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量"
             ],
             "开发流程": [

--- a/tests/task/test_maafw_project_update_orphans.py
+++ b/tests/task/test_maafw_project_update_orphans.py
@@ -1,0 +1,210 @@
+"""全量更新必须清掉资源目录里旧版布局的残留文件。
+
+更新器平时靠自己的清单算「上一版铺了哪些文件」，只删这些，用户自己放进项目的
+文件一概不碰。但项目第一次被更新时没有这份清单——用户是直接指到一棵已解压好的
+目录，那棵树不是更新器铺的。此时全量包退化成纯覆盖：新版挪走或删掉的文件会原地
+留下。
+
+现场是 MaaYYs v3.10.2 → v3.15.5 把 ``resource_pack/base/pipeline/kun28.json`` 挪进
+了 ``战斗/`` 子目录，旧的那份留在原地，两份都定义顶层节点 ``困28``，MaaFramework
+拒收整个资源包（``key already exists``），项目从此每次运行都失败。
+
+兜底的扫描范围**只有 interface.json 声明的资源包目录**，这里同时钉住这条边界：
+包也会铺 ``preset/`` 这类混着用户内容的目录（MXU 把用户自建预设写在那儿），它们
+不能被碰；有了清单之后必须走回精确口径。
+"""
+
+import json
+import zipfile
+from pathlib import Path
+
+from app.task.MaaFW.tools.core.automas_maafw_project_update.apply import (
+    apply_package_transaction,
+)
+
+RESOURCE_DIR = "resource_pack/base"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _interface(version: str) -> str:
+    return json.dumps(
+        {
+            "name": "MaaYYs",
+            "version": version,
+            "resource": [{"name": "官服2", "path": [f"./{RESOURCE_DIR}"]}],
+        },
+        ensure_ascii=False,
+    )
+
+
+def _make_package(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    package_path = tmp_path / f"{name}.zip"
+    with zipfile.ZipFile(package_path, "w") as archive:
+        for relative, content in files.items():
+            archive.writestr(relative, content)
+    return package_path
+
+
+def _apply(project: Path, package: Path, tmp_path: Path) -> dict:
+    return apply_package_transaction(
+        project,
+        package,
+        operation_root=tmp_path / "operations",
+    )
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """一棵用户自己解压好的旧版项目树：没有更新器清单。"""
+
+    project = tmp_path / "project"
+    _write(project / "interface.json", _interface("v3.10.2"))
+    _write(project / f"{RESOURCE_DIR}/pipeline/kun28.json", '{"困28": {}}')
+    _write(project / f"{RESOURCE_DIR}/pipeline/导航.json", '{"导航": {}}')
+    # 包不含的顶层目录：运行期产物与用户数据。
+    _write(project / "config/user.json", '{"服": "官服2"}')
+    _write(project / "debug/maa.log", "old log")
+    return project
+
+
+def test_full_update_without_baseline_removes_relocated_file(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    package = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {
+            "interface.json": _interface("v3.15.5"),
+            f"{RESOURCE_DIR}/pipeline/战斗/kun28.json": '{"困28": {}}',
+            f"{RESOURCE_DIR}/pipeline/导航.json": '{"导航": {}}',
+        },
+    )
+
+    result = _apply(project, package, tmp_path)
+
+    assert result["status"] == "committed"
+    assert result["packageType"] == "full"
+    assert (project / f"{RESOURCE_DIR}/pipeline/战斗/kun28.json").is_file()
+    assert not (project / f"{RESOURCE_DIR}/pipeline/kun28.json").exists(), (
+        "旧版遗留的同名节点文件必须清掉，否则 MaaFramework 会拒收整个资源包"
+    )
+
+
+def test_full_update_without_baseline_keeps_shipped_user_content_dirs(
+    tmp_path: Path,
+) -> None:
+    """包也会铺 preset/ 这类混着用户内容的目录，扫描范围不能扩到那里。
+
+    这条是在测试床上用真包试出来的：MaaYYs v3.15.5 自带两个预设放在 preset/，
+    而 MXU 把**用户自建的预设**写在同一个目录。
+    """
+
+    project = _make_project(tmp_path)
+    _write(project / "preset/我的预设.json", '{"mine": true}')
+    _write(project / "tasks/我的任务.json", '{"mine": true}')
+    package = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {
+            "interface.json": _interface("v3.15.5"),
+            "preset/一键日常.json": '{"builtin": true}',
+            "tasks/999.json": '{"builtin": true}',
+            f"{RESOURCE_DIR}/pipeline/导航.json": '{"导航": {}}',
+        },
+    )
+
+    _apply(project, package, tmp_path)
+
+    assert (project / "preset/我的预设.json").is_file(), "用户自建预设不能被当成残留"
+    assert (project / "tasks/我的任务.json").is_file()
+
+
+def test_full_update_without_baseline_keeps_runtime_dirs(tmp_path: Path) -> None:
+    """包不含的顶层目录是运行期产物与用户数据的家，一个都不能动。"""
+
+    project = _make_project(tmp_path)
+    package = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {
+            "interface.json": _interface("v3.15.5"),
+            f"{RESOURCE_DIR}/pipeline/导航.json": '{"导航": {}}',
+        },
+    )
+
+    _apply(project, package, tmp_path)
+
+    assert (project / "config/user.json").read_text(
+        encoding="utf-8"
+    ) == '{"服": "官服2"}'
+    assert (project / "debug/maa.log").is_file()
+
+
+def test_full_update_without_baseline_keeps_our_own_artifacts(tmp_path: Path) -> None:
+    """我们自己铺进项目的文件不是旧版残留，不能按「包里没有」清掉。"""
+
+    project = _make_project(tmp_path)
+    _write(project / f"{RESOURCE_DIR}/.auto_mas_something.json", "{}")
+    package = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {
+            "interface.json": _interface("v3.15.5"),
+            f"{RESOURCE_DIR}/pipeline/导航.json": '{"导航": {}}',
+        },
+    )
+
+    _apply(project, package, tmp_path)
+
+    assert (project / f"{RESOURCE_DIR}/.auto_mas_something.json").is_file()
+
+
+def test_full_update_skips_resource_dir_the_package_does_not_fill(
+    tmp_path: Path,
+) -> None:
+    """interface 声明了资源目录、包里却一个文件都没铺：声明与实际对不上，不能清。"""
+
+    project = _make_project(tmp_path)
+    package = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {"interface.json": _interface("v3.15.5"), "tasks/999.json": "{}"},
+    )
+
+    _apply(project, package, tmp_path)
+
+    assert (project / f"{RESOURCE_DIR}/pipeline/kun28.json").is_file()
+
+
+def test_second_update_falls_back_to_the_manifest(tmp_path: Path) -> None:
+    """装过一次就有清单了，之后必须走回精确口径：用户后放的文件不再被清。"""
+
+    project = _make_project(tmp_path)
+    first = _make_package(
+        tmp_path,
+        "v3.15.5",
+        {
+            "interface.json": _interface("v3.15.5"),
+            f"{RESOURCE_DIR}/pipeline/战斗/kun28.json": '{"困28": {}}',
+        },
+    )
+    _apply(project, first, tmp_path)
+
+    # 用户在资源目录里自己加了一份覆写。
+    _write(project / f"{RESOURCE_DIR}/pipeline/我的覆写.json", '{"我的": {}}')
+
+    second = _make_package(
+        tmp_path,
+        "v3.16.0",
+        {
+            "interface.json": _interface("v3.16.0"),
+            f"{RESOURCE_DIR}/pipeline/战斗/kun28.json": '{"困28": {"v": 2}}',
+        },
+    )
+    _apply(project, second, tmp_path)
+
+    assert (project / f"{RESOURCE_DIR}/pipeline/我的覆写.json").is_file(), (
+        "有清单之后，包外的未知文件必须保持不动"
+    )


### PR DESCRIPTION
把 dev 上已合并的 #659（`d8fb2cc64`）镜像到 `release/v5.5.0-beta.4`：`git cherry-pick -x`，`app/` 与 `tests/` 的 diff 与原提交逐字节相同；CHANGELOG 只追加对应一条，`res/version.json` 由 `scripts/changelog.py sync` 重生成，`version` 字段不动。

用户自己解压好、再指给 MAS 的 MFW 项目没有更新器清单，第一次全量更新退化成纯覆盖，新版挪走的文件留在原地，MaaFramework 因节点重名拒收整个资源包（MaaYYs v3.10.2 → v3.15.5 的 `困28`）。beta.3 起已有脚本默认「运行前更新」，所以这条对 beta.4 用户是「项目彻底跑不起来」级别，值得随热更新送出去。

本地验证（release 分支树）：

- `python -m pytest tests/task` → 350 passed；`tests --collect-only` 退出码 0；改动文件 ruff check / format 全过；`scripts/changelog.py check` 通过。
- 真链路复测：真实 `MaaYYs-win-x86_64-v3.15.5-MXU.zip` + 从 v3.10.2 发行包解出的干净项目树（无清单）+ 真实 `apply_package_transaction`，再用项目自带 MaaFramework 5.13.0b2 `post_bundle`。修复前复现 `key already exists [key=困28]`；修复后加载成功，清理 14 个旧版残留全部落在 `resource_pack/base/` 内，`preset/`（含用户自建）、`tasks/`、`assets/`、`config/`、`cache/`、`logs/`、`debug/` 原样保留；第二次更新（已有清单）0 删除。

独立复核另发现两处极少见布局下的边界（`resource[].path` 写 `.`/`..` 时更新硬失败但不丢数据；资源目录里的 junction 会被 `rglob` 钻进去），dev 上同样存在，另开 PR 修后再回移，不阻塞本条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

修复首次全量更新无法清理资源目录旧版残留而导致 MFW 项目无法加载的问题。

Bug Fixes:
- 修复首次对已解压且缺少更新器基线清单的 MFW 项目执行全量更新时，资源目录中的旧版残留文件未被清理，导致资源加载失败的问题。

Enhancements:
- 将无基线项目的清理范围限定为新版 interface.json 声明且实际包含文件的资源目录，同时保留用户内容、运行时目录及 MAS 自有文件；有基线后继续采用精确清理策略。

Tests:
- 新增覆盖旧版残留清理、用户内容保留、自有文件保留、空资源目录跳过及后续更新清单行为的更新测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复首次全量更新无法清理资源目录旧版残留而导致 MFW 项目无法加载的问题。

Bug Fixes:
- 修复首次对已解压且缺少更新器基线清单的 MFW 项目执行全量更新时，资源目录中的旧版残留文件未被清理，导致资源加载失败的问题。

Enhancements:
- 将无基线项目的清理范围限定为新版 interface.json 声明且实际包含文件的资源目录，同时保留用户内容、运行时目录及 MAS 自有文件；有基线后继续采用精确清理策略。

Tests:
- 新增覆盖旧版残留清理、用户内容保留、自有文件保留、空资源目录跳过及后续更新清单行为的更新测试。

</details>