### PR TITLE
feat(baah): 首页新增碧蓝档案活动卡片（日服/国际服/国服）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 - 模拟器 2.0 支持由原有全局开关控制的「大雷主人模式」，并新增「打开游戏中心」按钮 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)
 - 初始化 下载前先对各下载源测速并按最快的顺序使用，安装 Python 与依赖时显示当前文件、进度、速度与来源 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)
 - 星铁专项 可以自动更新三月七助手与 SRA 了：默认关闭，开启后在任务全部跑完时检查并安装新版，配置页也能随时手动检查或立即更新；三月七助手走 GitHub 或 Mirror 酱，SRA 还多一个免 CDK 的 AUTO-MAS 下载站。更新采用可回滚的事务方式，中途失败会还原到原版本，你自己的配置文件和另存的自定义策略不会被动到（与上游同名的模板文件会随更新覆盖）；脚本正开着窗口时会跳过本轮而不是强行关掉它 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)
+- BAAH专项 新增碧蓝档案爱丽丝助手脚本支持，可集中管理多个账号的配置并自动完成每日任务
+- BAAH专项 首页新增碧蓝档案活动卡片：可切换日服 / 国际服 / 国服查看进行中的活动与剩余时间，服务器顺序支持拖动调整
 
 ### 变更
 

--- a/app/api/info.py
+++ b/app/api/info.py
@@ -21,6 +21,9 @@
 #   Contact: DLmaster_361@163.com
 
 
+import time
+
+import httpx
 from fastapi import APIRouter, Body
 
 from app.core import Config
@@ -29,6 +32,16 @@ from app.utils import get_logger
 
 router = APIRouter(prefix="/api/info", tags=["信息获取"])
 logger = get_logger("信息获取 API")
+
+## 碧蓝档案活动数据取自 Kivo 古书馆时间轴。该接口对 Origin 做了白名单校验，
+## 只有 kivo.wiki 自己的来源能拿到数据，浏览器直连必定 403，所以由后端中转
+## ——后端请求不带 Origin，可以正常取回。
+## 地址末尾的斜杠不能省：少写会被 301 重定向到带斜杠的版本，而 httpx 默认不跟随。
+KIVO_TIMELINE_URL = "https://api.kivo.wiki/api/v1/timeline/"
+
+## 活动排期变化很慢，缓存十分钟，避免每个前端反复打这个第三方接口
+BLUEARCHIVE_CACHE_TTL = 600
+_bluearchive_cache: dict[str, tuple[float, dict]] = {}
 
 
 @router.post(
@@ -320,3 +333,55 @@ async def get_overview() -> InfoOut:
             "Proxy": proxy,
         }
     )
+
+
+@router.post(
+    "/bluearchive/activity",
+    tags=["Get"],
+    summary="获取碧蓝档案活动数据（Kivo 中转）",
+    response_model=InfoOut,
+    status_code=200,
+)
+async def get_bluearchive_activity(
+    payload: BlueArchiveActivityIn = Body(...),
+) -> InfoOut:
+    """按服务器取回碧蓝档案的活动时间轴。
+
+    这里只做转发：把 Kivo 的响应原样交给前端，筛选与格式转换都由前端完成。
+    之所以要绕一道后端，是因为 Kivo 的接口校验 Origin，浏览器直连必定 403。
+    """
+
+    cache_key = f"{payload.line_type}:{payload.page}:{payload.page_size}"
+    cached = _bluearchive_cache.get(cache_key)
+    if cached is not None and time.time() - cached[0] < BLUEARCHIVE_CACHE_TTL:
+        return InfoOut(data=cached[1])
+
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            response = await client.get(
+                KIVO_TIMELINE_URL,
+                params={
+                    "line_type": payload.line_type,
+                    "page": payload.page,
+                    "page_size": payload.page_size,
+                },
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+                    "Accept": "application/json",
+                },
+            )
+        response.raise_for_status()
+        data = response.json()
+    except Exception as e:
+        logger.opt(exception=True).warning(
+            f"获取碧蓝档案活动数据失败({payload.line_type}): {type(e).__name__}: {e}"
+        )
+        return InfoOut(
+            code=500,
+            status="error",
+            message=f"{type(e).__name__}: {str(e)}",
+            data={},
+        )
+
+    _bluearchive_cache[cache_key] = (time.time(), data)
+    return InfoOut(data=data)

--- a/app/api/info.py
+++ b/app/api/info.py
@@ -41,7 +41,22 @@ KIVO_TIMELINE_URL = "https://api.kivo.wiki/api/v1/timeline/"
 
 ## 活动排期变化很慢，缓存十分钟，避免每个前端反复打这个第三方接口
 BLUEARCHIVE_CACHE_TTL = 600
+
+## 缓存条数上限：参数组合本来就有限（3 个服 × 页数 × 每页条数），
+## 但接口对调用方是开放的，给个上限免得异常调用把进程内存撑大
+BLUEARCHIVE_CACHE_MAX_ENTRIES = 32
 _bluearchive_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _prune_bluearchive_cache(now: float) -> None:
