### PR TITLE
fix(maafw): 补回 #673 合并时丢失的 strip_host_python_environment 导入 (release/v5.5.0-beta.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次
 - MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)
 - 修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题 by [@1w1w11w1](https://github.com/1w1w11w1)
+- MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量 by [@qiyinxi](https://github.com/qiyinxi)
 - BetterGI专项 修复自动秘境刷取次数未达设定值就提前结束的问题
 
 ### 开发流程

--- a/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
+++ b/app/task/MaaFW/tools/core/automas_maafw_agent_env/env.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Callable
 
 from ..automas_maafw_runtime_pool import runtime_managed_uv_executable
+from ..automas_maafw_runtime_pool.host_environment import (
+    strip_host_python_environment,
+)
 from ..automas_maafw_runtime_pool.installer import (
     is_package_index_offline,
     resolve_package_index_candidates,

--- a/res/version.json
+++ b/res/version.json
@@ -27,6 +27,7 @@
                 "MFW专项 修复 agent 运行环境装到与项目自带 MaaFramework 不匹配的 maafw 版本，导致每次运行都卡在「AgentClient 连接超时」的问题；已经装错的环境会自动重建一次",
                 "MFW专项 修复首次更新「自己解压好、再指给 MAS」的项目时不清理资源目录里的旧版残留文件，新版挪走或删掉的文件留在原地导致资源加载失败、项目彻底跑不起来的问题 by [@qiyinxi](https://github.com/qiyinxi)",
                 "修复应用启动过程中后台弹出无意义的 Network Error 提示、且启动后首页卫星动画不显示的问题 by [@1w1w11w1](https://github.com/1w1w11w1)",
+                "MFW专项 修复运行环境准备与脚本运行会被电脑上的全局 uv 配置文件和 PYTHON 系环境变量带偏的问题：依赖解析只按 MAS 自己选定的下载源进行，脚本与 Agent 不再继承宿主的 PYTHONPATH、PYTHONWARNINGS 等变量 by [@qiyinxi](https://github.com/qiyinxi)",
                 "BetterGI专项 修复自动秘境刷取次数未达设定值就提前结束的问题"
             ],
             "开发流程": [


### PR DESCRIPTION
#673 在把 `release/v5.5.0-beta.4` 合进自己分支时（`3bf5d2f9f`），`env.py` 导入块的冲突按 PR 一侧解决，#680 加的 `strip_host_python_environment` 导入被删掉，而它的四处调用（`_ensure_isolated_venv` / `_create_venv_with_uv` / `_build_agent_env_for_pip` / `_python_supports_venv`）都还在。合进 release 后，凡是带 Python Agent 的 MFW 项目一到 Agent 环境准备就 `NameError`，脚本跑不起来；`_build_agent_env_for_pip` 在每次运行都会被无条件调用，不受已有 venv 缓存影响。

- `env.py` 补回 3 行导入，改后与 dev 逐字节一致；
- 同一次冲突解决还把 #680 的更新日志条目丢了，一并补回，`res/version.json` 由 `scripts/changelog.py sync` 重生成，`version` 字段不动。

本地验证（release 分支树）：本地宿主隔离测试在 `ac1a9d8c5` 上复现 `NameError: name 'strip_host_python_environment' is not defined`（`env.py:523`），修后 6 passed；`python -m pytest tests -q` → 779 passed, 3 skipped；collect 退出码 0；`ruff check`（含 F821）/ `format --check` 通过；`scripts/changelog.py check` 通过。用 `git merge-tree` 对照过 #673 那次合并，除这 3 行和更新日志外没有其他被吞掉的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

恢复缺失的环境隔离集成及其发布元数据，确保 Python Agent 项目能够可靠地准备和运行。

Bug 修复：
- 恢复缺失的主机 Python 环境隔离导入，防止 Python Agent 环境准备和脚本执行因 NameError 而失败。
- 恢复变更日志条目，记录对主机 uv 配置和 Python 环境变量影响 MFW 运行时设置的防护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the missing environment-isolation integration and its release metadata so Python Agent projects can prepare and run reliably.

Bug Fixes:
- Restore the missing host Python environment isolation import to prevent Python Agent environment preparation and script execution from failing with a NameError.
- Restore the changelog entry documenting protection against host uv configuration and Python environment variables affecting MFW runtime setup.

</details>