### PR TITLE
fix(emulator2): 关机 / 启动中的雷电实例不再被误判为别家模拟器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### 修复
 
+- 模拟器 2.0 修复雷电实例在关机或启动中时被误判为「别家模拟器」、上线后 ADB 地址被清空、MAA 直接报 ADB 连接异常的问题（beta.5 首日生产实测）
 - 模拟器 2.0 雷电的 VBox 服务卡住时（窗口开了、虚拟机起不来、MAA 报 ADB 连接异常且反复重试），启动会自动关掉空窗口并重启该服务再试一次；只在所有实例都异常时才动手，只要还有任何一台实例在运行或正在启动就不碰，改为明确提示先关闭它们或运行雷电修复工具 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)
 - 模拟器 2.0 的 MuMu 实例启动失败或超时时，报错里附上 MuMu 自己给出的启动错误码、错误信息和实例状态，不再只有一句「启动超时」 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)
 - 修复社区通知重复发送、标题重复及同名 Webhook 漏发签到摘要的问题。 by [@HarcoChen](https://github.com/HarcoChen)

--- a/app/utils/emulator2/applaunch.py
+++ b/app/utils/emulator2/applaunch.py
@@ -160,6 +160,21 @@ def is_package_missing(pm_path_output: str) -> bool:
     return not (pm_path_output or "").strip()
 
 
+def is_package_present(pm_path_output: str) -> bool:
+    """从 ``pm path <包名>`` 的输出里判断这个包是否**确定装了**。
+
+    与 :func:`is_package_missing` 不是互补的：设备掉线时 adb 打印
+    ``adb.exe: device 'emulator-5562' not found``——既不是「空」也不是「装了」。
+    2026-09-12 生产实测就栽在这里：拿「非空」当「装了」，把所有**关着的**雷电实例
+    都判成了 MuMu，缓存 30 秒后实例启动时 ADB 地址被清空、MAA 直接报连接异常。
+    只有真正的 ``package:`` 行才算装了。
+    """
+    return any(
+        line.strip().startswith("package:")
+        for line in (pm_path_output or "").splitlines()
+    )
+
+
 def parse_launch_component(resolve_output: str, package_name: str) -> str | None:
     """从 ``cmd package resolve-activity --brief <包名>`` 的输出里取启动组件。
 

--- a/app/utils/emulator2/ldplayer14.py
+++ b/app/utils/emulator2/ldplayer14.py
@@ -42,7 +42,7 @@ from app.utils.emulator.ldplayer import _INSTANCE_CONFIG_SNAPSHOTS, LDManager
 from app.utils.platform import IS_WINDOWS
 
 from .adb import parse_adb_devices, resolve_serial
-from .applaunch import AppLaunchMixin, is_package_missing
+from .applaunch import AppLaunchMixin, is_package_missing, is_package_present
 from .bosskey import BossKey, read_boss_key
 from .master_mode import is_master_mode_enabled, ldplayer_clean_mode_args
 from .settings import (
@@ -493,8 +493,9 @@ class LDPlayer14Manager(AppLaunchMixin, LDManager):
         :func:`~.adb.resolve_serial` 照样会把它标成「核对通过」。
 
         判据用「认出别人」而不是「认出自己」，理由见 :data:`_FOREIGN_MARKER_PACKAGES`。
-        查不动（没有 adb、命令失败）时一律返回 ``False``：拿不准就维持原样，
-        不要凭一次查询失败把一台好设备判死。
+        查不动（没有 adb、命令失败、设备掉线）时一律返回 ``False`` **且不缓存**：
+        拿不准就维持原样，不要凭一次查询失败把一台好设备判死。只有 ``pm path``
+        真打出 ``package:`` 行才算「装着别家的包」。
         """
         now = time.monotonic()
         cached = self._ownership_cache.get(serial)
@@ -522,9 +523,15 @@ class LDPlayer14Manager(AppLaunchMixin, LDManager):
             except Exception as e:  # noqa: BLE001 - 查不动就不下结论, 见 docstring
                 logger.debug(f"核对 {serial} 的归属失败: {e}")
                 return False
-            if not is_package_missing(str(getattr(result, "stdout", "") or "")):
+            output = str(getattr(result, "stdout", "") or "")
+            if is_package_present(output):
                 foreign = True
                 break
+            if not is_package_missing(output):
+                # 「device not found」「offline」这类：设备根本没连上，判不了归属，
+                # 也不能把这个结论缓存起来——它可能几秒后就上线了
+                logger.debug(f"核对 {serial} 的归属无结论: {output.strip()[:120]}")
+                return False
 
         self._ownership_cache[serial] = (foreign, now + _OWNERSHIP_CACHE_SECONDS)
         if foreign:
@@ -565,7 +572,12 @@ class LDPlayer14Manager(AppLaunchMixin, LDManager):
             outcome = resolve_serial(native_index, serials, others)
             address = outcome.serial
 
-            if await self._is_foreign_serial(address):
+            # 只核对在线实例：关着的和正在启动的 adb 连不上，查了只会得到
+            # 「device not found」；而且启动期间查出的结论会被缓存，等它真上线时
+            # 反而把地址清空。
+            if info.status == DeviceStatus.ONLINE and await self._is_foreign_serial(
+                address
+            ):
                 # 宁可交白卷也不交错的：把别家的设备当成本实例发出去，后面每一条
                 # adb 操作（连接、装包、启动应用）都会打到另一台模拟器上，
                 # 而日志还显示「核对通过」。原因由 _is_foreign_serial 记一次。

--- a/res/version.json
+++ b/res/version.json
@@ -17,6 +17,7 @@
                 "性能与清理 编辑页连续改动不再丢失，配置文件损坏时保留副本而不是静默清空；日志页、模拟器页、签到页与工具页不再高频轮询，任务日志改为增量推送，MAA 起步不再卡顿一秒，运行日志不再被访问记录撑大；并移除前端从不使用的 9 个接口（MCP 同名工具一并消失）与约两万行无用代码 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)"
             ],
             "修复": [
+                "模拟器 2.0 修复雷电实例在关机或启动中时被误判为「别家模拟器」、上线后 ADB 地址被清空、MAA 直接报 ADB 连接异常的问题（beta.5 首日生产实测）",
                 "模拟器 2.0 雷电的 VBox 服务卡住时（窗口开了、虚拟机起不来、MAA 报 ADB 连接异常且反复重试），启动会自动关掉空窗口并重启该服务再试一次；只在所有实例都异常时才动手，只要还有任何一台实例在运行或正在启动就不碰，改为明确提示先关闭它们或运行雷电修复工具 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
                 "模拟器 2.0 的 MuMu 实例启动失败或超时时，报错里附上 MuMu 自己给出的启动错误码、错误信息和实例状态，不再只有一句「启动超时」 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
                 "修复社区通知重复发送、标题重复及同名 Webhook 漏发签到摘要的问题。 by [@HarcoChen](https://github.com/HarcoChen)",

--- a/tests/models/test_emulator2_applaunch.py
+++ b/tests/models/test_emulator2_applaunch.py
@@ -4,6 +4,7 @@ from app.utils.emulator2.applaunch import (
     ensure_app_running,
     is_package_foreground,
     is_package_missing,
+    is_package_present,
     parse_launch_component,
 )
 
@@ -84,6 +85,27 @@ class MissingPackageTest(unittest.TestCase):
         self.assertFalse(
             is_package_missing("adb.exe: device '127.0.0.1:9999' not found")
         )
+
+
+class PresentTest(unittest.TestCase):
+    """「装了」和「没装」之间还有第三态：设备根本没连上。"""
+
+    def test_package_line_means_present(self) -> None:
+        self.assertTrue(
+            is_package_present(
+                "package:/system/system_ext/priv-app/Settings/Settings.apk"
+            )
+        )
+
+    def test_empty_output_is_not_present(self) -> None:
+        self.assertFalse(is_package_present(""))
+
+    def test_offline_device_error_is_not_present(self) -> None:
+        """2026-09-12 生产：关着的雷电实例被这行判成「装着 MuMu 商店」。"""
+        self.assertFalse(
+            is_package_present("adb.exe: device 'emulator-5562' not found")
+        )
+        self.assertFalse(is_package_present("error: device offline"))
 
 
 class ResolveComponentTest(unittest.TestCase):


### PR DESCRIPTION
beta.5 首日生产实测（2026-09-12 17:58 / 18:13，`D:\AUTO-MAS\debug\app.log`）。

## 现象

升到 beta.5、maa1号 切到 Emulator 2.0 后 5 分钟，`Emulator2 雷电管理` 连发五条 WARNING「ADB 序列号 emulator-5554 / 5556 / 5558 / 5562 / 5564 实际连到的是别家模拟器」——正好是当时**关着的**五台雷电实例。18:13 MAA2 号在实例 4 上启动：`Emulator2 应用启动 | 设备 #4 没有可用的 ADB 地址，跳过启动 com.hypergryph.arknights` → `未取到模拟器 adb 地址，跳过游戏版本检查` → MAA「ADB 连接异常」，两轮都是。

## 根因

`_is_foreign_serial` 对每个序列号跑 `adb -s <serial> shell pm path com.mumu.store`，关着的实例得到 `adb.exe: device 'emulator-5562' not found`；判据是 `not is_package_missing(output)`，而 `is_package_missing` 的定义是「输出为空」，错误文本非空 → 当成「装着 MuMu 商店」→ 判外来并缓存 30 秒。`getInfo(None)` 被状态轮询反复调用，实例启动期间（adb 还连不上）也会被探到一次，等它上线时缓存还没过期，地址就被清成空串。实例 3 那次能跑纯属探测时机好。

## 改动

- `applaunch.py` 新增 `is_package_present`：只有 `package:` 行才算装了；「没装」「装了」之外的第三态（掉线 / 错误文本）不下结论、**不缓存**。
- `getInfo` 只对 `ONLINE` 的实例核对归属；关机 / 启动中的一律不查。

## 本地验证

- `tests/models/test_emulator2_applaunch.py` 补 3 例（`package:` 行 / 空 / 掉线错误文本，错误文本逐字抄自当天 adb 输出）；`tests/models -k emulator2` 186 passed；collect-only 退出码 0；ruff 全绿
- 真机：用真实 `ldconsole.exe` 构造管理器，对关着的 `emulator-5556` 调 `_is_foreign_serial` → False 且不入缓存；`getInfo(None)` 六台实例地址全部保留（此前关着的五台会被清空），在线的实例 3 仍正常核对

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

防止 Emulator 2.0 实例在关闭或启动期间被错误分类，确保它们上线后仍能保持 ADB 连接。

Bug 修复：
- 防止已关机或正在启动的 Emulator 2.0 实例被误认为是外部模拟器，并清除其 ADB 地址。
- 当 ADB 报告离线或连接错误时，避免缓存模拟器归属结果。

增强功能：
- 仅对在线实例执行模拟器归属检查，并区分已确认的软件包存在与无法确定的 ADB 输出。

测试：
- 增加对已确认的软件包输出、空输出和 ADB 离线错误的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent Emulator 2.0 instances from being misclassified during shutdown or startup, preserving their ADB connectivity when they come online.

Bug Fixes:
- Prevent powered-off or starting Emulator 2.0 instances from being misidentified as foreign emulators and having their ADB addresses cleared.
- Avoid caching emulator ownership results when ADB reports offline or connection errors.

Enhancements:
- Restrict emulator ownership checks to online instances and distinguish confirmed package presence from indeterminate ADB output.

Tests:
- Add coverage for confirmed package output, empty output, and offline ADB errors.

</details>