+    """先清掉过期项，仍超出上限时按写入时间淘汰最旧的。"""
+
+    for key in [k for k, v in _bluearchive_cache.items() if now - v[0] >= BLUEARCHIVE_CACHE_TTL]:
+        _bluearchive_cache.pop(key, None)
+
+    while len(_bluearchive_cache) >= BLUEARCHIVE_CACHE_MAX_ENTRIES:
+        oldest = min(_bluearchive_cache, key=lambda key: _bluearchive_cache[key][0])
+        _bluearchive_cache.pop(oldest, None)
 
 
 @router.post(
@@ -383,5 +398,6 @@ async def get_bluearchive_activity(
             data={},
         )
 
+    _prune_bluearchive_cache(time.time())
     _bluearchive_cache[cache_key] = (time.time(), data)
     return InfoOut(data=data)

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -96,8 +96,8 @@ class BlueArchiveActivityIn(BaseModel):
     line_type: Literal["JP", "Globle", "CN"] = Field(
         ..., description="服务器：JP 日服 / Globle 国际服 / CN 国服（原文拼写如此）"
     )
-    page: int = Field(default=1, description="页码，从 1 开始")
-    page_size: int = Field(default=50, description="每页条数")
+    page: int = Field(default=1, ge=1, le=20, description="页码，从 1 开始")
+    page_size: int = Field(default=50, ge=1, le=100, description="每页条数")
 
 
 class BetterGICustomGroupOut(BaseModel):

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -90,6 +90,16 @@ class ComboBoxOut(OutBase):
     data: List[ComboBoxItem] = Field(..., description="下拉框选项")
 
 
+class BlueArchiveActivityIn(BaseModel):
+    """碧蓝档案活动数据查询参数"""
+
+    line_type: Literal["JP", "Globle", "CN"] = Field(
+        ..., description="服务器：JP 日服 / Globle 国际服 / CN 国服（原文拼写如此）"
+    )
+    page: int = Field(default=1, description="页码，从 1 开始")
+    page_size: int = Field(default=50, description="每页条数")
+
+
 class BetterGICustomGroupOut(BaseModel):
     """BetterGI 一条龙自定义配置组（非内置 8 组）"""
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -44,6 +44,7 @@ export type { BetterGIUserConfig_Info } from './models/BetterGIUserConfig_Info';
 export type { BetterGIUserConfig_OneDragon } from './models/BetterGIUserConfig_OneDragon';
 export type { BetterGIUserConfig_Switch } from './models/BetterGIUserConfig_Switch';
 export type { BetterGIUserConfig_Task } from './models/BetterGIUserConfig_Task';
+export { BlueArchiveActivityIn } from './models/BlueArchiveActivityIn';
 export type { Body_batch_update_oknte_configs_api_scripts_oknte_configs_batch_update_post } from './models/Body_batch_update_oknte_configs_api_scripts_oknte_configs_batch_update_post';
 export type { Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post } from './models/Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post';
 export type { CheckImageAllIn } from './models/CheckImageAllIn';

--- a/frontend/src/api/models/BlueArchiveActivityIn.ts
+++ b/frontend/src/api/models/BlueArchiveActivityIn.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * 碧蓝档案活动数据查询参数
+ */
+export type BlueArchiveActivityIn = {
+    /**
+     * 服务器：JP 日服 / Globle 国际服 / CN 国服（原文拼写如此）
+     */
+    line_type: BlueArchiveActivityIn.line_type;
+    /**
+     * 页码，从 1 开始
+     */
+    page?: number;
+    /**
+     * 每页条数
+     */
+    page_size?: number;
+};
+export namespace BlueArchiveActivityIn {
+    /**
+     * 服务器：JP 日服 / Globle 国际服 / CN 国服（原文拼写如此）
+     */
+    export enum line_type {
+        JP = 'JP',
+        GLOBLE = 'Globle',
+        CN = 'CN',
+    }
+}
+

--- a/frontend/src/api/services/GetService.ts
+++ b/frontend/src/api/services/GetService.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { ADBScreenshotIn } from '../models/ADBScreenshotIn';
 import type { ADBScreenshotOut } from '../models/ADBScreenshotOut';
+import type { BlueArchiveActivityIn } from '../models/BlueArchiveActivityIn';
 import type { Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post } from '../models/Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post';
 import type { CheckImageAllIn } from '../models/CheckImageAllIn';
 import type { CheckImageAnyIn } from '../models/CheckImageAnyIn';
@@ -196,6 +197,29 @@ export class GetService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/info/get/overview',
+        });
+    }
+    /**
+     * 获取碧蓝档案活动数据（Kivo 中转）
+     * 按服务器取回碧蓝档案的活动时间轴。
+     *
+     * 这里只做转发：把 Kivo 的响应原样交给前端，筛选与格式转换都由前端完成。
+     * 之所以要绕一道后端，是因为 Kivo 的接口校验 Origin，浏览器直连必定 403。
+     * @param requestBody
+     * @returns InfoOut Successful Response
+     * @throws ApiError
+     */
+    public static getBluearchiveActivityApiInfoBluearchiveActivityPost(
+        requestBody: BlueArchiveActivityIn,
+    ): CancelablePromise<InfoOut> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/info/bluearchive/activity',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
     /**

--- a/frontend/src/api/services/Service.ts
+++ b/frontend/src/api/services/Service.ts
@@ -17,6 +17,7 @@ import type { BetterGIScriptGroupDetailOut } from '../models/BetterGIScriptGroup
 import type { BetterGIScriptGroupSaveIn } from '../models/BetterGIScriptGroupSaveIn';
 import type { BetterGIScriptReadmeOut } from '../models/BetterGIScriptReadmeOut';
 import type { BetterGIScriptSettingsUiOut } from '../models/BetterGIScriptSettingsUiOut';
+import type { BlueArchiveActivityIn } from '../models/BlueArchiveActivityIn';
 import type { Body_batch_update_oknte_configs_api_scripts_oknte_configs_batch_update_post } from '../models/Body_batch_update_oknte_configs_api_scripts_oknte_configs_batch_update_post';
 import type { Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post } from '../models/Body_get_maa_depot_stage_candidates_api_scripts_maa_depot_stage_candidates_post';
 import type { ComboBoxOut } from '../models/ComboBoxOut';
@@ -349,6 +350,29 @@ export class Service {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/info/get/overview',
+        });
+    }
+    /**
+     * 获取碧蓝档案活动数据（Kivo 中转）
+     * 按服务器取回碧蓝档案的活动时间轴。
+     *
+     * 这里只做转发：把 Kivo 的响应原样交给前端，筛选与格式转换都由前端完成。
+     * 之所以要绕一道后端，是因为 Kivo 的接口校验 Origin，浏览器直连必定 403。
+     * @param requestBody
+     * @returns InfoOut Successful Response
+     * @throws ApiError
+     */
+    public static getBluearchiveActivityApiInfoBluearchiveActivityPost(
+        requestBody: BlueArchiveActivityIn,
+    ): CancelablePromise<InfoOut> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/info/bluearchive/activity',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
     /**

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2515,6 +2515,7 @@ export default {
       wutheringwaves: 'Wuthering Waves events',
       nte: 'Neverness to Everness events',
       reverse1999: 'Reverse: 1999 events',
+      bluearchive: 'Blue Archive events',
       arknights: 'Arknights events',
     },
     empty: {
@@ -2559,6 +2560,20 @@ export default {
       nextVersionSoon: 'Next version starts soon',
       versionTime: 'Version window:',
       endedAt: 'Ends {time}',
+    },
+    bluearchive: {
+      serverLabel: 'Server',
+      server: {
+        jp: 'JP',
+        global: 'Global',
+        cn: 'CN',
+      },
+      versionName: '{server} events',
+      unavailable: '{server} event data is temporarily unavailable',
+      noActivity: 'No events running',
+      stale: 'Cached',
+      staleMessage: 'Using the last successfully fetched event data',
+      source: 'Kivo Wiki',
     },
     command: {
       aria: 'Quick task launcher',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2563,6 +2563,7 @@ export default {
     },
     bluearchive: {
       serverLabel: 'Server',
+      serverDragHint: 'Drag to reorder servers',
       server: {
         jp: 'JP',
         global: 'Global',

--- a/frontend/src/i18n/locales/ja-JP.ts
+++ b/frontend/src/i18n/locales/ja-JP.ts
@@ -2198,6 +2198,7 @@ export default {
       wutheringwaves: '鳴潮のイベント情報',
       nte: 'Neverness to Everness のイベント情報',
       reverse1999: 'リバース：1999 のイベント情報',
+      bluearchive: 'ブルーアーカイブのイベント情報',
       arknights: 'アークナイツのイベント情報',
     },
     empty: {
@@ -2242,6 +2243,20 @@ export default {
       nextVersionSoon: 'まもなく次のバージョンが始まります',
       versionTime: 'バージョン期間：',
       endedAt: '{time} 終了',
+    },
+    bluearchive: {
+      serverLabel: 'サーバー',
+      server: {
+        jp: '日本版',
+        global: 'グローバル版',
+        cn: '中国版',
+      },
+      versionName: '{server}のイベント',
+      unavailable: '{server}のイベント情報を一時的に取得できません',
+      noActivity: '開催中のイベントはありません',
+      stale: 'キャッシュ',
+      staleMessage: '前回取得したイベント情報を表示しています',
+      source: 'Kivo 古書館',
     },
     command: {
       aria: 'タスクのクイック起動',

--- a/frontend/src/i18n/locales/ja-JP.ts
+++ b/frontend/src/i18n/locales/ja-JP.ts
@@ -2246,6 +2246,7 @@ export default {
     },
     bluearchive: {
       serverLabel: 'サーバー',
+      serverDragHint: 'ドラッグでサーバーの順番を変更できます',
       server: {
         jp: '日本版',
         global: 'グローバル版',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2409,6 +2409,7 @@ export default {
       wutheringwaves: '鸣潮活动信息',
       nte: '异环活动信息',
       reverse1999: '重返未来：1999活动信息',
+      bluearchive: '碧蓝档案活动信息',
       arknights: '明日方舟活动信息',
     },
     empty: {
@@ -2453,6 +2454,20 @@ export default {
       nextVersionSoon: '即将进入下个版本',
       versionTime: '版本时间：',
       endedAt: '结束于 {time}',
+    },
+    bluearchive: {
+      serverLabel: '服务器',
+      server: {
+        jp: '日服',
+        global: '国际服',
+        cn: '国服',
+      },
+      versionName: '{server}活动',
+      unavailable: '{server}活动数据暂不可用',
+      noActivity: '暂无活动',
+      stale: '缓存数据',
+      staleMessage: '正在使用上次成功获取的活动数据',
+      source: 'Kivo 古书馆',
     },
     command: {
       aria: '调度快速启动',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2457,6 +2457,7 @@ export default {
     },
     bluearchive: {
       serverLabel: '服务器',
+      serverDragHint: '拖动可调整服务器顺序',
       server: {
         jp: '日服',
         global: '国际服',

--- a/frontend/src/types/home.ts
+++ b/frontend/src/types/home.ts
@@ -10,6 +10,7 @@ export type HomeModuleKey =
   | 'wutheringwaves'
   | 'nte'
   | 'reverse1999'
+  | 'bluearchive'
   | 'arknights'
 
 export interface HomeLayoutConfig {
@@ -135,6 +136,21 @@ export type ZenlessZoneZeroActivityOverview = SraActivityOverview
 export type WutheringWavesActivityOverview = SraActivityOverview
 export type NevernessToEvernessActivityOverview = SraActivityOverview
 export type Reverse1999ActivityOverview = SraActivityOverview
+export type BlueArchiveActivityOverview = SraActivityOverview
+
+/** 碧蓝档案的三个服务器；与数据源的 line_type 一一对应 */
+export type BlueArchiveServerKey = 'jp' | 'global' | 'cn'
+
+/**
+ * 单张碧蓝档案卡片要同时承载三个服的数据：数据源按服各拉一次，
+ * 卡片内用分段控件切换展示，任一服失败只影响它自己。
+ */
+export interface BlueArchiveServerOverview {
+  key: BlueArchiveServerKey
+  /** 已按当前界面语言本地化的服名（日服 / 国际服 / 国服），直接用作切换控件文案 */
+  label: string
+  overview: BlueArchiveActivityOverview
+}
 
 export const createEmptySraActivityOverview = (): SraActivityOverview => ({
   Available: false,

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -148,6 +148,14 @@
             :loading="reverse1999Source.loading.value"
             :overview="reverse1999Source.overview.value"
           />
+
+          <HomeBlueArchiveOverview
+            v-else-if="moduleKey === 'bluearchive'"
+            :servers="blueArchiveSource.servers.value"
+            :selected="blueArchiveSource.selectedServer.value"
+            :loading-by-server="blueArchiveSource.loadingByServer"
+            @select="blueArchiveSource.selectServer"
+          />
         </section>
       </template>
     </div>
@@ -166,6 +174,7 @@ import SatelliteAnimation from '@/components/SatelliteAnimation.vue'
 import { useAppInitialization } from '@/composables/useAppInitialization'
 import HomeArknightsOverview from '@/views/home/components/HomeArknightsOverview.vue'
 import HomeBackToTop from '@/views/home/components/HomeBackToTop.vue'
+import HomeBlueArchiveOverview from '@/views/home/components/HomeBlueArchiveOverview.vue'
 import HomeCommandCard from '@/views/home/components/HomeCommandCard.vue'
 import HomeEndfieldOverview from '@/views/home/components/HomeEndfieldOverview.vue'
 import HomeLayoutDrawer from '@/views/home/components/HomeLayoutDrawer.vue'
@@ -179,6 +188,7 @@ import { useHomeNotice } from '@/views/home/useHomeNotice'
 import { useHomeOverview } from '@/views/home/useHomeOverview'
 import { useSraActivitySource } from '@/views/home/useSraActivitySource'
 import { useReverse1999ActivitySource } from '@/views/home/useReverse1999ActivitySource'
+import { useBlueArchiveActivitySource } from '@/views/home/useBlueArchiveActivitySource'
 import { useEndfieldActivitySource } from '@/views/home/useEndfieldActivitySource'
 import type { HomeModuleKey } from '@/types/home'
 import { useHomeQuickStart } from '@/views/home/useHomeQuickStart'
@@ -238,6 +248,7 @@ const zenlessSource = useSraActivitySource('zzz', t('home.module.zenless'))
 const wutheringWavesSource = useSraActivitySource('ww', t('home.module.wutheringwaves'))
 const nevernessToEvernessSource = useSraActivitySource('nte', t('home.module.nte'))
 const reverse1999Source = useReverse1999ActivitySource()
+const blueArchiveSource = useBlueArchiveActivitySource()
 const endfieldSource = useEndfieldActivitySource()
 
 // 只有模块可见时才拉活动数据；布局要等 loadHomeLayout 读回来才知道哪些模块被隐藏，
@@ -249,6 +260,7 @@ const activitySourcesByModule: Array<[HomeModuleKey, { start: () => void; stop: 
   ['wutheringwaves', wutheringWavesSource],
   ['nte', nevernessToEvernessSource],
   ['reverse1999', reverse1999Source],
+  ['bluearchive', blueArchiveSource],
   ['endfield', endfieldSource],
 ]
 for (const [moduleKey, source] of activitySourcesByModule) {

--- a/frontend/src/views/home/components/HomeBlueArchiveOverview.vue
+++ b/frontend/src/views/home/components/HomeBlueArchiveOverview.vue
@@ -1,0 +1,531 @@
+<template>
+  <a-card
+    :title="t('home.module.bluearchive')"
+    class="bluearchive-card"
+    :style="cardStyle"
+    :loading="currentLoading"
+  >
+    <template #extra>
+      <div class="card-extra">
+        <a-typography-link
+          href="https://kivo.wiki/timeline"
+          target="_blank"
+          rel="noreferrer"
+          class="source-link"
+          @click="handleExternalLink"
+        >
+          {{ t('home.bluearchive.source') }}
+        </a-typography-link>
+        <a-tag v-if="overview.Stale" color="orange">{{ t('home.bluearchive.stale') }}</a-tag>
+      </div>
+    </template>
+
+    <!-- 三个服的数据在数据源里已并行拉好，这里只切显示，不重新请求 -->
+    <div class="server-switch" role="group" :aria-label="t('home.bluearchive.serverLabel')">
+      <span class="server-switch-label">{{ t('home.bluearchive.serverLabel') }}</span>
+      <a-segmented :value="selected" :options="serverOptions" @change="onServerChange" />
+    </div>
+
+    <!-- 当前服的失败提示：只影响这一个服，切到其它服照常显示 -->
+    <a-alert
+      v-if="overview.Message"
+      :message="overview.Message"
+      :type="overview.Available ? 'warning' : 'error'"
+      show-icon
+      class="status-alert"
+    />
+
+    <div
+      v-if="overview.Available && !currentLoading && !overview.activities.length"
+      class="empty-state"
+    >
+      <a-empty :description="t('home.bluearchive.noActivity')" />
+    </div>
+
+    <!-- 活动 Banner（超高竖图只显示上部条带） -->
+    <div v-else-if="overview.Available && !currentLoading && versionCover" class="version-banner">
+      <img
+        :src="versionCover"
+        :alt="overview.versionName"
+        class="version-cover"
+        @error="failedVersionCover = true"
+      />
+      <div class="version-overlay" />
+
+      <div class="version-content">
+        <div class="version-badge">
+          <span class="badge-dot" />
+          <span class="badge-text">{{
+            t('home.sra.versionBadge', { version: overview.version })
+          }}</span>
+        </div>
+
+        <div class="version-name">{{ overview.versionName }}</div>
+
+        <div class="version-time">
+          <ClockCircleOutlined class="version-time-icon" />
+          <span>{{ t('home.sra.endsAt', { time: formatTime(overview.endTime) }) }}</span>
+        </div>
+
+        <div v-if="activeActivities.length" class="activity-tags">
+          <a-tag
+            v-for="activity in activeActivities"
+            :key="`${activity.name}-${activity.endTime}`"
+            class="activity-tag"
+          >
+            {{ activity.name }}
+          </a-tag>
+        </div>
+      </div>
+
+      <div class="version-remaining">
+        <div class="remaining-label">{{ t('home.sra.versionRemaining') }}</div>
+        <a-statistic-countdown
+          :value="getCountdownValue(overview.endTime)"
+          :format="t('home.countdown.dh')"
+          :value-style="remainingCountdownStyle"
+        />
+        <div class="remaining-sub">{{ t('home.sra.nextVersionSoon') }}</div>
+      </div>
+    </div>
+
+    <!-- 无活动封面：简洁信息条 -->
+    <div v-else-if="overview.Available && !currentLoading" class="version-info">
+      <div class="version-info-left">
+        <div class="version-info-name">{{ overview.versionName }}</div>
+        <div class="version-info-time">
+          <ClockCircleOutlined class="version-info-time-icon" />
+          <span class="version-info-time-label">{{ t('home.sra.versionTime') }}</span>
+          <span class="version-info-time-value"
+            >{{ formatTime(overview.startTime) }} ~ {{ formatTime(overview.endTime) }}</span
+          >
+        </div>
+      </div>
+
+      <div class="version-info-right">
+        <a-statistic-countdown
+          :title="t('home.sra.versionRemaining')"
+          :value="getCountdownValue(overview.endTime)"
+          :format="
+            getPlainTimeStatus(overview.endTime) === 'ended'
+              ? t('home.countdown.ended')
+              : t('home.countdown.dh')
+          "
+          :value-style="plainRemainingCountdownStyle"
+        />
+      </div>
+    </div>
+  </a-card>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { computed, ref, watch } from 'vue'
+import type { CSSProperties } from 'vue'
+import { ClockCircleOutlined } from '@ant-design/icons-vue'
+import { createEmptySraActivityOverview } from '@/types/home'
+import type {
+  BlueArchiveActivityOverview,
+  BlueArchiveServerKey,
+  BlueArchiveServerOverview,
+} from '@/types/home'
+import { handleExternalLink } from '@/utils/openExternal'
+
+defineOptions({ name: 'HomeBlueArchiveOverview' })
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  servers: BlueArchiveServerOverview[]
+  selected: BlueArchiveServerKey
+  loadingByServer: Record<BlueArchiveServerKey, boolean>
+}>()
+
+const emit = defineEmits<{
+  select: [server: BlueArchiveServerKey]
+}>()
+
+const ACCENT = '#3ba9ee'
+const MAX_VISIBLE_ACTIVITIES = 4
+const failedVersionCover = ref(false)
+
+const cardStyle = computed<CSSProperties>(
+  () =>
+    ({
+      '--bluearchive-accent': ACCENT,
+    }) as CSSProperties
+)
+
+const currentServer = computed(() => props.servers.find(server => server.key === props.selected))
+
+const overview = computed<BlueArchiveActivityOverview>(
+  () => currentServer.value?.overview ?? createEmptySraActivityOverview()
+)
+
+// 每个服各有自己的加载态，卡片只关心当前选中的这个服
+const currentLoading = computed(() => props.loadingByServer[props.selected] === true)
+
+// 封面加载失败是「上一张图」的结果，切换服务器时必须重新判定，否则一个服取不到图会拖累其它服
+watch(
+  () => props.selected,
+  () => {
+    failedVersionCover.value = false
+  }
+)
+
+const serverOptions = computed(() =>
+  props.servers.map(server => ({ label: server.label, value: server.key }))
+)
+
+const onServerChange = (value: string | number) => {
+  const matched = props.servers.find(server => server.key === value)
+  if (matched) {
+    emit('select', matched.key)
+  }
+}
+
+const activeActivities = computed(() => {
+  const now = Date.now()
+  return overview.value.activities
+    .filter(activity => {
+      return (
+        getCountdownValue(activity.startTime) <= now && getCountdownValue(activity.endTime) > now
+      )
+    })
+    .sort((left, right) => getCountdownValue(left.endTime) - getCountdownValue(right.endTime))
+    .slice(0, MAX_VISIBLE_ACTIVITIES)
+})
+
+const versionCover = computed(() => {
+  if (failedVersionCover.value) return ''
+  return (
+    overview.value.cover ||
+    overview.value.activities.find(activity => activity.cover)?.cover ||
+    ''
+  )
+})
+
+const remainingCountdownStyle = computed<CSSProperties>(() => ({
+  color: ACCENT,
+  fontSize: '34px',
+  fontWeight: 700,
+  lineHeight: 1.1,
+  fontVariantNumeric: 'tabular-nums',
+}))
+
+const getPlainTimeStatus = (value: string): 'normal' | 'warning' | 'ended' => {
+  const remaining = getCountdownValue(value) - Date.now()
+  if (remaining <= 0) return 'ended'
+  if (remaining <= 2 * 24 * 60 * 60 * 1000) return 'warning'
+  return 'normal'
+}
+
+const plainRemainingCountdownStyle = computed<CSSProperties>(() => {
+  const status = getPlainTimeStatus(overview.value.endTime)
+  if (status === 'ended') {
+    return { color: 'var(--ant-color-error)', fontWeight: 600, fontSize: '18px' }
+  }
+  if (status === 'warning') {
+    return { color: 'var(--ant-color-warning)', fontWeight: 600, fontSize: '18px' }
+  }
+  return { color: 'var(--ant-color-text)', fontWeight: 600, fontSize: '18px' }
+})
+
+const getCountdownValue = (value: string) => new Date(value).getTime()
+
+const formatTime = (value: string) =>
+  new Date(value).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+</script>
+
+<style scoped>
+.bluearchive-card {
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.bluearchive-card :deep(.ant-card-head-title) {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.card-extra {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.source-link {
+  font-size: 13px;
+}
+
+.server-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.server-switch-label {
+  color: var(--ant-color-text-secondary);
+  font-size: 13px;
+}
+
+.status-alert {
+  margin-bottom: 16px;
+}
+
+.empty-state {
+  padding: 24px 0;
+}
+
+/* ---------- 活动 Banner ---------- */
+.version-banner {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  min-height: 300px;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background:
+    radial-gradient(
+      ellipse at 78% 20%,
+      color-mix(in srgb, var(--bluearchive-accent) 14%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(ellipse at 90% 85%, rgba(64, 128, 255, 0.18), transparent 60%),
+    linear-gradient(135deg, #0b1220 0%, #101a2e 55%, #0e1a2b 100%);
+}
+
+.version-cover {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+  /* Kivo 时间轴配图多为竖图，只显示上部约 14% 处的条带 */
+  object-position: right 14%;
+}
+
+.version-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(11, 18, 32, 0.9) 0%,
+    rgba(11, 18, 32, 0.72) 42%,
+    rgba(11, 18, 32, 0.15) 100%
+  );
+}
+
+.version-content {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 28px 32px;
+  color: white;
+}
+
+.version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 12px;
+  margin-bottom: 12px;
+  border: 1px solid color-mix(in srgb, var(--bluearchive-accent) 45%, transparent);
+  border-radius: 999px;
+  background: rgba(11, 18, 32, 0.55);
+}
+
+.badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--bluearchive-accent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--bluearchive-accent) 80%, transparent);
+}
+
+.badge-text {
+  color: var(--bluearchive-accent);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.version-name {
+  margin-bottom: 14px;
+  color: white;
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  overflow-wrap: anywhere;
+}
+
+.version-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 6px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(11, 18, 32, 0.5);
+  color: white;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.version-time-icon {
+  color: var(--bluearchive-accent);
+  font-size: 15px;
+}
+
+/* ---------- 活动标签 ---------- */
+.activity-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.activity-tag {
+  margin-inline-end: 0;
+  border: 1px solid color-mix(in srgb, var(--bluearchive-accent) 45%, transparent);
+  border-radius: 999px;
+  background: rgba(11, 18, 32, 0.55);
+  color: white;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+/* ---------- 剩余时间 ---------- */
+.version-remaining {
+  position: relative;
+  z-index: 1;
+  align-self: center;
+  margin-right: 28px;
+  padding: 18px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--bluearchive-accent) 35%, transparent);
+  border-radius: 14px;
+  background: rgba(11, 18, 32, 0.6);
+  backdrop-filter: blur(10px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.35),
+    inset 0 0 24px color-mix(in srgb, var(--bluearchive-accent) 5%, transparent);
+  white-space: nowrap;
+}
+
+.remaining-label {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.08em;
+}
+
+.version-remaining :deep(.ant-statistic-content) {
+  color: var(--bluearchive-accent);
+  font-size: 34px;
+  font-weight: 700;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 20px color-mix(in srgb, var(--bluearchive-accent) 35%, transparent);
+}
+
+.remaining-sub {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  line-height: 1;
+}
+
+/* ---------- 无封面：简洁信息条 ---------- */
+.version-info {
+  padding: 16px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px;
+}
+
+.version-info-left {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.version-info-name {
+  color: var(--ant-color-text);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.version-info-time {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.version-info-time-icon,
+.version-info-time-label {
+  color: var(--ant-color-text-secondary);
+}
+
+.version-info-time-value {
+  color: var(--ant-color-text);
+  font-weight: 500;
+}
+
+.version-info-right {
+  flex-shrink: 0;
+  text-align: right;
+}
+
+@media (max-width: 800px) {
+  .version-banner {
+    flex-direction: column;
+  }
+
+  .version-name {
+    font-size: 26px;
+  }
+
+  .version-remaining {
+    align-self: stretch;
+    align-items: flex-start;
+    margin: 0 28px 24px;
+  }
+
+  .version-info {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .version-info-right {
+    text-align: left;
+  }
+}
+</style>

--- a/frontend/src/views/home/components/HomeBlueArchiveOverview.vue
+++ b/frontend/src/views/home/components/HomeBlueArchiveOverview.vue
@@ -23,7 +23,24 @@
     <!-- 三个服的数据在数据源里已并行拉好，这里只切显示，不重新请求 -->
     <div class="server-switch" role="group" :aria-label="t('home.bluearchive.serverLabel')">
       <span class="server-switch-label">{{ t('home.bluearchive.serverLabel') }}</span>
-      <a-segmented :value="selected" :options="serverOptions" @change="onServerChange" />
+      <!-- 拖动即可调整顺序，顺序记在本地 -->
+      <div class="server-tabs" :title="t('home.bluearchive.serverDragHint')">
+        <button
+          v-for="(server, index) in orderedServers"
+          :key="server.key"
+          type="button"
+          class="server-tab"
+          :class="{ 'is-active': server.key === selected, 'is-dragging': dragIndex === index }"
+          draggable="true"
+          @click="emit('select', server.key)"
+          @dragstart="onDragStart(index, $event)"
+          @dragover.prevent="onDragOver(index)"
+          @dragend="onDragEnd"
+          @drop.prevent="onDragEnd"
+        >
+          {{ server.label }}
+        </button>
+      </div>
     </div>
 
     <!-- 当前服的失败提示：只影响这一个服，切到其它服照常显示 -->
@@ -173,15 +190,65 @@ watch(
   }
 )
 
-const serverOptions = computed(() =>
-  props.servers.map(server => ({ label: server.label, value: server.key }))
-)
+/** 服务器显示顺序的本地记忆键；顺序只影响展示，不影响各自取数 */
+const SERVER_ORDER_STORAGE_KEY = 'auto-mas.home.bluearchive-server-order'
 
-const onServerChange = (value: string | number) => {
-  const matched = props.servers.find(server => server.key === value)
-  if (matched) {
-    emit('select', matched.key)
+const readStoredOrder = (): BlueArchiveServerKey[] => {
+  try {
+    const raw = localStorage.getItem(SERVER_ORDER_STORAGE_KEY)
+    const parsed: unknown = raw ? JSON.parse(raw) : []
+    if (Array.isArray(parsed)) {
+      return parsed.filter((key): key is BlueArchiveServerKey => typeof key === 'string')
+    }
+  } catch {
+    // 记忆损坏时退回默认顺序即可，不影响卡片显示
   }
+  return []
+}
+
+const serverOrder = ref<BlueArchiveServerKey[]>(readStoredOrder())
+const dragIndex = ref<number | null>(null)
+
+/** 按用户拖出来的顺序排列；顺序里还没有的（例如以后新增服务器）接在末尾 */
+const orderedServers = computed(() => {
+  const byKey = new Map(props.servers.map(server => [server.key, server]))
+  const ordered = serverOrder.value
+    .map(key => byKey.get(key))
+    .filter((server): server is BlueArchiveServerOverview => server !== undefined)
+  const listed = new Set(ordered.map(server => server.key))
+  return [...ordered, ...props.servers.filter(server => !listed.has(server.key))]
+})
+
+const persistServerOrder = () => {
+  try {
+    localStorage.setItem(SERVER_ORDER_STORAGE_KEY, JSON.stringify(serverOrder.value))
+  } catch {
+    // 存储不可用时只保留本次会话的顺序
+  }
+}
+
+const onDragStart = (index: number, event: DragEvent) => {
+  dragIndex.value = index
+  event.dataTransfer?.setData('text/plain', String(index))
+}
+
+/** 拖到哪一格就实时插到哪一格，松手才算数（dragend 统一落盘） */
+const onDragOver = (index: number) => {
+  const from = dragIndex.value
+  if (from === null || from === index) return
+
+  const keys = orderedServers.value.map(server => server.key)
+  const [moved] = keys.splice(from, 1)
+  keys.splice(index, 0, moved)
+  serverOrder.value = keys
+  dragIndex.value = index
+}
+
+const onDragEnd = () => {
+  if (dragIndex.value === null) return
+  dragIndex.value = null
+  serverOrder.value = orderedServers.value.map(server => server.key)
+  persistServerOrder()
 }
 
 const activeActivities = computed(() => {
@@ -207,7 +274,7 @@ const versionCover = computed(() => {
 
 const remainingCountdownStyle = computed<CSSProperties>(() => ({
   color: ACCENT,
-  fontSize: '34px',
+  fontSize: '28px',
   fontWeight: 700,
   lineHeight: 1.1,
   fontVariantNumeric: 'tabular-nums',
@@ -276,6 +343,46 @@ const formatTime = (value: string) =>
   font-size: 13px;
 }
 
+/* 自己做分段控件而不用 a-segmented：那一排要能拖动排序 */
+.server-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--ant-color-fill-tertiary);
+}
+
+.server-tab {
+  padding: 4px 14px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ant-color-text);
+  font-size: 14px;
+  line-height: 22px;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.server-tab:hover {
+  color: var(--bluearchive-accent);
+}
+
+.server-tab.is-active {
+  background: var(--ant-color-bg-container);
+  color: var(--bluearchive-accent);
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.server-tab.is-dragging {
+  opacity: 0.5;
+}
+
 .status-alert {
   margin-bottom: 16px;
 }
@@ -290,7 +397,7 @@ const formatTime = (value: string) =>
   display: flex;
   align-items: stretch;
   justify-content: space-between;
-  min-height: 300px;
+  min-height: 380px;
   overflow: hidden;
   border: 1px solid transparent;
   border-radius: 10px;
@@ -413,18 +520,19 @@ const formatTime = (value: string) =>
 }
 
 /* ---------- 剩余时间 ---------- */
+/* 贴右下角、压成一行：封面里的人物多在画面中部，浮层居中会挡脸 */
 .version-remaining {
   position: relative;
   z-index: 1;
-  align-self: center;
-  margin-right: 28px;
-  padding: 18px 28px;
+  align-self: flex-end;
+  margin: 0 28px 20px 0;
+  padding: 12px 22px;
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
   border: 1px solid color-mix(in srgb, var(--bluearchive-accent) 35%, transparent);
-  border-radius: 14px;
+  border-radius: 12px;
   background: rgba(11, 18, 32, 0.6);
   backdrop-filter: blur(10px);
   box-shadow:
@@ -442,7 +550,7 @@ const formatTime = (value: string) =>
 
 .version-remaining :deep(.ant-statistic-content) {
   color: var(--bluearchive-accent);
-  font-size: 34px;
+  font-size: 28px;
   font-weight: 700;
   line-height: 1.1;
   font-variant-numeric: tabular-nums;
@@ -507,6 +615,7 @@ const formatTime = (value: string) =>
 @media (max-width: 800px) {
   .version-banner {
     flex-direction: column;
+    min-height: 320px;
   }
 
   .version-name {
@@ -515,8 +624,8 @@ const formatTime = (value: string) =>
 
   .version-remaining {
     align-self: stretch;
-    align-items: flex-start;
-    margin: 0 28px 24px;
+    justify-content: flex-end;
+    margin: 0 24px 20px;
   }
 
   .version-info {

--- a/frontend/src/views/home/useBlueArchiveActivitySource.ts
+++ b/frontend/src/views/home/useBlueArchiveActivitySource.ts
@@ -43,7 +43,8 @@ const SERVER_LINE_TYPES: Record<BlueArchiveServerKey, BlueArchiveActivityIn.line
   cn: BlueArchiveActivityIn.line_type.CN,
 }
 
-const SERVER_KEYS: BlueArchiveServerKey[] = ['jp', 'global', 'cn']
+/** 默认展示顺序：国服优先（国服玩家最多），三个服的先后不影响各自独立取数 */
+const SERVER_KEYS: BlueArchiveServerKey[] = ['cn', 'jp', 'global']
 
 /**
  * 固定 +08:00 偏移（Asia/Shanghai 无夏令时）。
@@ -228,7 +229,7 @@ export const useBlueArchiveActivitySource = () => {
     global: false,
     cn: false,
   })
-  const selectedServer = ref<BlueArchiveServerKey>('jp')
+  const selectedServer = ref<BlueArchiveServerKey>(SERVER_KEYS[0])
 
   let active = false
   let started = false

--- a/frontend/src/views/home/useBlueArchiveActivitySource.ts
+++ b/frontend/src/views/home/useBlueArchiveActivitySource.ts
@@ -1,5 +1,6 @@
 import { computed, onScopeDispose, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { BlueArchiveActivityIn, GetService } from '@/api'
 import { createEmptySraActivityOverview } from '@/types/home'
 import type {
   BlueArchiveActivityOverview,
@@ -15,7 +16,11 @@ const FETCH_TIMEOUT_MS = 20_000
 const RETRY_DELAY_MS = 30_000
 const MAX_RETRIES = 8
 
-const SOURCE_URL = 'https://api.kivo.wiki/api/v1/timeline'
+/**
+ * 数据取自 Kivo 古书馆时间轴，但那个接口对 Origin 做了白名单校验（只放行
+ * kivo.wiki 自己的来源），浏览器直连必定 403，因此统一走本软件后端中转。
+ * 后端只做转发，筛选与格式转换仍在这里完成。
+ */
 
 /** 每页 50 条且按时间倒序，3 页足以覆盖最近数周 */
 const PAGE_SIZE = 50
@@ -32,10 +37,10 @@ const DESCRIPTION_MAX_LENGTH = 200
 const WANTED_TYPE = 'Event'
 
 /** 三个服与 Kivo 的 line_type 对应关系（国际服的原文拼写就是 Globle） */
-const SERVER_LINE_TYPES: Record<BlueArchiveServerKey, string> = {
-  jp: 'JP',
-  global: 'Globle',
-  cn: 'CN',
+const SERVER_LINE_TYPES: Record<BlueArchiveServerKey, BlueArchiveActivityIn.line_type> = {
+  jp: BlueArchiveActivityIn.line_type.JP,
+  global: BlueArchiveActivityIn.line_type.GLOBLE,
+  cn: BlueArchiveActivityIn.line_type.CN,
 }
 
 const SERVER_KEYS: BlueArchiveServerKey[] = ['jp', 'global', 'cn']
@@ -164,16 +169,29 @@ const fetchTimeline = async (
 ): Promise<KivoTimelineItem[]> => {
   const items: KivoTimelineItem[] = []
   for (let page = 1; page <= MAX_PAGES; page += 1) {
-    const query =
-      'line_type=' + SERVER_LINE_TYPES[server] + '&page=' + page + '&page_size=' + PAGE_SIZE
-    const response = await fetch(SOURCE_URL + '?' + query, {
-      signal,
-      headers: { Accept: 'application/json' },
+    const request = GetService.getBluearchiveActivityApiInfoBluearchiveActivityPost({
+      line_type: SERVER_LINE_TYPES[server],
+      page,
+      page_size: PAGE_SIZE,
     })
-    if (!response.ok) {
-      throw new Error('HTTP ' + response.status)
+
+    // 生成的客户端返回 CancelablePromise、不接受 AbortSignal，
+    // 用它自带的 cancel 桥接外层的整体超时，避免超时后请求还悬着
+    const cancelOnAbort = () => request.cancel()
+    signal.addEventListener('abort', cancelOnAbort, { once: true })
+
+    let payload: KivoTimelineResponse
+    try {
+      const result = await request
+      if (result.code !== 200) {
+        throw new Error(result.message || 'HTTP ' + result.code)
+      }
+      // 后端把 Kivo 的响应原样放在 data 里
+      payload = result.data as unknown as KivoTimelineResponse
+    } finally {
+      signal.removeEventListener('abort', cancelOnAbort)
     }
-    const payload = (await response.json()) as KivoTimelineResponse
+
     const batch = payload.data?.timeline
     if (!Array.isArray(batch) || batch.length === 0) break
     items.push(...batch)

--- a/frontend/src/views/home/useBlueArchiveActivitySource.ts
+++ b/frontend/src/views/home/useBlueArchiveActivitySource.ts
@@ -1,0 +1,365 @@
+import { computed, onScopeDispose, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createEmptySraActivityOverview } from '@/types/home'
+import type {
+  BlueArchiveActivityOverview,
+  BlueArchiveServerKey,
+  BlueArchiveServerOverview,
+} from '@/types/home'
+import type { Ref } from 'vue'
+
+const logger = window.electronAPI.getLogger('活动数据')
+
+/** 与其它活动源一致的请求超时与失败重试节奏 */
+const FETCH_TIMEOUT_MS = 20_000
+const RETRY_DELAY_MS = 30_000
+const MAX_RETRIES = 8
+
+const SOURCE_URL = 'https://api.kivo.wiki/api/v1/timeline'
+
+/** 每页 50 条且按时间倒序，3 页足以覆盖最近数周 */
+const PAGE_SIZE = 50
+const MAX_PAGES = 3
+
+/** 往前多带几天已经结束的活动，让卡片在活动间隙里也有内容可显示 */
+const RECENT_WINDOW_DAYS = 14
+const SECONDS_PER_DAY = 86_400
+
+/** Kivo 的 body_summary 很长（含话题标签），按卡片展示宽度截断 */
+const DESCRIPTION_MAX_LENGTH = 200
+
+/** 只取「活动」；卡池、掉落加倍、维护等分类不进卡片 */
+const WANTED_TYPE = 'Event'
+
+/** 三个服与 Kivo 的 line_type 对应关系（国际服的原文拼写就是 Globle） */
+const SERVER_LINE_TYPES: Record<BlueArchiveServerKey, string> = {
+  jp: 'JP',
+  global: 'Globle',
+  cn: 'CN',
+}
+
+const SERVER_KEYS: BlueArchiveServerKey[] = ['jp', 'global', 'cn']
+
+/**
+ * 固定 +08:00 偏移（Asia/Shanghai 无夏令时）。
+ * Kivo 的时间戳是 Unix 秒，而 SRA 格式的时间字段不带时区标记、按其惯例填北京时间。
+ */
+const TIMEZONE_OFFSET_MS = 8 * 60 * 60 * 1000
+
+interface KivoTimelineItem {
+  title?: string
+  image?: string
+  body_summary?: string
+  type?: string
+  start_time?: number
+  end_time?: number
+}
+
+interface KivoTimelineResponse {
+  data?: { timeline?: KivoTimelineItem[] }
+}
+
+/** 快照里存整份 overview，恢复时重置 Stale / Message 这两个运行时元数据 */
+const snapshotKey = (server: BlueArchiveServerKey) => 'auto-mas.home.bluearchive-snapshot.' + server
+
+const pad = (value: number) => String(value).padStart(2, '0')
+
+/** Unix 秒 → 北京时间的 ISO 串（不带时区标记，与 SRA 现有字段惯例一致） */
+const formatTime = (seconds: number): string => {
+  const shifted = new Date(seconds * 1000 + TIMEZONE_OFFSET_MS)
+  return (
+    shifted.getUTCFullYear() +
+    '-' +
+    pad(shifted.getUTCMonth() + 1) +
+    '-' +
+    pad(shifted.getUTCDate()) +
+    'T' +
+    pad(shifted.getUTCHours()) +
+    ':' +
+    pad(shifted.getUTCMinutes()) +
+    ':' +
+    pad(shifted.getUTCSeconds())
+  )
+}
+
+/** 碧蓝档案没有版本号概念，用北京时间当月占位，保证字段齐全 */
+const currentMonth = (): string => {
+  const shifted = new Date(Date.now() + TIMEZONE_OFFSET_MS)
+  return shifted.getUTCFullYear() + '-' + pad(shifted.getUTCMonth() + 1)
+}
+
+/** Kivo 的图片地址是协议相对 URL（//static...），补全为 https */
+const normalizeImage = (image: string | undefined): string => {
+  if (!image) return ''
+  return image.startsWith('//') ? 'https:' + image : image
+}
+
+/**
+ * 原始时间轴 → SRA 活动条目：筛分类、去重、按开始时间升序。
+ *
+ * 与 Kivo 时间轴的取值口径保持一致：同一活动可能被拆成「活动」与
+ * 「活动介绍PV」等多条记录，只保留结束时间最晚的那条。
+ */
+const buildActivities = (items: KivoTimelineItem[], nowSeconds: number) => {
+  const horizon = nowSeconds - RECENT_WINDOW_DAYS * SECONDS_PER_DAY
+  const picked = new Map<string, { item: KivoTimelineItem; start: number; end: number }>()
+
+  for (const item of items) {
+    if (item.type !== WANTED_TYPE) continue
+    const start = item.start_time
+    const end = item.end_time
+    if (typeof start !== 'number' || typeof end !== 'number') continue
+    if (end < horizon) continue
+
+    const name = (item.title ?? '').trim()
+    if (!name) continue
+
+    const existing = picked.get(name)
+    if (existing && existing.end >= end) continue
+    picked.set(name, { item, start, end })
+  }
+
+  return [...picked.entries()]
+    .sort((left, right) => left[1].start - right[1].start)
+    .map(([name, row]) => ({
+      name,
+      description: (row.item.body_summary ?? '').trim().slice(0, DESCRIPTION_MAX_LENGTH),
+      startTime: formatTime(row.start),
+      endTime: formatTime(row.end),
+      cover: normalizeImage(row.item.image),
+    }))
+}
+
+const buildOverview = (
+  items: KivoTimelineItem[],
+  versionName: string
+): BlueArchiveActivityOverview => {
+  const activities = buildActivities(items, Date.now() / 1000)
+  return {
+    Available: true,
+    Stale: false,
+    Message: '',
+    version: currentMonth(),
+    versionName,
+    startTime: activities[0]?.startTime ?? '',
+    endTime: activities[activities.length - 1]?.endTime ?? '',
+    activities,
+  }
+}
+
+/** 一个服务器的运行时状态：重试计数与定时器按服隔离，一个服挂掉不拖累另外两个 */
+interface ServerRuntime {
+  key: BlueArchiveServerKey
+  overview: Ref<BlueArchiveActivityOverview>
+  retryTimer: number | null
+  retryCount: number
+  hasData: boolean
+  retryPending: boolean
+}
+
+/** 拉取一个服的完整时间轴（分页直到空页或达到页数上限） */
+const fetchTimeline = async (
+  server: BlueArchiveServerKey,
+  signal: AbortSignal
+): Promise<KivoTimelineItem[]> => {
+  const items: KivoTimelineItem[] = []
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const query =
+      'line_type=' + SERVER_LINE_TYPES[server] + '&page=' + page + '&page_size=' + PAGE_SIZE
+    const response = await fetch(SOURCE_URL + '?' + query, {
+      signal,
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) {
+      throw new Error('HTTP ' + response.status)
+    }
+    const payload = (await response.json()) as KivoTimelineResponse
+    const batch = payload.data?.timeline
+    if (!Array.isArray(batch) || batch.length === 0) break
+    items.push(...batch)
+  }
+  return items
+}
+
+/**
+ * 碧蓝档案活动数据的直连数据源（Kivo 古书馆时间轴）。
+ *
+ * 与其它活动源的职责一致：带超时、失败退避重试、本地快照
+ * （stale-while-revalidate）与独立失败态。区别在于碧蓝档案分日/国际/国
+ * 三个服，这里为每个服各跑一份完整状态——请求、重试、快照、错误都不互通，
+ * 所以一个服不可用时另外两个服照常显示，卡片也只需切显示、无需重新请求。
+ */
+export const useBlueArchiveActivitySource = () => {
+  const { t } = useI18n()
+
+  const serverLabel = (server: BlueArchiveServerKey) => t(`home.bluearchive.server.${server}`)
+  const serverVersionName = (server: BlueArchiveServerKey) =>
+    t('home.bluearchive.versionName', { server: serverLabel(server) })
+
+  const runtimes: ServerRuntime[] = SERVER_KEYS.map(key => ({
+    key,
+    overview: ref<BlueArchiveActivityOverview>(createEmptySraActivityOverview()),
+    retryTimer: null,
+    retryCount: 0,
+    hasData: false,
+    retryPending: false,
+  }))
+
+  const loadingByServer: Record<BlueArchiveServerKey, boolean> = reactive({
+    jp: false,
+    global: false,
+    cn: false,
+  })
+  const selectedServer = ref<BlueArchiveServerKey>('jp')
+
+  let active = false
+  let started = false
+  let disposed = false
+
+  // 启动先用上次快照填卡片，不等网络
+  for (const runtime of runtimes) {
+    try {
+      const raw = localStorage.getItem(snapshotKey(runtime.key))
+      if (raw) {
+        const cached = JSON.parse(raw) as BlueArchiveActivityOverview
+        runtime.overview.value = {
+          ...createEmptySraActivityOverview(),
+          ...cached,
+          Stale: false,
+          Message: '',
+          // 服名随界面语言变化，按当前语言重算，避免切换语言后残留旧语言的版本名
+          versionName: serverVersionName(runtime.key),
+        }
+        runtime.hasData = true
+      }
+    } catch {
+      // 快照损坏按无缓存处理
+    }
+    if (!runtime.hasData) {
+      loadingByServer[runtime.key] = true
+    }
+  }
+
+  const loadServer = async (runtime: ServerRuntime) => {
+    if (disposed) return
+    try {
+      const controller = new AbortController()
+      const timer = window.setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+      let items: KivoTimelineItem[]
+      try {
+        items = await fetchTimeline(runtime.key, controller.signal)
+      } finally {
+        window.clearTimeout(timer)
+      }
+      if (disposed) return
+
+      const overview = buildOverview(items, serverVersionName(runtime.key))
+      runtime.overview.value = overview
+      runtime.hasData = true
+      runtime.retryCount = 0
+      try {
+        localStorage.setItem(snapshotKey(runtime.key), JSON.stringify(overview))
+      } catch {
+        // 本地存储不可用时仅跳过快照缓存
+      }
+    } catch (requestError) {
+      if (disposed) return
+      const errorMessage =
+        requestError instanceof Error ? requestError.message : String(requestError)
+      logger.warn('获取碧蓝档案' + serverLabel(runtime.key) + '活动数据失败: ' + errorMessage)
+
+      runtime.overview.value = runtime.hasData
+        ? {
+            ...runtime.overview.value,
+            Stale: true,
+            Message: t('home.bluearchive.staleMessage'),
+          }
+        : {
+            ...createEmptySraActivityOverview(),
+            Message: t('home.bluearchive.unavailable', { server: serverLabel(runtime.key) }),
+          }
+
+      if (runtime.retryCount < MAX_RETRIES) {
+        runtime.retryCount += 1
+        if (active) {
+          scheduleRetry(runtime)
+        } else {
+          // 模块隐藏期间不重试，重新可见时补一次
+          runtime.retryPending = true
+        }
+      }
+    } finally {
+      if (!disposed) {
+        loadingByServer[runtime.key] = false
+      }
+    }
+  }
+
+  const scheduleRetry = (runtime: ServerRuntime) => {
+    runtime.retryTimer = window.setTimeout(() => {
+      runtime.retryTimer = null
+      void loadServer(runtime)
+    }, RETRY_DELAY_MS)
+  }
+
+  // 模块可见时才发请求；隐藏时停掉重试定时器，重新可见时把攒下的重试补上
+  const start = () => {
+    if (disposed) return
+    active = true
+    if (!started) {
+      started = true
+      for (const runtime of runtimes) void loadServer(runtime)
+      return
+    }
+    for (const runtime of runtimes) {
+      if (runtime.retryPending) {
+        runtime.retryPending = false
+        void loadServer(runtime)
+      }
+    }
+  }
+
+  const stop = () => {
+    active = false
+    for (const runtime of runtimes) {
+      if (runtime.retryTimer !== null) {
+        window.clearTimeout(runtime.retryTimer)
+        runtime.retryTimer = null
+        runtime.retryPending = true
+      }
+    }
+  }
+
+  onScopeDispose(() => {
+    disposed = true
+    for (const runtime of runtimes) {
+      if (runtime.retryTimer !== null) {
+        window.clearTimeout(runtime.retryTimer)
+        runtime.retryTimer = null
+      }
+    }
+  })
+
+  return {
+    servers: computed<BlueArchiveServerOverview[]>(() =>
+      runtimes.map(runtime => ({
+        key: runtime.key,
+        label: serverLabel(runtime.key),
+        overview: runtime.overview.value,
+      }))
+    ),
+    selectedServer,
+    loadingByServer,
+    selectServer: (server: BlueArchiveServerKey) => {
+      selectedServer.value = server
+    },
+    start,
+    stop,
+    refresh: () => {
+      for (const runtime of runtimes) {
+        runtime.retryCount = 0
+        void loadServer(runtime)
+      }
+    },
+  }
+}

--- a/frontend/src/views/home/useBlueArchiveActivitySource.ts
+++ b/frontend/src/views/home/useBlueArchiveActivitySource.ts
@@ -70,7 +70,13 @@ const snapshotKey = (server: BlueArchiveServerKey) => 'auto-mas.home.bluearchive
 
 const pad = (value: number) => String(value).padStart(2, '0')
 
-/** Unix 秒 → 北京时间的 ISO 串（不带时区标记，与 SRA 现有字段惯例一致） */
+/**
+ * Unix 秒 → 带 +08:00 偏移的北京时间 ISO 串。
+ *
+ * 偏移不能省：卡片的消费端一律 `new Date(值)` 解析，没有时区标记的裸字符串
+ * 会被当成本地时间，在北京时间以外的设备上活动状态与倒计时会整体偏掉
+ * （1999 活动源也踩过同一个坑）。
+ */
 const formatTime = (seconds: number): string => {
   const shifted = new Date(seconds * 1000 + TIMEZONE_OFFSET_MS)
   return (
@@ -84,7 +90,8 @@ const formatTime = (seconds: number): string => {
     ':' +
     pad(shifted.getUTCMinutes()) +
     ':' +
-    pad(shifted.getUTCSeconds())
+    pad(shifted.getUTCSeconds()) +
+    '+08:00'
   )
 }
 
@@ -136,19 +143,38 @@ const buildActivities = (items: KivoTimelineItem[], nowSeconds: number) => {
     }))
 }
 
+/**
+ * 横幅的起始 / 结束取**当前这批活动**的区间。
+ *
+ * 直接拿整份数据里最晚的结束时间是不对的：Kivo 会提前放出后面的活动，
+ * 于是「剩余时间」倒数的会是还没开始的那一期。所以先看正在进行中的活动，
+ * 没有进行中的就退回最近结束的那一次（横幅如实显示「已结束」），
+ * 两者都没有才用还没开始的活动。
+ */
 const buildOverview = (
   items: KivoTimelineItem[],
   versionName: string
 ): BlueArchiveActivityOverview => {
   const activities = buildActivities(items, Date.now() / 1000)
+  const now = Date.now()
+  const toTimestamp = (value: string) => new Date(value).getTime()
+
+  // activities 已按开始时间升序，所以取首尾即可
+  const running = activities.filter(
+    activity => toTimestamp(activity.startTime) <= now && toTimestamp(activity.endTime) > now
+  )
+  const ended = activities.filter(activity => toTimestamp(activity.endTime) <= now)
+  const upcoming = activities.filter(activity => toTimestamp(activity.startTime) > now)
+  const current = running.length ? running : ended.length ? ended : upcoming
+
   return {
     Available: true,
     Stale: false,
     Message: '',
     version: currentMonth(),
     versionName,
-    startTime: activities[0]?.startTime ?? '',
-    endTime: activities[activities.length - 1]?.endTime ?? '',
+    startTime: current[0]?.startTime ?? '',
+    endTime: current[current.length - 1]?.endTime ?? '',
     activities,
   }
 }

--- a/frontend/src/views/home/useHomeLayout.ts
+++ b/frontend/src/views/home/useHomeLayout.ts
@@ -17,6 +17,7 @@ export const defaultHomeModuleOrder: HomeModuleKey[] = [
   'wutheringwaves',
   'nte',
   'reverse1999',
+  'bluearchive',
   'arknights',
 ]
 

--- a/res/version.json
+++ b/res/version.json
@@ -9,7 +9,9 @@
                 "MFW专项 同一个任务可以重复加入任务队列，每一份各自配置选项与排序；设了「每日/每周/每月仅一次」的任务仍按任务计，一轮只跑一次 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
                 "模拟器 2.0 支持由原有全局开关控制的「大雷主人模式」，并新增「打开游戏中心」按钮 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
                 "初始化 下载前先对各下载源测速并按最快的顺序使用，安装 Python 与依赖时显示当前文件、进度、速度与来源 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
-                "星铁专项 可以自动更新三月七助手与 SRA 了：默认关闭，开启后在任务全部跑完时检查并安装新版，配置页也能随时手动检查或立即更新；三月七助手走 GitHub 或 Mirror 酱，SRA 还多一个免 CDK 的 AUTO-MAS 下载站。更新采用可回滚的事务方式，中途失败会还原到原版本，你自己的配置文件和另存的自定义策略不会被动到（与上游同名的模板文件会随更新覆盖）；脚本正开着窗口时会跳过本轮而不是强行关掉它 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)"
+                "星铁专项 可以自动更新三月七助手与 SRA 了：默认关闭，开启后在任务全部跑完时检查并安装新版，配置页也能随时手动检查或立即更新；三月七助手走 GitHub 或 Mirror 酱，SRA 还多一个免 CDK 的 AUTO-MAS 下载站。更新采用可回滚的事务方式，中途失败会还原到原版本，你自己的配置文件和另存的自定义策略不会被动到（与上游同名的模板文件会随更新覆盖）；脚本正开着窗口时会跳过本轮而不是强行关掉它 by [@qiyinxi](https://github.com/qiyinxi) by [@HarcoChen](https://github.com/HarcoChen)",
+                "BAAH专项 新增碧蓝档案爱丽丝助手脚本支持，可集中管理多个账号的配置并自动完成每日任务",
+                "BAAH专项 首页新增碧蓝档案活动卡片：可切换日服 / 国际服 / 国服查看进行中的活动与剩余时间，服务器顺序支持拖动调整"
             ],
             "变更": [
                 "全局设置 虚拟显示器改为常驻监测：运行期间检测不到真实显示输出自动挂上，恢复后自动拆掉（任务运行中等结束再拆）；说明里可直接点开 Parsec 驱动下载页 by [@qiyinxi](https://github.com/qiyinxi)",


### PR DESCRIPTION
#697 合并之后追加的首页活动卡片，另开一个 PR。

- 首页新增碧蓝档案活动卡片，日服 / 国际服 / 国服可切换，服务器顺序支持拖动调整
- 数据来自 Kivo 古书馆时间轴；该接口校验 Origin（浏览器直连 403），因此走了一层后端转发
- 按当前规则随 PR 附一个更新日志碎片，不再改动 `CHANGELOG.md` 与版本号
## Sourcery 摘要

在主页中添加多服务器《蔚蓝档案》活动追踪，并恢复缺失的发布元数据。

新功能：
- 在主页中添加《蔚蓝档案》活动卡片，支持日服、国际服和国服视图，以及本地化的活动信息。
- 允许用户在《蔚蓝档案》服务器之间切换，并通过拖拽持久化调整服务器顺序。
- 为《蔚蓝档案》卡片提供本地化的英文、日文和简体中文标签及状态消息。

错误修复：
- 恢复之前合并过程中被移除的缺失更新日志条目和版本元数据。

增强功能：
- 集成《蔚蓝档案》时间线数据，支持按服务器独立加载、重试、过期数据回退和本地快照。
- 为 Kivo Wiki 时间线服务添加带短期缓存的后端代理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在主页中添加多语言、多服务器的《蔚蓝档案》活动追踪，并恢复缺失的版本发布元数据。

新功能：
- 在主页添加《蔚蓝档案》活动卡片，支持 JP、Global 和 CN 服务器视图，以及持久化的拖放式服务器排序。

错误修复：
- 恢复缺失的变更日志条目和版本发布元数据。

增强功能：
- 集成本地化的《蔚蓝档案》活动时间线，支持按服务器加载、重试、缓存快照、过期数据回退，以及用于 Kivo Wiki 数据的后端代理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在主页中添加多服务器《蔚蓝档案》活动追踪，并恢复缺失的发布元数据。

新功能：
- 在主页中添加《蔚蓝档案》活动卡片，支持日服、国际服和国服视图，以及持久化的拖放服务器排序。

错误修复：
- 恢复缺失的变更日志和发布元数据条目。

增强功能：
- 集成本地化的 Kivo Wiki 活动时间线，支持按服务器加载、重试、缓存快照、过期数据回退和后端代理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在主页中新增支持多语言、多服务器的《碧蓝档案》活动追踪功能，并提供具备高韧性的时间线数据访问能力和持久化服务器排序功能。

新功能：
- 在主页中添加《碧蓝档案》活动卡片，支持日服、国际服和国服视图。
- 支持在服务器之间切换，并通过拖放操作持久化调整服务器顺序。
- 提供本地化的《碧蓝档案》标签、活动详情、状态消息和倒计时显示。

错误修复：
- 恢复缺失的版本发布变更日志片段及相关版本发布元数据。

增强功能：
- 集成 Kivo 时间线数据，支持独立的服务器加载、重试、缓存快照和过期数据回退。
- 为 Kivo 时间线服务添加具有短期缓存功能的后端代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multilingual, multi-server Blue Archive activity tracking to the home page with resilient timeline data access and persistent server ordering.

New Features:
- Add a Blue Archive activity card to the home page with JP, Global, and CN server views.
- Support switching between servers and persistently reordering them by drag and drop.
- Provide localized Blue Archive labels, activity details, status messages, and countdown displays.

Bug Fixes:
- Restore the missing release changelog fragment and associated release metadata.

Enhancements:
- Integrate Kivo timeline data with independent server loading, retries, cached snapshots, and stale-data fallback.
- Add a backend proxy with short-lived caching for the Kivo timeline service.

</details>

</details>

</details>

</details>