### PR TITLE
fix(LogMonitor): 日志文件消失时监控不再静默死亡

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - 修复脚本配置目录含只读文件（如脚本自带的 `.git` 版本库）时，任务收尾复原配置失败、整单被记为异常的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)
 - OK-WW专项 修复脚本配置页点「检查更新」后任务立即报错、鸣潮客户端手动更新无法开始的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)
 - 调度台 修复任务运行期间日志被大量「订阅已存在，跳过重复订阅」记录刷屏的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)
+- 修复日志文件在运行过程中被重建或删除时，日志监控会静默失效、该趟任务再也不会被正常判定（卡到超时或误报异常）的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)
 
 ### 开发流程
 

--- a/app/utils/LogMonitor.py
+++ b/app/utils/LogMonitor.py
@@ -167,28 +167,21 @@ class LogMonitor:
                 warned_mtime_date = None
                 offset = read_offsets.get(current_path, 0)
 
-            # 检查文件是否仍然存在
-            if not current_path.exists():
-                logger.warning(f"日志文件不存在: {current_path}")
-                await self.do_callback()
-                await asyncio.sleep(1)
-                continue
-
-            if not if_mtime_checked:
-                file_mtime_date = date.fromtimestamp(current_path.stat().st_mtime)
-                if file_mtime_date == date.today():
-                    log_stat = current_path.stat()
-                    if_mtime_checked = True
-                else:
-                    if warned_mtime_date != file_mtime_date:
-                        logger.warning(f"日志文件今天未被修改: {file_mtime_date}")
-                        warned_mtime_date = file_mtime_date
-                    await self.do_callback()
-                    await asyncio.sleep(1)
-                    continue
-
             # 尝试读取文件
             try:
+                if not if_mtime_checked:
+                    file_mtime_date = date.fromtimestamp(current_path.stat().st_mtime)
+                    if file_mtime_date == date.today():
+                        log_stat = current_path.stat()
+                        if_mtime_checked = True
+                    else:
+                        if warned_mtime_date != file_mtime_date:
+                            logger.warning(f"日志文件今天未被修改: {file_mtime_date}")
+                            warned_mtime_date = file_mtime_date
+                        await self.do_callback()
+                        await asyncio.sleep(1)
+                        continue
+
                 # 轮转或文件被替换（同一路径上换了文件身份）：滚动前后属于
                 # 同一次运行，log_contents 与 if_log_start 保留不清空，否则
                 # 落库历史只剩轮转后内容（跨零点实测）；被重命名的旧文件按

--- a/res/version.json
+++ b/res/version.json
@@ -45,7 +45,8 @@
                 "MaaEnd专项 修复脚本更新移除旧任务后，自动代理重试反复报「没有启用的任务」并卡住的问题；现在会自动跳过这些任务并提示重做「MaaEnd 配置」 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)",
                 "修复脚本配置目录含只读文件（如脚本自带的 `.git` 版本库）时，任务收尾复原配置失败、整单被记为异常的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)",
                 "OK-WW专项 修复脚本配置页点「检查更新」后任务立即报错、鸣潮客户端手动更新无法开始的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)",
-                "调度台 修复任务运行期间日志被大量「订阅已存在，跳过重复订阅」记录刷屏的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)"
+                "调度台 修复任务运行期间日志被大量「订阅已存在，跳过重复订阅」记录刷屏的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)",
+                "修复日志文件在运行过程中被重建或删除时，日志监控会静默失效、该趟任务再也不会被正常判定（卡到超时或误报异常）的问题 by [@1w1w11w1](https://github.com/1w1w11w1) by [@HarcoChen](https://github.com/HarcoChen)"
             ],
             "开发流程": [
                 "首页卫星图标改从全局图标表取，新增专项时不再漏掉主页卫星"


### PR DESCRIPTION
$monitor_file 的循环体里，mtime 检查落在读取分支的 try 之外。文件在 exists() 与随后的 stat() 之间被删除或重建时，FileNotFoundError 直接逃逸、监控协程带异常终止；调用方没有 done_callback，异常无人回收，日志监控静默失效，该趟任务再也读不到日志，只能卡到超时或误判异常。

exists() 与紧随其后的 stat() 是同一件事的两次查询，且读取分支本就对文件不存在给出 FileNotFoundError 并 continue。删除该冗余检查后，把 mtime 块并入已有的读取分支 try，循环体只保留一个异常出口。净减 7 行，不新增守卫。

替换 #670：该 PR 走的是「给 stat 补 try」的加守卫路线，本 PR 直接消除冗余检查并复用已有异常出口。

- 修复日志文件被重建或删除时日志监控静默失效、该趟任务无法正常判定的问题

Closes #666

## Summary by Sourcery

Bug Fixes:
- 修复日志文件在监控过程中被删除或重建后导致监控协程静默终止、任务无法正常判定的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复日志文件在监控过程中被删除或重建后导致监控协程静默终止、任务无法正常判定的问题。

</details>